### PR TITLE
feat(client): permit ClickItem click type to be more permissive

### DIFF
--- a/look-and-feel/css/src/List/ClickList/ClickList.scss
+++ b/look-and-feel/css/src/List/ClickList/ClickList.scss
@@ -54,6 +54,7 @@
 
   &__label {
     text-align: left;
+    color: common.$color-gray-900;
   }
 
   &__title {

--- a/look-and-feel/react/src/List/ClickList/ClickItem/ClickItem.tsx
+++ b/look-and-feel/react/src/List/ClickList/ClickItem/ClickItem.tsx
@@ -12,15 +12,25 @@ type TClickItem = { classModifier?: string; isDisabled?: boolean } & Omit<
      * @deprecated Use children prop instead
      */
     label?: ReactNode;
+    parentClickComponent?: ({
+      children,
+    }: { children: ReactNode } & Record<string, unknown>) => ReactNode;
     children?: ReactNode;
     icon?: ReactNode;
-  };
+  } & Record<string, unknown>;
 
 export const ClickItem = ({
   label,
   children,
   icon,
-  href,
+  parentClickComponent: ClickComponent = ({
+    children: parentClickComponentChildren,
+    ...parentClickComponentProps
+  }) => (
+    <button type="button" {...parentClickComponentProps}>
+      {parentClickComponentChildren}
+    </button>
+  ),
   isDisabled = false,
   className,
   classModifier = "",
@@ -36,23 +46,13 @@ export const ClickItem = ({
     [className, classModifier, isDisabled],
   );
 
-  const ClickComponent = useMemo(() => (href ? "a" : "button"), [href]);
-
-  const clickComponentProps: ComponentProps<"button"> & ComponentProps<"a"> =
-    useMemo(
-      () =>
-        href
-          ? { href, "aria-disabled": isDisabled, ...otherProps }
-          : {
-              type: "button",
-              disabled: isDisabled,
-              ...otherProps,
-            },
-      [isDisabled, href, otherProps],
-    );
-
   return (
-    <ClickComponent className={componentClassName} {...clickComponentProps}>
+    <ClickComponent
+      className={componentClassName}
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
+      {...otherProps}
+    >
       <div className="af-click-item__content">
         {icon && <div className="af-click-item__icon">{icon}</div>}
         <div className="af-click-item__label">{children || label}</div>

--- a/look-and-feel/react/src/List/ClickList/ClickItem/__tests__/ClickItem.test.tsx
+++ b/look-and-feel/react/src/List/ClickList/ClickItem/__tests__/ClickItem.test.tsx
@@ -63,7 +63,17 @@ describe("ClickItem", () => {
     const label = "Sample Label";
     const href = "https://example.com";
 
-    render(<ClickItem href={href}>{label}</ClickItem>);
+    render(
+      <ClickItem
+        parentClickComponent={({ children, ...parentClickComponentProps }) => (
+          <a href={href} rel="noreferrer" {...parentClickComponentProps}>
+            {children}
+          </a>
+        )}
+      >
+        {label}
+      </ClickItem>,
+    );
 
     const linkElement = screen.getByRole("link", { name: label });
 
@@ -77,7 +87,14 @@ describe("ClickItem", () => {
     const disabled = true;
 
     render(
-      <ClickItem href={href} isDisabled={disabled}>
+      <ClickItem
+        parentClickComponent={({ children, ...parentClickComponentProps }) => (
+          <a href={href} rel="noreferrer" {...parentClickComponentProps}>
+            {children}
+          </a>
+        )}
+        isDisabled={disabled}
+      >
         {label}
       </ClickItem>,
     );

--- a/look-and-feel/react/src/List/ClickList/ClickList.mdx
+++ b/look-and-feel/react/src/List/ClickList/ClickList.mdx
@@ -120,8 +120,16 @@ const MyComponentWithoutIcon = () => (
             </p>
           </>
         ),
-        href: "https://github.com/AxaFrance/design-system",
-        target: "_blank",
+        parentClickComponent: ({ children, ...parentClickComponentProps }) => (
+          <a
+            href="https://github.com/AxaFrance/design-system"
+            target="_blank"
+            rel="noreferrer"
+            {...parentClickComponentProps}
+          >
+            {children}
+          </a>
+        ),
       },
       {
         id: "contractual_Orias_sheet-2",
@@ -138,9 +146,17 @@ const MyComponentWithoutIcon = () => (
             </p>
           </>
         ),
-        href: "https://github.com/AxaFrance/design-system",
-        target: "_blank",
-        disabled: true,
+        parentClickComponent: ({ children, ...parentClickComponentProps }) => (
+          <a
+            href="https://github.com/AxaFrance/design-system"
+            target="_blank"
+            rel="noreferrer"
+            {...parentClickComponentProps}
+          >
+            {children}
+          </a>
+        ),
+        isDisabled: true,
       },
     ]}
   />

--- a/look-and-feel/react/src/List/ClickList/ClickList.stories.tsx
+++ b/look-and-feel/react/src/List/ClickList/ClickList.stories.tsx
@@ -108,8 +108,16 @@ export const ClickListLinkWithoutIcon: StoryObj<typeof ClickList> = {
             <p className="af-click-item__secondary">Signé électroniquement</p>
           </>
         ),
-        href: "https://github.com/AxaFrance/design-system",
-        target: "_blank",
+        parentClickComponent: ({ children, ...parentClickComponentProps }) => (
+          <a
+            href="https://github.com/AxaFrance/design-system"
+            target="_blank"
+            rel="noreferrer"
+            {...parentClickComponentProps}
+          >
+            {children}
+          </a>
+        ),
       },
       {
         id: "2",
@@ -122,8 +130,16 @@ export const ClickListLinkWithoutIcon: StoryObj<typeof ClickList> = {
             <p className="af-click-item__secondary">Signé électroniquement</p>
           </>
         ),
-        href: "https://github.com/AxaFrance/design-system",
-        target: "_blank",
+        parentClickComponent: ({ children, ...parentClickComponentProps }) => (
+          <a
+            href="https://github.com/AxaFrance/design-system"
+            target="_blank"
+            rel="noreferrer"
+            {...parentClickComponentProps}
+          >
+            {children}
+          </a>
+        ),
         isDisabled: true,
       },
     ],


### PR DESCRIPTION
Issue : https://github.com/AxaFrance/design-system/issues/540

Instead of use a condition to switch between a link (`a` tag) or a button we can now choose directly the ClickItem parent.
That permit to use Link from react-router for example.