### PR TITLE
ci: add npm package publish to npmjs.org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,11 @@ jobs:
         with:
           node-version: "*" # Use the LTS Node.js version
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
       - run: npm run package:check
       - run: npm ci
       - run: npm run lint -- --max-processes 1
       - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
First, 
I wanna point out that i'm really not familiar with package publishing nor github actions, so do not hesitate to point out things missing or wrong,
thanks !

Based on https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

Adapted to publish a package at each PR on main on current github workflow.

We will probably need a dedicated github workflow for official release later on.

The following needs to be done for it work :

> To perform authenticated operations against the npm registry in your workflow, you'll need to store your npm authentication token as a secret. For example, create a repository secret called NPM_TOKEN. For more information, see "[Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)."