### PR TITLE
fix(RadioSelect): added missing aria-describedby to read error

### DIFF
--- a/look-and-feel/css/src/Form/Radio/Radio.scss
+++ b/look-and-feel/css/src/Form/Radio/Radio.scss
@@ -7,8 +7,13 @@
     box-sizing: border-box;
   }
 
+  &__container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
   &__label {
-    margin-bottom: 0.5rem;
     font-size: 1.25rem;
     font-weight: 600;
     color: common.$color-gray-900;
@@ -56,16 +61,11 @@
   }
 
   & ~ .af-input-error {
-    margin-left: 3.2rem;
     gap: 0.5rem;
 
     &__message {
       line-height: 1.25rem;
     }
-  }
-
-  &-select ~ .af-input-error {
-    margin: 1rem 0 0;
   }
 
   & label {

--- a/look-and-feel/css/src/Form/Radio/Radio.stories.ts
+++ b/look-and-feel/css/src/Form/Radio/Radio.stories.ts
@@ -73,9 +73,10 @@ export const Basic: StoryObj = {
   argTypes: {},
 };
 
-const InputError = `<div class="af-input-error">
-<svg class="af-input-error__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ErrorOutlineIcon"><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path></svg>
-<span class="af-input-error__message">Veuillez sélectionner au moins une ville</span>
+const InputError = `
+<div class="af-input-error">
+  <svg class="af-input-error__icon" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ErrorOutlineIcon"><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"></path></svg>
+  <span aria-live="assertive" id="cities-error" class="af-input-error__message">Veuillez sélectionner au moins une ville</span>
 </div>`;
 
 export const BasicWithError: StoryObj = {
@@ -114,6 +115,7 @@ export const BasicWithError: StoryObj = {
 export const Vertical: StoryObj = {
   render: () => {
     const container = document.createElement("div");
+    container.classList.add("af-radio__container");
     container.innerHTML = `<div role="group" class="af-radio af-radio-select">
       <label>
         <input type="radio" name="cities" value="paris" />
@@ -186,7 +188,8 @@ export const Vertical: StoryObj = {
 export const VerticalWithError: StoryObj = {
   render: () => {
     const container = document.createElement("div");
-    container.innerHTML = `<div role="group" class="af-radio af-radio-select" aria-invalid="true">
+    container.classList.add("af-radio__container");
+    container.innerHTML = `<div role="group" class="af-radio af-radio-select" aria-invalid="true" aria-describedby="cities-error">
       <label>
         <input type="radio" name="cities" value="paris" />
         <div class="af-radio__icons">
@@ -240,10 +243,11 @@ export const VerticalWithError: StoryObj = {
 export const VerticalWithLabel: StoryObj = {
   render: () => {
     const container = document.createElement("div");
+    container.classList.add("af-radio__container");
     container.innerHTML = `
-     <legend class="af-radio__label" aria-label="Quelle ville ?">
+     <span class="af-radio__label" aria-label="Quelle ville ?">
     Quelle ville ?<span aria-hidden="true">&nbsp;*</span>
-  </legend>
+  </span>
   <div
     role="radiogroup"
     class="af-radio af-radio-select af-radio-select--vertical"
@@ -397,6 +401,7 @@ export const VerticalWithLabel: StoryObj = {
 export const Horizontal: StoryObj = {
   render: () => {
     const container = document.createElement("div");
+    container.classList.add("af-radio__container");
     container.innerHTML = `<div role="group" class="af-radio af-radio-select af-radio-select--horizontal">
       <label>
         <input type="radio" name="cities" value="paris" />
@@ -469,7 +474,8 @@ export const Horizontal: StoryObj = {
 export const HorizontalWithError: StoryObj = {
   render: () => {
     const container = document.createElement("div");
-    container.innerHTML = `<div role="group" class="af-radio af-radio-select af-radio-select--horizontal" aria-invalid="true">
+    container.classList.add("af-radio__container");
+    container.innerHTML = `<div role="group" class="af-radio af-radio-select af-radio-select--horizontal" aria-invalid="true" aria-describedby="cities-error">
       <label>
         <input type="radio" name="cities" value="paris" />
         <div class="af-radio__icons">

--- a/look-and-feel/react/src/Form/Radio/RadioSelect.tsx
+++ b/look-and-feel/react/src/Form/Radio/RadioSelect.tsx
@@ -47,7 +47,7 @@ export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
     const generatedId = useId();
     const optionId = id || generatedId;
     return (
-      <>
+      <div className="af-radio__container">
         {label && (
           <span className="af-radio__label" id={optionId}>
             {label}
@@ -61,6 +61,7 @@ export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
           className={`af-radio af-radio-select af-radio-select--${type}`}
           aria-invalid={Boolean(errorMessage)}
           aria-labelledby={optionId}
+          aria-describedby={errorMessage ? `${optionId}-error` : undefined}
         >
           {options.map(
             ({
@@ -106,8 +107,10 @@ export const RadioSelect = forwardRef<HTMLDivElement, RadioSelectProps>(
             ),
           )}
         </div>
-        {errorMessage && <InputError message={errorMessage} />}
-      </>
+        {errorMessage && (
+          <InputError id={`${optionId}-error`} message={errorMessage} />
+        )}
+      </div>
     );
   },
 );


### PR DESCRIPTION
Added aria-describedby prop so screen readers can read it when focusing the input.

Before change:
![radioselect-pre-describedby](https://github.com/user-attachments/assets/e819bf0d-a6db-4cf7-ad08-811fdbcbfc43)

After change:
![radioselect-describedby](https://github.com/user-attachments/assets/c03b12fc-71a4-4c7b-b43e-dcc2db49880e)
