### PR TITLE
fix: remove storybook-static folder from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 node_modules/
 dist/
+packages/**/storybook-static/


### PR DESCRIPTION
After building both storybooks we have a storybook-static folder that comes listing inside the project folder but who is not excluded from git.
This pull request adds those folders inside the .gitignore of the project