### PR TITLE
fix(slash): remove deprecated sass fade-in() method

### DIFF
--- a/slash/css/src/common/common.scss
+++ b/slash/css/src/common/common.scss
@@ -1272,7 +1272,10 @@ $popover-arrow-width: 1rem !default;
 $popover-arrow-height: 0.5rem !default;
 $popover-arrow-color: $popover-bg !default;
 
-$popover-arrow-outer-color: fade-in($popover-border-color, 0.05) !default;
+$popover-arrow-outer-color: color.adjust(
+  $popover-border-color,
+  $alpha: 0.05
+) !default;
 
 // Badges
 


### PR DESCRIPTION
fix sass deprecated : https://sass-lang.com/documentation/breaking-changes/color-functions/#single-channel-adjustment-functions