### PR TITLE
fix(RadioSelect): add `disabled` props at component level + style

### DIFF
--- a/slash/css/src/Form/Radio/Client/Radio.scss
+++ b/slash/css/src/Form/Radio/Client/Radio.scss
@@ -164,22 +164,22 @@
     & .af-radio__content > svg,
     & .af-radio__checked,
     & .af-radio__unchecked {
-      color: common.$color-btn-disabled-text;
-      fill: common.$color-btn-disabled-text;
+      color: common.$color-gray-500;
+      fill: common.$color-gray-500;
     }
-  }
-
-  &-select label:has(input[type="radio"]:disabled) {
-    color: common.$color-btn-disabled-text;
-    background-color: common.$color-gray-200;
-    box-shadow: 0 0 0 1px var(--box-shadow-color) inset;
-
-    --box-shadow-color: #{common.$color-gray-400};
   }
 
   &-select[aria-invalid="false"] label:has(input[type="radio"]:checked) {
     background-color: common.$color-blue-2;
     box-shadow: 0 0 0 2px common.$color-axa inset;
+  }
+
+  &-select[aria-invalid="false"] label:has(input[type="radio"]:disabled) {
+    color: common.$color-gray-500;
+    background-color: common.$color-gray-200;
+    box-shadow: 0 0 0 1px var(--box-shadow-color) inset;
+
+    --box-shadow-color: #{common.$color-gray-400};
   }
 
   & label input[type="radio"]:focus-visible ~ .af-radio__icons {

--- a/slash/react/src/Form/Radio/Client/RadioSelect.stories.tsx
+++ b/slash/react/src/Form/Radio/Client/RadioSelect.stories.tsx
@@ -45,8 +45,49 @@ export const RadioSelectStory: StoryObj<ComponentProps<typeof RadioSelect>> = {
       control: { type: "inline-radio" },
       options: ["vertical", "horizontal"],
     },
-    options: {
-      control: { type: "object" },
+    errorMessage: {
+      control: { type: "text" },
+    },
+    onChange: { action: "onChange" },
+  },
+};
+
+export const RadioSelectDisabledStory: StoryObj<
+  ComponentProps<typeof RadioSelect>
+> = {
+  name: "SelectDisabled",
+  render: ({ ...args }) => <RadioSelect {...args} />,
+  args: {
+    type: "vertical",
+    "aria-label": "Quelle ville ?",
+    name: "cities",
+    options: [
+      {
+        label: "Paris",
+        description: "Capitale de la France",
+        subtitle: "Nord",
+        value: "paris",
+        icon: <Svg src={home} />,
+      },
+      {
+        label: "Bruxelles",
+        description: "Capitale de la Belgique",
+        value: "bruxelles",
+        icon: <Svg src={home} />,
+      },
+      {
+        label: "Lille",
+        value: "lille",
+        icon: <Svg src={home} />,
+        checked: true,
+      },
+    ],
+    isDisabled: true,
+  },
+  argTypes: {
+    type: {
+      control: { type: "inline-radio" },
+      options: ["vertical", "horizontal"],
     },
     errorMessage: {
       control: { type: "text" },

--- a/slash/react/src/Form/Radio/Client/RadioSelect.tsx
+++ b/slash/react/src/Form/Radio/Client/RadioSelect.tsx
@@ -22,6 +22,7 @@ type RadioSelectProps = {
   errorMessage?: string;
   onChange?: React.ChangeEventHandler;
   value?: string;
+  isDisabled?: boolean;
 } & Omit<ComponentPropsWithRef<"div">, "className" | "aria-invalid">;
 
 export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
@@ -34,6 +35,7 @@ export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
       type = "vertical",
       name,
       value,
+      isDisabled,
       ...rest
     },
     ref,
@@ -50,10 +52,18 @@ export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
           aria-invalid={Boolean(errorMessage)}
         >
           {options.map(
-            ({ label, description, subtitle, icon, ...inputProps }) => (
+            ({
+              label,
+              description,
+              subtitle,
+              icon,
+              disabled: inputDisabled,
+              ...inputProps
+            }) => (
               <label key={label as string} htmlFor={`${optionId}-${label}`}>
                 <input
                   type="radio"
+                  {...(isDisabled || inputDisabled ? { disabled: true } : null)}
                   {...inputProps}
                   name={name}
                   id={`${optionId}-${label}`}


### PR DESCRIPTION
**Before**: avec un champ déjà coché, on garde une bordure bleue
![image](https://github.com/user-attachments/assets/0f788cce-7081-4900-a3d5-f858b0528028)

**After**: on n'a pas de distinction entre les champs
![image](https://github.com/user-attachments/assets/2535fe47-f95e-4ff9-846e-15a2b3dd6501)
