### PR TITLE
fix(RadioSelect client): correct options id generated

### DIFF
--- a/packages/react/src/Form/Radio/Client/RadioSelect.stories.tsx
+++ b/packages/react/src/Form/Radio/Client/RadioSelect.stories.tsx
@@ -18,25 +18,23 @@ export const RadioSelectStory: StoryObj<ComponentProps<typeof RadioSelect>> = {
   args: {
     type: "vertical",
     "aria-label": "Quelle ville ?",
+    name: "cities",
     options: [
       {
         label: "Paris",
         description: "Capitale de la France",
         subtitle: "Nord",
-        name: "cities",
         value: "paris",
         icon: <Svg src={home} />,
       },
       {
         label: "Bruxelles",
         description: "Capitale de la Belgique",
-        name: "cities",
         value: "bruxelles",
         icon: <Svg src={home} />,
       },
       {
         label: "Lille",
-        name: "cities",
         value: "lille",
         icon: <Svg src={home} />,
       },

--- a/packages/react/src/Form/Radio/Client/RadioSelect.tsx
+++ b/packages/react/src/Form/Radio/Client/RadioSelect.tsx
@@ -2,7 +2,12 @@ import "@axa-fr/design-system-css/dist/Form/Radio/Client/Radio.scss";
 import radioIcon from "@material-design-icons/svg/outlined/radio_button_checked.svg";
 import radioOutlineBlankIcon from "@material-design-icons/svg/filled/radio_button_unchecked.svg";
 import errorOutline from "@material-design-icons/svg/outlined/error_outline.svg";
-import React, { ComponentPropsWithRef, ReactNode, forwardRef } from "react";
+import React, {
+  ComponentPropsWithRef,
+  ReactNode,
+  forwardRef,
+  useId,
+} from "react";
 import { Svg } from "../../../Svg";
 
 type RadioSelectProps = {
@@ -13,57 +18,66 @@ type RadioSelectProps = {
     description?: ReactNode;
     icon?: ReactNode;
   } & React.InputHTMLAttributes<HTMLInputElement>)[];
+  name: string;
   errorMessage?: string;
   onChange?: React.ChangeEventHandler;
 } & Omit<ComponentPropsWithRef<"div">, "className" | "aria-invalid">;
 
 export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
-  ({ options, errorMessage, onChange, type = "vertical", ...rest }, ref) => (
-    <>
-      <div
-        ref={ref}
-        {...rest}
-        role="radiogroup"
-        className={`af-radio af-radio-select af-radio-select--${type}`}
-        aria-invalid={Boolean(errorMessage)}
-      >
-        {options.map(
-          ({ label, description, subtitle, icon, ...inputProps }) => (
-            <label key={label as string} htmlFor={`id-${label}`}>
-              <input
-                type="radio"
-                {...inputProps}
-                id={`id-${label}`}
-                onChange={onChange}
-                aria-checked={inputProps.checked}
-              />
-              <div className="af-radio__icons">
-                <Svg
-                  src={radioOutlineBlankIcon}
-                  className="af-radio__unchecked"
+  (
+    { id, options, errorMessage, onChange, type = "vertical", name, ...rest },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const optionId = id || generatedId;
+    return (
+      <>
+        <div
+          ref={ref}
+          {...rest}
+          role="radiogroup"
+          className={`af-radio af-radio-select af-radio-select--${type}`}
+          aria-invalid={Boolean(errorMessage)}
+        >
+          {options.map(
+            ({ label, description, subtitle, icon, ...inputProps }) => (
+              <label key={label as string} htmlFor={`${optionId}-${label}`}>
+                <input
+                  type="radio"
+                  {...inputProps}
+                  name={name}
+                  id={`${optionId}-${label}`}
+                  onChange={onChange}
+                  aria-checked={inputProps.checked}
                 />
-                <Svg src={radioIcon} className="af-radio__checked" />
-              </div>
-              <div className="af-radio__content">
-                {icon}
-                <div className="af-radio__content-description">
-                  <span>{label}</span>
-                  {description && <span>{description}</span>}
-                  {subtitle && <span>{subtitle}</span>}
+                <div className="af-radio__icons">
+                  <Svg
+                    src={radioOutlineBlankIcon}
+                    className="af-radio__unchecked"
+                  />
+                  <Svg src={radioIcon} className="af-radio__checked" />
                 </div>
-              </div>
-            </label>
-          ),
-        )}
-      </div>
-      {errorMessage && (
-        <div className="af-radio__error" aria-live="assertive">
-          <Svg src={errorOutline} />
-          {errorMessage}
+                <div className="af-radio__content">
+                  {icon}
+                  <div className="af-radio__content-description">
+                    <span>{label}</span>
+                    {description && <span>{description}</span>}
+                    {subtitle && <span>{subtitle}</span>}
+                  </div>
+                </div>
+              </label>
+            ),
+          )}
         </div>
-      )}
-    </>
-  ),
+        {errorMessage && (
+          <div className="af-radio__error" aria-live="assertive">
+            <Svg src={errorOutline} />
+            {errorMessage}
+          </div>
+        )}
+      </>
+    );
+  },
 );
 
 RadioSelect.displayName = "RadioSelect";


### PR DESCRIPTION
correct id options generated per RadioSelect box (previous could conflict if 2 RadioSelect with same labels on same page ...)
use name on Comp automatically for each options (instead of passing it everytime in options...)