### PR TITLE
chore: define css version in react on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,10 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm version "${{ steps.gitversion.outputs.fullSemVer }}" --workspaces --workspaces-update=true
+      - name: Set to react package the @axa-fr/design-system-css dependency version
+        run: |
+          cd packages/react
+          jq '.peerDependencies["@axa-fr/design-system-css"] = "${{ steps.gitversion.outputs.fullSemVer }}"' package.json > temp.json && mv temp.json package.json
       - run: npm publish --workspace "packages" --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25632,7 +25632,6 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@axa-fr/design-system-css": "*",
         "@fontsource/source-sans-pro": "^5.0.8",
         "@tanem/svg-injector": "^10.1.68",
         "classnames": "^2.5.1",
@@ -25689,6 +25688,7 @@
         "vitest": "^1.4.0"
       },
       "peerDependencies": {
+        "@axa-fr/design-system-css": "*",
         "@material-symbols/svg-400": ">= 0.19.0",
         "react": ">= 18"
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/AxaFrance/design-system#readme",
   "peerDependencies": {
+    "@axa-fr/design-system-css": "*",
     "@material-symbols/svg-400": ">= 0.19.0",
     "react": ">= 18"
   },
@@ -54,7 +55,6 @@
     }
   },
   "dependencies": {
-    "@axa-fr/design-system-css": "*",
     "@fontsource/source-sans-pro": "^5.0.8",
     "@tanem/svg-injector": "^10.1.68",
     "classnames": "^2.5.1",


### PR DESCRIPTION
Make @axa-fr/design-system-css react package dependency as peerDependency and set it's version in react package.json on publish.
Example of functional workflow : https://github.com/GuillaumeKESTEMAN/design-system/actions/runs/9364533749/job/25777728750#step:11:156