### PR TITLE
feat(alert): pass button for action [Look and Feel]

### DIFF
--- a/look-and-feel/css/src/Alert/Alert.scss
+++ b/look-and-feel/css/src/Alert/Alert.scss
@@ -20,10 +20,10 @@
     border: 1px solid common.$color-axa;
 
     .af-alert__icon {
+      margin-top: 0.75rem;
       color: common.$color-axa;
       transform: rotate(180deg);
       fill: common.$color-axa;
-      margin-top: 0.75rem;
     }
 
     .af-alert__title {
@@ -86,7 +86,9 @@
   .af-alert-client__content {
     width: 100%;
 
-    .af-alert__link {
+    .af-alert__action {
+      display: flex;
+      justify-content: end;
       text-align: right;
     }
 

--- a/look-and-feel/css/src/Alert/Alert.stories.ts
+++ b/look-and-feel/css/src/Alert/Alert.stories.ts
@@ -1,5 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/html";
+import type { Args, Meta, StoryObj } from "@storybook/html";
 import "./Alert.scss";
+import "../Link/Link.scss";
 
 const meta: Meta = {
   title: "Components/Alert",
@@ -7,53 +8,65 @@ const meta: Meta = {
 
 export default meta;
 
-const MODIFIERS = ["information", "neutral", "error", "validation", "warning"];
+const alertTypes = {
+  validation: "validation",
+  error: "error",
+  warning: "warning",
+  information: "information",
+  neutral: "neutral",
+} as const;
 
-export type AlertType =
-  | "validation"
-  | "error"
-  | "warning"
-  | "information"
-  | "neutral";
+const MODIFIERS = [...Object.values(alertTypes)];
+
+type AlertType = keyof typeof alertTypes;
+
+const setSvg = (path: string) =>
+  `<svg class="af-alert__icon" width="24" height="24" focusable="false" aria-hidden="true" viewBox="0 0 24 24"><path d="${path}"></path></svg>`;
 
 function getIconFromType(type: AlertType) {
   switch (type) {
     case "information":
-      return '<svg class="af-alert__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="WbIncandescentOutlinedIcon"><path d="m3.55 19.09 1.41 1.41 1.79-1.8-1.41-1.41zM11 20h2v3h-2zM1 11h3v2H1zm12-6.95v3.96l1 .58c1.24.72 2 2.04 2 3.46 0 2.21-1.79 4-4 4s-4-1.79-4-4c0-1.42.77-2.74 2-3.46l1-.58V4.05zm2-2H9v4.81C7.21 7.9 6 9.83 6 12.05c0 3.31 2.69 6 6 6s6-2.69 6-6c0-2.22-1.21-4.15-3-5.19zM20 11h3v2h-3zm-2.76 7.71 1.79 1.8 1.41-1.41-1.8-1.79z"></path></svg>';
+      return setSvg(
+        "m3.55 19.09 1.41 1.41 1.79-1.8-1.41-1.41zM11 20h2v3h-2zM1 11h3v2H1zm12-6.95v3.96l1 .58c1.24.72 2 2.04 2 3.46 0 2.21-1.79 4-4 4s-4-1.79-4-4c0-1.42.77-2.74 2-3.46l1-.58V4.05zm2-2H9v4.81C7.21 7.9 6 9.83 6 12.05c0 3.31 2.69 6 6 6s6-2.69 6-6c0-2.22-1.21-4.15-3-5.19zM20 11h3v2h-3zm-2.76 7.71 1.79 1.8 1.41-1.41-1.8-1.79z",
+      );
     case "neutral":
-      return '<svg class="af-alert__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ErrorOutlineIcon"><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path></svg>';
+      return setSvg(
+        "M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8",
+      );
     case "warning":
-      return '<svg class="af-alert__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ErrorOutlineIcon"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path><path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path></svg>';
+      return setSvg(
+        'M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path><path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z',
+      );
     case "validation":
-      return '<svg class="af-alert__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="CheckCircleOutlineIcon"><path d="M16.59 7.58 10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path></svg>';
+      return setSvg(
+        "M16.59 7.58 10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8",
+      );
     case "error":
-      return '<svg class="af-alert__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ErrorOutlineIcon"><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path></svg>';
+      return setSvg(
+        "M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8",
+      );
     default:
-      return '<svg class="af-alert__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="WbIncandescentOutlinedIcon"><path d="m3.55 19.09 1.41 1.41 1.79-1.8-1.41-1.41zM11 20h2v3h-2zM1 11h3v2H1zm12-6.95v3.96l1 .58c1.24.72 2 2.04 2 3.46 0 2.21-1.79 4-4 4s-4-1.79-4-4c0-1.42.77-2.74 2-3.46l1-.58V4.05zm2-2H9v4.81C7.21 7.9 6 9.83 6 12.05c0 3.31 2.69 6 6 6s6-2.69 6-6c0-2.22-1.21-4.15-3-5.19zM20 11h3v2h-3zm-2.76 7.71 1.79 1.8 1.41-1.41-1.8-1.79z"></path></svg>';
+      return setSvg(
+        "m3.55 19.09 1.41 1.41 1.79-1.8-1.41-1.41zM11 20h2v3h-2zM1 11h3v2H1zm12-6.95v3.96l1 .58c1.24.72 2 2.04 2 3.46 0 2.21-1.79 4-4 4s-4-1.79-4-4c0-1.42.77-2.74 2-3.46l1-.58V4.05zm2-2H9v4.81C7.21 7.9 6 9.83 6 12.05c0 3.31 2.69 6 6 6s6-2.69 6-6c0-2.22-1.21-4.15-3-5.19zM20 11h3v2h-3zm-2.76 7.71 1.79 1.8 1.41-1.41-1.8-1.79z",
+      );
   }
 }
 
-export const Default: StoryObj = {
-  name: "Alert",
-  render: (args) => {
+const commonProps = {
+  render: (args: Args) => {
     const alert = document.createElement("div");
 
     alert.className = `af-alert af-alert--${args.type}`;
+    alert.role = "alert";
 
     alert.innerHTML = `
       ${getIconFromType(args.type)}
-      <div>
-        ${args.title ? `<p class="af-alert__title">${args.title}</p>` : ""}
+      <div class="af-alert-client__content">
+        ${args.title ? `<h4 class="af-alert__title">${args.title}</h4>` : ""}
         ${args.children}
       </div>
     `;
     return alert;
-  },
-  args: {
-    title: "My Alert title",
-    type: "information",
-    children:
-      "Vestibulum nunc neque, sodales non luctus in, dictum vitae nisl. Curabitur vitae massa non nisl lacinia tempus. Pellentesque id nulla tortor.",
   },
   argTypes: {
     type: {
@@ -61,5 +74,29 @@ export const Default: StoryObj = {
       control: { type: "select" },
       defaultValue: "information",
     },
+  },
+};
+
+export const Default: StoryObj = {
+  ...commonProps,
+  name: "Alert",
+  args: {
+    title: "My Alert title",
+    type: "information",
+    children: `Vestibulum nunc neque, sodales non luctus in, dictum vitae nisl. Curabitur vitae massa non nisl lacinia tempus. Pellentesque id nulla tortor.
+      <p class="af-alert__action"><a class="af-link  af-link--openInNewTab" href="https://fakelink.com" target="_blank" rel="noopener noreferrer">Plus de détails<svg data-src="/@fs/Users/a770ml/Documents/DEV/GITHUB%20AXAFRANCE/design-system/node_modules/@material-symbols/svg-400/outlined/open_in_new.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M180-120q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h279v60H180v600h600v-279h60v279q0 24-18 42t-42 18H180Zm202-219-42-43 398-398H519v-60h321v321h-60v-218L382-339Z"></path></svg></a></p>
+      `,
+  },
+};
+
+export const WithButtonAction: StoryObj = {
+  ...commonProps,
+  name: "Alert with Button action",
+  args: {
+    title: "My Alert title",
+    type: "information",
+    children: `Vestibulum nunc neque, sodales non luctus in, dictum vitae nisl. Curabitur vitae massa non nisl lacinia tempus. Pellentesque id nulla tortor.
+      <p class="af-alert__action"><button class="af-btn-client af-btn-client--ghost" type="button">Button Ghost</button></p>
+      `,
   },
 };

--- a/look-and-feel/react/src/Alert/Alert.stories.tsx
+++ b/look-and-feel/react/src/Alert/Alert.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Alert } from "./Alert";
 import { Link } from "../Link/Link";
+import { ButtonClient, Variants } from "../Button/Button";
 
 const MODIFIERS = ["information", "neutral", "error", "validation", "warning"];
 
@@ -17,7 +18,7 @@ export const Default: StoryObj<typeof Alert> = {
     type: "information",
     children:
       "Vestibulum nunc neque, sodales non luctus in, dictum vitae nisl. Curabitur vitae massa non nisl lacinia tempus. Pellentesque id nulla tortor.",
-    link: (
+    action: (
       <Link openInNewTab href="https://fakelink.com">
         Plus de détails
       </Link>
@@ -30,5 +31,17 @@ export const Default: StoryObj<typeof Alert> = {
       control: { type: "select" },
       defaultValue: "information",
     },
+  },
+};
+
+export const WithButtonAction: StoryObj<typeof Alert> = {
+  name: "Alert with Button action",
+  args: {
+    title: "My Alert title",
+    type: "information",
+    children:
+      "Vestibulum nunc neque, sodales non luctus in, dictum vitae nisl. Curabitur vitae massa non nisl lacinia tempus. Pellentesque id nulla tortor.",
+    action: <ButtonClient variant={Variants.ghost}>Actualiser</ButtonClient>,
+    iconSize: 24,
   },
 };

--- a/look-and-feel/react/src/Alert/Alert.tsx
+++ b/look-and-feel/react/src/Alert/Alert.tsx
@@ -11,19 +11,26 @@ import checkCircleOutline from "@material-symbols/svg-400/outlined/check_circle.
 import "@axa-fr/design-system-look-and-feel-css/dist/Alert/Alert.scss";
 import { Svg } from "../Svg";
 import { Link } from "../Link/Link";
+import { ButtonClient } from "../Button/Button";
 
-export type AlertType =
-  | "validation"
-  | "error"
-  | "warning"
-  | "information"
-  | "neutral";
+type Headings = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+export const alertTypes = {
+  validation: "validation",
+  error: "error",
+  warning: "warning",
+  information: "information",
+  neutral: "neutral",
+} as const;
+
+export type AlertType = keyof typeof alertTypes;
 
 type AlertProps = {
   type: AlertType;
   title?: string;
-  link?: ReactElement<typeof Link>;
+  action?: ReactElement<typeof Link | typeof ButtonClient>;
   iconSize?: number;
+  heading?: Headings;
 } & ComponentPropsWithoutRef<"div">;
 
 function getIconFromType(type: AlertType) {
@@ -42,26 +49,28 @@ function getIconFromType(type: AlertType) {
 }
 
 export const Alert = ({
-  type = "information",
+  type = alertTypes.information,
   title,
   children,
-  link,
+  action,
   iconSize = 24,
+  heading: Heading = "h4",
 }: PropsWithChildren<AlertProps>) => {
   const icon = useMemo(() => getIconFromType(type), [type]);
 
   return (
-    <div className={`af-alert af-alert--${type}`}>
+    <div className={`af-alert af-alert--${type}`} role="alert">
       <Svg
         src={icon}
         width={iconSize}
         height={iconSize}
         className="af-alert__icon"
+        aria-label="hidden"
       />
       <div className="af-alert-client__content">
-        {title && <p className="af-alert__title">{title}</p>}
+        {title && <Heading className="af-alert__title">{title}</Heading>}
         {children}
-        {link && <p className="af-alert__link">{link}</p>}
+        {action && <p className="af-alert__action">{action}</p>}
       </div>
     </div>
   );

--- a/look-and-feel/react/src/Alert/Alert.tsx
+++ b/look-and-feel/react/src/Alert/Alert.tsx
@@ -13,7 +13,7 @@ import { Svg } from "../Svg";
 import { Link } from "../Link/Link";
 import { ButtonClient } from "../Button/Button";
 
-type Headings = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type Headings = "h2" | "h3" | "h4" | "h5" | "h6";
 
 export const alertTypes = {
   validation: "validation",
@@ -33,20 +33,14 @@ type AlertProps = {
   heading?: Headings;
 } & ComponentPropsWithoutRef<"div">;
 
-function getIconFromType(type: AlertType) {
-  switch (type) {
-    case "error":
-      return errorIcon;
-    case "validation":
-      return checkCircleOutline;
-    case "neutral":
-    case "warning":
-      return errorOutline;
-    case "information":
-    default:
-      return wbIncandescentOutlined;
-  }
-}
+const getIconFromType = (type: AlertType) =>
+  ({
+    [alertTypes.validation]: checkCircleOutline,
+    [alertTypes.error]: errorIcon,
+    [alertTypes.neutral]: errorOutline,
+    [alertTypes.warning]: errorOutline,
+    [alertTypes.information]: wbIncandescentOutlined,
+  })[type] || wbIncandescentOutlined;
 
 export const Alert = ({
   type = alertTypes.information,

--- a/look-and-feel/react/src/Alert/Alert.tsx
+++ b/look-and-feel/react/src/Alert/Alert.tsx
@@ -65,7 +65,7 @@ export const Alert = ({
         width={iconSize}
         height={iconSize}
         className="af-alert__icon"
-        aria-label="hidden"
+        aria-hidden
       />
       <div className="af-alert-client__content">
         {title && <Heading className="af-alert__title">{title}</Heading>}

--- a/look-and-feel/react/src/Alert/__tests__/Alert.test.tsx
+++ b/look-and-feel/react/src/Alert/__tests__/Alert.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { Alert, alertTypes } from "../Alert";
+import { Link } from "../../Link/Link";
+import { ButtonClient, Variants } from "../../Button/Button";
+
+const MoreDetails = () => (
+  <Link openInNewTab href="https://fakelink.com">
+    Plus de détails
+  </Link>
+);
+
+describe("Alert", () => {
+  it.each`
+    type                      | title         | children       | action                                                                | icon                     | iconSize     | expectLink | expectButton
+    ${undefined}              | ${undefined}  | ${undefined}   | ${undefined}                                                          | ${"wb_incandescent.svg"} | ${undefined} | ${false}   | ${false}
+    ${alertTypes.information} | ${"my title"} | ${"some text"} | ${(<MoreDetails />)}                                                  | ${"wb_incandescent.svg"} | ${undefined} | ${true}    | ${false}
+    ${alertTypes.error}       | ${"my title"} | ${"some text"} | ${(<MoreDetails />)}                                                  | ${"emergency_home.svg"}  | ${undefined} | ${true}    | ${false}
+    ${alertTypes.neutral}     | ${"my title"} | ${"some text"} | ${(<MoreDetails />)}                                                  | ${"error.svg"}           | ${undefined} | ${true}    | ${false}
+    ${alertTypes.validation}  | ${"my title"} | ${"some text"} | ${(<MoreDetails />)}                                                  | ${"check_circle.svg"}    | ${undefined} | ${true}    | ${false}
+    ${alertTypes.warning}     | ${"my title"} | ${"some text"} | ${(<ButtonClient variant={Variants.ghost}>Actualiser</ButtonClient>)} | ${"error.svg"}           | ${undefined} | ${false}   | ${true}
+  `(
+    "Should render correctly with type: $type, title: $title, children: $children, icon: $icon, action: $action, iconSize: $iconSize",
+    ({
+      type,
+      title,
+      children,
+      action,
+      icon,
+      iconSize,
+      expectLink,
+      expectButton,
+    }) => {
+      const { container } = render(
+        <Alert {...{ type, title, action, iconSize }}>{children}</Alert>,
+      );
+
+      if (title) {
+        expect(screen.getByText(RegExp(title))).toBeDefined();
+      }
+
+      if (children) {
+        expect(screen.getByText(RegExp(children))).toBeDefined();
+      }
+
+      expect(screen.getByRole("alert")).toHaveClass(
+        `af-alert--${type || alertTypes.information}`,
+      );
+
+      if (expectLink && action) {
+        expect(screen.getByRole("link")).toHaveAttribute(
+          "href",
+          "https://fakelink.com",
+        );
+      }
+
+      if (expectButton && action) {
+        expect(
+          screen.getByRole("button", { name: /Actualiser/ }),
+        ).toBeInTheDocument();
+      }
+
+      expect(container.querySelector(`[data-src$="${icon}"]`)).toBeDefined();
+    },
+  );
+});


### PR DESCRIPTION
Permettre au composant Alert (Look and Feel) de passer un bouton ou un lien d'action

> note : amélioration de l'accessibilité (sémantique et rôle)

🚨BREAKING CHANGE🚨
La prop "**link**" devient "**action**", on peut dorénavant lui passer un type "Link" ou un type "Button".

![image](https://github.com/user-attachments/assets/1547e8ae-6de7-43f5-a7cc-bf9965b69415)


