### PR TITLE
Fix(client): style between List and ClickItem when use full-width modifier

### DIFF
--- a/look-and-feel/css/src/List/List.scss
+++ b/look-and-feel/css/src/List/List.scss
@@ -11,7 +11,8 @@
 
   &__separator {
     margin: 0;
-    border: 1px solid common.$color-gray-300;
+    border: 0;
+    border-top: 1px solid common.$color-gray-300;
   }
 }
 

--- a/look-and-feel/css/src/List/List.scss
+++ b/look-and-feel/css/src/List/List.scss
@@ -48,6 +48,10 @@
 
     .af-list__item {
       padding: 1rem;
+
+      &:has(.af-click-item) {
+        padding: 0;
+      }
     }
 
     .af-list__separator ~ .af-list__separator {

--- a/look-and-feel/css/src/List/List.stories.ts
+++ b/look-and-feel/css/src/List/List.stories.ts
@@ -44,29 +44,44 @@ export const Default: StoryObj = {
   },
   args: {
     children: [
-      "<div><span>Prénom NOM</span></div>",
-      "<div><span>nom.prénom@mail.fr</span></div>",
-      `<div style="display: flex; flex-direction: row; align-items: center; gap: 0.5rem;">
-        <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/sync-fill.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-          <path d="M167-160v-60h130l-15-12q-64-51-93-111t-29-134q0-106 62.5-190.5T387-784v62q-75 29-121 96.5T220-477q0 63 23.5 109.5T307-287l30 21v-124h60v230H167Zm407-15v-63q76-29 121-96.5T740-483q0-48-23.5-97.5T655-668l-29-26v124h-61v-230h230v60H665l15 14q60 56 90 120t30 123q0 106-62 191T574-175Z"></path>
-        </svg>
-        <div style="display: flex; flex-direction: row; justify-content: space-between; align-items: center; width: 100%">
-          <span>Modifier le profil</span>
-          <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/arrow_right.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M400-280v-400l200 200-200 200Z"></path>
-          </svg>
+      `<div class="af-content-item-mono af-content-item-mono--m">
+        <div class="af-content-item-mono__text-container">
+          <p class="af-content-item-mono__main-text">Prénom NOM</p>
+          <p class="af-content-item-mono__secondary-text">nom.prénom@mail.fr</p>
         </div>
       </div>`,
-      `<div style="display: flex; flex-direction: row; align-items: center; gap: 4rem;">
-        <div style="display: flex; flex-direction: row; align-items: center; gap: 0.5rem;">
-          <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/delete.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M261-120q-24.75 0-42.37-17.63Q201-155.25 201-180v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Zm438-630H261v570h438v-570ZM367-266h60v-399h-60v399Zm166 0h60v-399h-60v399ZM261-750v570-570Z"></path>
-          </svg>
-          <span>Supprimer le profil</span>
+      `<button class="af-click-item" type="button">
+        <div class="af-click-item__content">
+          <div class="af-click-item__icon">
+            <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/published_with_changes-fill.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M430-82q-72-9-134.5-43t-108-86.5Q142-264 116-332.5T90-480q0-88 41.5-168T243-790H121v-60h229v229h-60v-129q-64 51-102 121.5T150-480q0 132 80 225.5T430-143v61Zm-7-228L268-465l42-42 113 113 227-227 42 42-269 269Zm187 200v-229h60v129q64-52 102-122t38-148q0-132-80-225.5T530-817v-61q146 18 243 129t97 269q0 88-41.5 168T717-170h122v60H610Z"></path>
+            </svg>
+          </div>
+          <div class="af-click-item__label">Modifier le profil</div>
         </div>
-      </div>`,
+        <div class="af-click-item__action">
+          <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/chevron_right.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M530-481 332-679l43-43 241 241-241 241-43-43 198-198Z"></path>
+          </svg>
+        </div>
+      </button>`,
+      `<button class="af-click-item" type="button">
+        <div class="af-click-item__content">
+          <div class="af-click-item__icon">
+            <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/delete.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M261-120q-24.75 0-42.37-17.63Q201-155.25 201-180v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Zm438-630H261v570h438v-570ZM367-266h60v-399h-60v399Zm166 0h60v-399h-60v399ZM261-750v570-570Z"></path>
+            </svg>
+          </div>
+          <div class="af-click-item__label">Supprimer le profil</div>
+        </div>
+        <div class="af-click-item__action">
+          <svg data-src="/@fs/C:/Users/B519MA/projects/design-system/node_modules/@material-symbols/svg-400/outlined/chevron_right.svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="injected-svg" viewBox="0 -960 960 960" height="24" width="24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M530-481 332-679l43-43 241 241-241 241-43-43 198-198Z"></path>
+          </svg>
+        </div>
+      </button>`,
     ],
-    classModifier: [],
+    classModifier: ["first-separator-full-width"],
   },
   argTypes: {
     classModifier: {

--- a/look-and-feel/react/src/List/List.mdx
+++ b/look-and-feel/react/src/List/List.mdx
@@ -10,67 +10,27 @@ import * as ListStories from "./List.stories";
 To use the List component import it like that:
 
 ```tsx title="test.js"
-import { List } from "./List";
-import { Svg } from "../Svg";
-import trash from "@material-symbols/svg-400/outlined/delete.svg";
-import sync from "@material-symbols/svg-400/outlined/sync-fill.svg";
-import arrow from "@material-symbols/svg-400/outlined/arrow_right.svg";
+import {
+  ClickItem,
+  ContentItemMono,
+  List,
+  Svg,
+} from "@axa-fr/design-system-look-and-feel-react";
+import trashIcon from "@material-symbols/svg-400/outlined/delete.svg";
+import publishedWithChangesIcon from "@material-symbols/svg-400/outlined/published_with_changes-fill.svg";
 
 const MyComponent = () => (
-  <List>
-    <div key="list-item-1">
-      <span>Prénom NOM</span>
-    </div>
-    <div key="list-item-2">
-      <span>npm.prénom@mail.fr</span>
-    </div>
-    <div
-      key="list-item-3"
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        gap: "4rem",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
-        <Svg src={sync} />
-        <span>Modifier le profil</span>
-      </div>
-      <Svg src={arrow} />
-    </div>
-    <div
-      key="list-element-3"
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        gap: "4rem",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
-        <Svg src={trash} />
-        <span>Supprimer le profil</span>
-      </div>
-    </div>
+  <List classModifier="first-separator-full-width">
+    <ContentItemMono secondaryText="nom.prénom@mail.fr">
+      Prénom NOM
+    </ContentItemMono>
+    <ClickItem icon={<Svg src={publishedWithChangesIcon} />}>
+      Modifier le profil
+    </ClickItem>
+    <ClickItem icon={<Svg src={trashIcon} />}>Supprimer le profil</ClickItem>
   </List>
 );
 ```
 
 <Canvas of={ListStories.Default} />
-
 <Controls story="List" />

--- a/look-and-feel/react/src/List/List.stories.tsx
+++ b/look-and-feel/react/src/List/List.stories.tsx
@@ -1,9 +1,10 @@
-import arrow from "@material-symbols/svg-400/outlined/arrow_right.svg";
-import trash from "@material-symbols/svg-400/outlined/delete.svg";
-import sync from "@material-symbols/svg-400/outlined/sync-fill.svg";
+import trashIcon from "@material-symbols/svg-400/outlined/delete.svg";
+import publishedWithChangesIcon from "@material-symbols/svg-400/outlined/published_with_changes-fill.svg";
 import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 import { Svg } from "../Svg";
+import { ClickItem } from "./ClickList";
+import { ContentItemMono } from "./ContentItemMono";
 import { List } from "./List";
 
 const meta: Meta<typeof List> = {
@@ -23,66 +24,21 @@ export const Default: StoryObj<
   ),
   args: {
     children: [
-      <div key="list-item-1">
-        <span>Prénom NOM</span>
-      </div>,
-      <div key="list-item-2">
-        <span>nom.prénom@mail.fr</span>
-      </div>,
-      <div
-        key="list-item-3"
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
-        <Svg src={sync} />
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "space-between",
-            width: "100%",
-          }}
-        >
-          <span>Modifier le profil</span>
-          <Svg src={arrow} />
-        </div>
-      </div>,
-      <div
-        key="list-element-3"
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-          gap: "4rem",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-            gap: "0.5rem",
-          }}
-        >
-          <Svg src={trash} />
-          <span>Supprimer le profil</span>
-        </div>
-      </div>,
+      <ContentItemMono key={0} secondaryText="nom.prénom@mail.fr">
+        Prénom NOM
+      </ContentItemMono>,
+      <ClickItem key={1} icon={<Svg src={publishedWithChangesIcon} />}>
+        Modifier le profil
+      </ClickItem>,
+      <ClickItem key={2} icon={<Svg src={trashIcon} />}>
+        Supprimer le profil
+      </ClickItem>,
     ],
-    classModifier: [],
+    classModifier: ["first-separator-full-width"],
   },
   argTypes: {
     classModifier: {
-      options: [
-        "large",
-        "first-separator-full-width",
-        "first-separator-full-width",
-      ],
+      options: ["large", "first-separator-full-width"],
       control: { type: "multi-select" },
       defaultValue: [],
     },


### PR DESCRIPTION
Fix : 
- separator height size from 2px to 1px
- remove extra padding to ClickItem when using `first-separator-full-width` class modifier 

And update List story.

Before : 
![image](https://github.com/user-attachments/assets/bf94162f-e5f8-4023-926a-0c6ac3b5cf27)

After :
![image](https://github.com/user-attachments/assets/e1d378f8-cd94-4c91-b24e-b938f0d399f2)
