### PR TITLE
fix: input text style on error, on hover, on focus and on active

### DIFF
--- a/packages/css/src/Form/Text/Client/Text.client.scss
+++ b/packages/css/src/Form/Text/Client/Text.client.scss
@@ -5,42 +5,46 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    justify-content: flex-start;
   }
 
   &__input-label {
-    margin-bottom: 0.5rem;
+    margin: 0;
     font-size: 1.125rem;
     font-weight: 600;
     color: common.$color-gray-900;
   }
 
   &__input-description {
-    margin: -0.25rem 0 0.5rem;
+    margin-top: -0.25rem;
     font-size: 1rem;
     font-weight: 400;
     color: common.$color-gray-700;
   }
 
   &__input-text {
+    margin: 0.5rem 0;
     padding: 1rem;
     padding-right: 2.5rem;
     border: 1px solid common.$color-gray;
     border-radius: 4px;
     font-size: 1.125rem;
+    color: common.$color-gray-900;
 
-    &:not(:disabled) {
-      &:focus-visible {
-        outline: 2px solid common.$color-blue-3;
-        outline-offset: 3px;
-      }
+    &--error {
+      border: 2px solid common.$color-btn-error;
+    }
 
-      &:hover,
+    &:enabled {
       &:focus,
       &:active {
-        border: 1px solid transparent;
-        box-shadow: 0 0 0 2px common.$color-axa inset;
+        border: 1px solid common.$color-axa;
+        outline: none;
       }
+    }
+
+    &:not(:disabled, :focus, :active, &--error):hover {
+      border: 2px solid common.$color-axa;
+      outline: none;
     }
   }
 }

--- a/packages/css/src/Form/Text/Client/Text.stories.ts
+++ b/packages/css/src/Form/Text/Client/Text.stories.ts
@@ -8,6 +8,7 @@ const meta: Meta = {
     placeholder: "Your name",
     disabled: false,
     required: true,
+    isOnError: false,
   },
   argTypes: {
     label: {
@@ -31,6 +32,7 @@ const getInput = (args: Args) => {
   input.id = "nameid";
   input.name = "name";
   input.className = "af-form__input-text";
+  if (args.isOnError) input.className += " af-form__input-text--error";
   input.placeholder = args.placeholder;
   input.type = args.type;
   input.value = args.value;
@@ -93,5 +95,22 @@ export const TextWithDescriptionStory: StoryObj = {
   },
   args: {
     description: "Description",
+  },
+};
+
+export const TextOnErrorStory: StoryObj = {
+  name: "Text on error",
+  render: (args) => {
+    const container = getContainer();
+    const input = getInput(args);
+    const label = getLabel(args);
+
+    container.appendChild(label);
+    container.appendChild(input);
+
+    return container;
+  },
+  args: {
+    isOnError: true,
   },
 };

--- a/packages/react/src/Form/Text/Client/Text.stories.tsx
+++ b/packages/react/src/Form/Text/Client/Text.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof Text> = {
   argTypes: {
     type: {
       control: { type: "text" },
+      onChange: { action: "onChange" },
     },
     onChange: { action: "onChange" },
   },
@@ -37,5 +38,13 @@ export const TextWithDescriptionStory: Story = {
   render: ({ onChange, ...args }) => <Text onChange={onChange} {...args} />,
   args: {
     description: "Description",
+  },
+};
+
+export const TextOnErrorStory: Story = {
+  name: "Text on error",
+  render: ({ onChange, ...args }) => <Text onChange={onChange} {...args} />,
+  args: {
+    classModifier: "error",
   },
 };

--- a/packages/react/src/Form/Text/Client/Text.tsx
+++ b/packages/react/src/Form/Text/Client/Text.tsx
@@ -4,20 +4,21 @@ import { ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../../core";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "required"> & {
+  classModifier?: string;
   description?: string;
   label?: string;
   required?: boolean;
 };
 
 const Text = forwardRef<HTMLInputElement, Props>(
-  ({ className, ...otherProps }, inputRef) => {
+  ({ className, classModifier = "", ...otherProps }, inputRef) => {
     const componentClassName = getComponentClassName(
       className,
-      "",
+      classModifier,
       "af-form__input-text",
     );
 
-    const { id, label, required, disabled, description } = otherProps;
+    const { description, disabled, id, label, required } = otherProps;
 
     return (
       <div className="af-form__input-container">


### PR DESCRIPTION
This pull request aims to fix the style of the input text on hover, on focus and on active.

**Hover:**

![image](https://github.com/AxaFrance/design-system/assets/69311378/d611e56c-7490-4cd5-8fe4-ca6807601f2f)

**Focus and active:**

![image](https://github.com/AxaFrance/design-system/assets/69311378/26d7374c-7da6-4bac-b4c5-3e77a0c25aad)

**Error:**

![image](https://github.com/AxaFrance/design-system/assets/69311378/0864a1d3-e972-4453-8d10-b3a2b4fced91)
