### PR TITLE
fix: disable button outline when clicked

### DIFF
--- a/look-and-feel/css/src/Button/Button.scss
+++ b/look-and-feel/css/src/Button/Button.scss
@@ -29,6 +29,7 @@
   &:focus {
     color: common.$color-white;
     background-color: common.$color-btn-light;
+    outline: none;
   }
 
   &:focus-visible {


### PR DESCRIPTION
Cette PR a pour but d'enlever l'outline noir qui apparait lors du clique sur un bouton:

![image](https://github.com/user-attachments/assets/e294088c-c1fa-4358-8761-ec2c05963959)
