### PR TITLE
feat: add description to text input

### DIFF
--- a/packages/css/src/Form/Text/Client/Text.client.scss
+++ b/packages/css/src/Form/Text/Client/Text.client.scss
@@ -15,6 +15,13 @@
     color: common.$color-gray-900;
   }
 
+  &__input-description {
+    margin: -0.25rem 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 400;
+    color: common.$color-gray-700;
+  }
+
   &__input-text {
     padding: 1rem;
     padding-right: 2.5rem;

--- a/packages/css/src/Form/Text/Client/Text.stories.ts
+++ b/packages/css/src/Form/Text/Client/Text.stories.ts
@@ -1,44 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/html";
+import type { Args, Meta, StoryObj } from "@storybook/html";
 import "./Text.client.scss";
 
 const meta: Meta = {
-  title: "Client/Components/Form/Input/Text",
-};
-
-export default meta;
-
-export const TextStory: StoryObj = {
-  name: "Text",
-  render: (args) => {
-    const input = document.createElement("input");
-    input.id = "nameid";
-    input.name = "name";
-    input.className = "af-form__input-text";
-    input.placeholder = args.placeholder;
-    input.type = args.type;
-    input.value = args.value;
-    input.disabled = args.disabled;
-    input.required = args.required;
-
-    const container = document.createElement("div");
-    container.className = "af-form__input-container";
-
-    const label = document.createElement("label");
-    label.htmlFor = "nameid";
-    label.className = "af-form__input-label";
-    label.textContent = args.label;
-
-    if (args.required) {
-      const required = document.createElement("span");
-      required.textContent = " *";
-      label.appendChild(required);
-    }
-
-    container.appendChild(label);
-    container.appendChild(input);
-
-    return container;
-  },
   args: {
     value: "John Doe",
     label: "Label",
@@ -50,5 +13,85 @@ export const TextStory: StoryObj = {
     label: {
       control: { type: "text" },
     },
+  },
+  title: "Client/Components/Form/Input/Text",
+};
+
+export default meta;
+
+const getContainer = () => {
+  const container = document.createElement("div");
+  container.className = "af-form__input-container";
+
+  return container;
+};
+
+const getInput = (args: Args) => {
+  const input = document.createElement("input");
+  input.id = "nameid";
+  input.name = "name";
+  input.className = "af-form__input-text";
+  input.placeholder = args.placeholder;
+  input.type = args.type;
+  input.value = args.value;
+  input.disabled = args.disabled;
+  input.required = args.required;
+
+  return input;
+};
+
+const getLabel = (args: Args) => {
+  const label = document.createElement("label");
+  label.htmlFor = "nameid";
+  label.className = "af-form__input-label";
+  label.textContent = args.label;
+
+  if (args.required) {
+    const required = document.createElement("span");
+    required.textContent = " *";
+    label.appendChild(required);
+  }
+
+  return label;
+};
+
+const getDescription = (args: Args) => {
+  const description = document.createElement("span");
+  description.className = "af-form__input-description";
+  description.textContent = args.description;
+
+  return description;
+};
+
+export const TextStory: StoryObj = {
+  name: "Text",
+  render: (args) => {
+    const container = getContainer();
+    const input = getInput(args);
+    const label = getLabel(args);
+
+    container.appendChild(label);
+    container.appendChild(input);
+
+    return container;
+  },
+};
+
+export const TextWithDescriptionStory: StoryObj = {
+  name: "Text with description",
+  render: (args) => {
+    const container = getContainer();
+    const input = getInput(args);
+    const label = getLabel(args);
+    const description = getDescription(args);
+
+    container.appendChild(label);
+    container.appendChild(description);
+    container.appendChild(input);
+
+    return container;
+  },
+  args: {
+    description: "Description",
   },
 };

--- a/packages/react/src/Form/Text/Client/Text.stories.tsx
+++ b/packages/react/src/Form/Text/Client/Text.stories.tsx
@@ -4,16 +4,6 @@ import { Text } from "./Text";
 const meta: Meta<typeof Text> = {
   component: Text,
   title: "Client/Components/Form/Input/Text",
-  argTypes: { onChange: { action: "onChange" } },
-};
-
-export default meta;
-
-type Story = StoryObj<typeof Text>;
-
-export const TextStory: Story = {
-  name: "Text",
-  render: ({ onChange, ...args }) => <Text onChange={onChange} {...args} />,
   args: {
     value: "John Doe",
     label: "Name",
@@ -29,5 +19,23 @@ export const TextStory: Story = {
     type: {
       control: { type: "text" },
     },
+    onChange: { action: "onChange" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Text>;
+
+export const TextStory: Story = {
+  name: "Text",
+  render: ({ onChange, ...args }) => <Text onChange={onChange} {...args} />,
+};
+
+export const TextWithDescriptionStory: Story = {
+  name: "Text with description",
+  render: ({ onChange, ...args }) => <Text onChange={onChange} {...args} />,
+  args: {
+    description: "Description",
   },
 };

--- a/packages/react/src/Form/Text/Client/Text.tsx
+++ b/packages/react/src/Form/Text/Client/Text.tsx
@@ -4,6 +4,7 @@ import { ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../../core";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "required"> & {
+  description?: string;
   label?: string;
   required?: boolean;
 };
@@ -16,13 +17,16 @@ const Text = forwardRef<HTMLInputElement, Props>(
       "af-form__input-text",
     );
 
-    const { id, label, required, disabled } = otherProps;
+    const { id, label, required, disabled, description } = otherProps;
 
     return (
       <div className="af-form__input-container">
         <label htmlFor={id} className="af-form__input-label">
           {label} {required && <span> *</span>}
         </label>
+        {description && (
+          <span className="af-form__input-description">{description}</span>
+        )}
         <input
           className={componentClassName}
           type="text"


### PR DESCRIPTION
Cette PR permet d'ajouter un champ description sur un text input.

Image provenant du Figma de l'espace client:

![image](https://github.com/AxaFrance/design-system/assets/69311378/a1d43657-e2d8-445d-89e1-efcc2fb6edf7)

Rendu visuel final:

![D1](https://github.com/AxaFrance/design-system/assets/69311378/be8426e3-088d-462e-9eb3-a1d123fa6a43)
