### PR TITLE
feat(look-and-feel): title level

### DIFF
--- a/look-and-feel/react/src/Title/Title.mdx
+++ b/look-and-feel/react/src/Title/Title.mdx
@@ -7,6 +7,32 @@ import * as TitleStories from "./Title.stories";
 
 ### Use of Title
 
+#### Title Basic
+
+The basic title use `<h1>` tag (default value of size is `<TitleSize.XL`)
+
+When you set the size to `<TitleSize.L`, this use the `<h2>` tag by default.
+
+```tsx
+import { Title } from "@axa-fr/design-system-look-and-feel-react";
+
+export const TitleBasic = () => <Title>Titre de la page</Title>;
+```
+
+<Canvas of={TitleStories.TitleBasic} />
+
+<Controls of={TitleStories.TitleBasic} />
+
+If you want to set another level heading tag, you can use the **level** property :
+
+```tsx
+import { Title } from "@axa-fr/design-system-look-and-feel-react";
+
+export const TitleH3 = () => (
+  <Title level={3}>Titre de la page with h3 tag</Title>
+);
+```
+
 #### Title with icon
 
 ```tsx

--- a/look-and-feel/react/src/Title/Title.stories.tsx
+++ b/look-and-feel/react/src/Title/Title.stories.tsx
@@ -11,6 +11,26 @@ const meta: Meta<typeof Title> = {
 
 export default meta;
 
+export const TitleBasic: StoryObj<typeof Title> = {
+  render: (args) => <Title {...args} />,
+  args: {
+    children: "Titre de la page",
+    size: TitleSize.XL,
+  },
+  argTypes: {
+    size: {
+      options: Object.values(TitleSize),
+      control: { type: "select" },
+      defaultValue: TitleSize.XL,
+    },
+    level: {
+      options: [1, 2, 3, 4, 5, 6],
+      control: { type: "select" },
+      defaultValue: 1,
+    },
+  },
+};
+
 export const TitleWithIcon: StoryObj<typeof Title> = {
   render: (args) => <Title {...args} />,
   args: {

--- a/look-and-feel/react/src/Title/Title.tsx
+++ b/look-and-feel/react/src/Title/Title.tsx
@@ -6,7 +6,7 @@ import {
 } from "react";
 import { IconBg } from "..";
 import { getComponentClassName } from "../utilities";
-import { TitleSize } from "./constants";
+import { TitleSize, TitleLevel } from "./constants";
 import { TitleWithSubtitles } from "./TitleWithSubtitles";
 
 type TitleProps = {
@@ -17,6 +17,7 @@ type TitleProps = {
   className?: string;
   classModifier?: string;
   size?: TitleSize;
+  level?: TitleLevel;
 };
 
 export const Title = ({
@@ -27,6 +28,7 @@ export const Title = ({
   icon,
   secondSubtitle,
   size = TitleSize.XL,
+  level = size === TitleSize.L ? 2 : 1,
 }: TitleProps) => {
   const componentClassName = useMemo(
     () =>
@@ -59,11 +61,14 @@ export const Title = ({
         <>
           <IconBg className="af-title__icon af-icon-bg">{icon}</IconBg>
           <div className="af-title__text-container">
-            <TitleWithSubtitlesPart secondSubtitle={secondSubtitle} />
+            <TitleWithSubtitlesPart
+              secondSubtitle={secondSubtitle}
+              level={level}
+            />
           </div>
         </>
       ) : (
-        <TitleWithSubtitlesPart />
+        <TitleWithSubtitlesPart level={level} />
       )}
     </div>
   );

--- a/look-and-feel/react/src/Title/TitleWithSubtitles.tsx
+++ b/look-and-feel/react/src/Title/TitleWithSubtitles.tsx
@@ -1,23 +1,33 @@
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
+import { TitleLevel } from "./constants";
 
 type TitleTextProps = {
   title: ReactNode;
   firstSubtitle?: string;
   secondSubtitle?: string;
+  level?: TitleLevel;
 };
 
 export const TitleWithSubtitles = ({
   title,
   firstSubtitle,
   secondSubtitle,
-}: TitleTextProps) => (
-  <>
-    <h1 className="af-title__title">{title}</h1>
-    {firstSubtitle && (
-      <span className="af-title__subtitle">{firstSubtitle}</span>
-    )}
-    {secondSubtitle && (
-      <span className="af-title__subtitle">{secondSubtitle}</span>
-    )}
-  </>
-);
+  level = 1,
+}: TitleTextProps) => {
+  const HLevel = useMemo(
+    () => `h${level}`,
+    [level],
+  ) as keyof JSX.IntrinsicElements;
+
+  return (
+    <>
+      <HLevel className="af-title__title">{title}</HLevel>
+      {firstSubtitle && (
+        <span className="af-title__subtitle">{firstSubtitle}</span>
+      )}
+      {secondSubtitle && (
+        <span className="af-title__subtitle">{secondSubtitle}</span>
+      )}
+    </>
+  );
+};

--- a/look-and-feel/react/src/Title/__tests__/Title.test.tsx
+++ b/look-and-feel/react/src/Title/__tests__/Title.test.tsx
@@ -61,10 +61,18 @@ describe("Title", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Title", level: 1 }),
+      screen.getByRole("heading", { name: "Title", level: 2 }),
     ).toBeInTheDocument();
     expect(screen.getByText("firstSubtitle")).toBeInTheDocument();
     expect(screen.queryByText("secondSubtitle")).not.toBeInTheDocument();
     expect(screen.queryByText("icon")).not.toBeInTheDocument();
+  });
+
+  it("should use the h3 heading tag when level equal 3", () => {
+    render(<Title level={3}>Title H3</Title>);
+
+    expect(
+      screen.getByRole("heading", { name: "Title H3", level: 3 }),
+    ).toBeInTheDocument();
   });
 });

--- a/look-and-feel/react/src/Title/constants.ts
+++ b/look-and-feel/react/src/Title/constants.ts
@@ -2,3 +2,5 @@ export enum TitleSize {
   XL = "xl",
   L = "l",
 }
+
+export type TitleLevel = 1 | 2 | 3 | 4 | 5 | 6;

--- a/look-and-feel/react/src/Title/index.ts
+++ b/look-and-feel/react/src/Title/index.ts
@@ -1,4 +1,4 @@
 import "@axa-fr/design-system-look-and-feel-css/dist/Title/Title.scss";
 
-export { TitleSize } from "./constants";
+export { TitleSize, type TitleLevel } from "./constants";
 export { Title } from "./Title";

--- a/look-and-feel/react/src/index.ts
+++ b/look-and-feel/react/src/index.ts
@@ -31,4 +31,4 @@ export { Stepper } from "./Stepper/Stepper";
 export { Svg } from "./Svg";
 export { TabsClient as Tabs } from "./Tabs/Tabs";
 export { Tag } from "./Tag";
-export { Title, TitleSize } from "./Title";
+export { Title, TitleSize, type TitleLevel } from "./Title";


### PR DESCRIPTION
- when you set the size to 'L', use `h2`by default
- add **level** property to choose the heading level