### PR TITLE
Feature/icons client

### DIFF
--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -1,4 +1,5 @@
 import { dirname, join } from "path";
+import { mergeConfig } from 'vite';
 
 /**
  * This function is used to resolve the absolute path of a package.
@@ -25,6 +26,23 @@ const config = {
   },
   docs: {
     autodocs: "tag",
+  },
+  // See https://github.com/rollup/rollup/issues/4699
+  // and https://github.com/TanStack/query/issues/5175
+  async viteFinal(config) {
+    // Merge custom configuration into the default config
+    return mergeConfig(config, {
+      build: {
+        chunkSizeWarningLimit: 100,
+        rollupOptions: {
+        onwarn(warning, warn) {
+          if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+            return
+          }
+          warn(warning)
+        }}
+      },
+    });
   },
 };
 export default config;

--- a/packages/react/src/Icons/Icon.client.stories.css
+++ b/packages/react/src/Icons/Icon.client.stories.css
@@ -1,0 +1,26 @@
+.icon-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  list-style: none;
+
+  li {
+    display: flex;
+    width: 10rem;
+    height: 10rem;
+    margin-bottom: 1rem;
+    border: 1px solid #ccc;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-evenly;
+    background: #fff;
+    box-shadow: 0 0 5px 0 rgba(250, 250, 250, 50%);
+  }
+
+  svg {
+    width: 8rem;
+    height: 8rem;
+  }
+}

--- a/packages/react/src/Icons/Icon.client.stories.tsx
+++ b/packages/react/src/Icons/Icon.client.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Headphones } from "@mui/icons-material";
 import * as Icons from "@mui/icons-material";
 import "./Icon.client.stories.css";
 
@@ -11,7 +10,7 @@ export default meta;
 
 export const Example: StoryObj = {
   name: "Icon",
-  render: ({ ...args }) => <Headphones {...args} />,
+  render: ({ ...args }) => <Icons.Headphones {...args} />,
   args: {},
 };
 
@@ -19,13 +18,11 @@ export const AllIcons: StoryObj = {
   render: () => {
     return (
       <ul className="icon-list">
-        {Object.keys(Icons).map((x) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const Comp = (Icons as any)[x];
+        {Object.values(Icons).map((Comp: Icons.SvgIconComponent) => {
           return (
-            <li key={x}>
+            <li key={Comp.muiName}>
               <Comp />
-              <span>{x}</span>
+              <span>key</span>
             </li>
           );
         })}

--- a/packages/react/src/Icons/Icon.client.stories.tsx
+++ b/packages/react/src/Icons/Icon.client.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Headphones } from "@mui/icons-material";
+import * as Icons from "@mui/icons-material";
+import "./Icon.client.stories.css";
+
+const meta: Meta = {
+  title: "Look'n feel/Icons",
+};
+
+export default meta;
+
+export const Example: StoryObj = {
+  name: "Icon",
+  render: ({ ...args }) => <Headphones {...args} />,
+  args: {},
+};
+
+export const AllIcons: StoryObj = {
+  render: () => {
+    return (
+      <ul className="icon-list">
+        {Object.keys(Icons).map((x) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const Comp = (Icons as any)[x];
+          return (
+            <li key={x}>
+              <Comp />
+              <span>{x}</span>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  },
+};


### PR DESCRIPTION
added story for new client material icons:

![image](https://github.com/AxaFrance/design-system/assets/35838907/71b09ce7-8655-4320-9811-a75e65b20c37)

+ fix vite config because of excessive warns displayed on bundling of files containing 'use client' directives