### PR TITLE
build(prettier): fixed endOfLine param & exclusions in css packages

### DIFF
--- a/config/prettier.config.js
+++ b/config/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  endOfLine: "auto",
+};

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -15,8 +15,8 @@
     "eslint:fix": "eslint src --ext js,jsx,ts,tsx --fix",
     "stylelint": "stylelint \"src/**/*.{scss,css}\"",
     "stylelint:fix": "stylelint \"src/**/*.{scss,css}\" --fix",
-    "prettier": "prettier \"src/**/*.!(js|jsx|ts|tsx|scss|css)\" --check",
-    "prettier:fix": "prettier \"src/**/*.!(js|jsx|ts|tsx|scss|css)\" --write",
+    "prettier": "prettier \"src/**/*\" --check",
+    "prettier:fix": "prettier \"src/**/*\" --write",
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {
@@ -85,7 +85,7 @@
     "*.(js|jsx|ts|tsx)": "eslint --fix",
     "*.(ts|tsx)": "tsc-files --noEmit",
     "*.(scss|css)": "stylelint --fix",
-    "*.!(js|jsx|ts|tsx|scss|css)": "prettier --write"
+    "*.mdx": "prettier --write"
   },
   "volta": {
     "node": "20.10.0",

--- a/packages/css/prettier.config.js
+++ b/packages/css/prettier.config.js
@@ -1,0 +1,1 @@
+module.exports = require("../../config/prettier.config");

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,7 @@
   "lint-staged": {
     "*.(js|jsx|ts|tsx)": "eslint --fix",
     "*.(ts|tsx)": "tsc-files --noEmit",
-    "*.!(js|jsx|ts|tsx)": "prettier --write"
+    "*.mdx": "prettier --write"
   },
   "volta": {
     "node": "20.10.0",

--- a/packages/react/prettier.config.js
+++ b/packages/react/prettier.config.js
@@ -1,0 +1,1 @@
+module.exports = require("../../config/prettier.config");

--- a/packages/react/src/agent.ts
+++ b/packages/react/src/agent.ts
@@ -5,12 +5,12 @@ export { ButtonAgent as Button } from "./Button/Button.agent";
 export { Text, TextInput } from "./Form/InputText";
 export {
   Field,
-  FieldInput,
-  MessageTypes,
   FieldError,
-  FormClassManager,
   FieldForm,
+  FieldInput,
+  FormClassManager,
   HelpMessage,
   InputList,
+  MessageTypes,
   getComponentClassName,
 } from "./Form/core";


### PR DESCRIPTION
prettier voulait forcer nos endOfLine à lf. Mais vu qu'on fait du git, cette règle n'a pas de sens vu qu'on à `core.autocrlf=true` sur windows, et sur unix on a du lf par défaut.

Aussi, prettier sur le package css voulait lancer prettier sur des fichiers qui n'auraient pas du l'être, ils sont donc dans le prettierignore maintenant.

Enfin, le precommit hook tente de lancer prettier sur chaque fichier dans le stage qui n'est ni ts/js/css, sauf que par exemple un .prettierignore matchait. Donc pour l'instant on formatte que les mdx.