### PR TITLE
fix(form): add space between label and required visual indication

### DIFF
--- a/packages/css/src/Form/core/FormCore.agent.scss
+++ b/packages/css/src/Form/core/FormCore.agent.scss
@@ -23,7 +23,7 @@
   &__group--required &__group-label {
     &::after {
       color: common.$color-red-error;
-      content: "*";
+      content: " *";
     }
   }
 


### PR DESCRIPTION
![image](https://github.com/AxaFrance/design-system/assets/1991349/7637670d-3e79-4029-adf4-2a794e69e67a)
