### PR TITLE
fix(look-and-feel): responsive sizes text input

### DIFF
--- a/look-and-feel/css/src/Form/Text/Text.scss
+++ b/look-and-feel/css/src/Form/Text/Text.scss
@@ -8,10 +8,15 @@
   }
 
   &__input-label {
-    margin: 0;
-    font-size: 1.125rem;
+    font-size: common.rem(16);
     font-weight: 600;
+    line-height: common.rem(20);
     color: common.$color-gray-900;
+
+    @media (width > #{common.$breakpoint-md}) {
+      font-size: common.rem(18);
+      line-height: common.rem(24);
+    }
   }
 
   &__input-description {
@@ -38,12 +43,17 @@
 
   &__input-text {
     margin-top: 0.5rem;
-    padding: 1rem;
-    padding-right: 2.5rem;
+    padding: 1rem 2.5rem 1rem 1rem;
     border: 1px solid common.$color-gray;
     border-radius: common.$default-border-radius;
-    font-size: 1.125rem;
+    font-size: common.rem(16);
+    line-height: common.rem(20);
     color: common.$color-gray-900;
+
+    @media (width > #{common.$breakpoint-md}) {
+      font-size: common.rem(18);
+      line-height: common.rem(24);
+    }
 
     &--error {
       border: 2px solid common.$color-red-700;

--- a/look-and-feel/css/src/Form/Text/Text.scss
+++ b/look-and-feel/css/src/Form/Text/Text.scss
@@ -20,16 +20,27 @@
   }
 
   &__input-description {
-    margin-top: -0.25rem;
-    font-size: 1rem;
+    font-size: common.rem(14);
     font-weight: 400;
+    line-height: common.rem(18);
     color: common.$color-gray-700;
+
+    @media (width > #{common.$breakpoint-md}) {
+      font-size: common.rem(16);
+      line-height: common.rem(20);
+    }
   }
 
   &__input-helper {
     margin-top: 0.2rem;
-    font-size: 0.9rem;
+    font-size: common.rem(14);
+    line-height: common.rem(18);
     color: common.$color-gray-700;
+
+    @media (width > #{common.$breakpoint-md}) {
+      font-size: common.rem(16);
+      line-height: common.rem(20);
+    }
   }
 
   &__input-more {

--- a/look-and-feel/css/src/common/common.scss
+++ b/look-and-feel/css/src/common/common.scss
@@ -1,3 +1,5 @@
+@import "./mixins";
+
 $font-family-sans-serif: "Source Sans Pro", arial, sans-serif !default;
 $font-family-serif: georgia, times, "Times New Roman", serif !default;
 $font-family-base: $font-family-sans-serif !default;

--- a/look-and-feel/css/src/common/mixins.scss
+++ b/look-and-feel/css/src/common/mixins.scss
@@ -1,0 +1,5 @@
+@use "sass:math";
+
+@function rem($pxValue) {
+  @return math.div($pxValue * 1px, 16px) * 1rem;
+}

--- a/look-and-feel/css/src/common/reboot.scss
+++ b/look-and-feel/css/src/common/reboot.scss
@@ -198,11 +198,6 @@ th {
   text-align: inherit;
 }
 
-label {
-  display: inline-block;
-  margin-bottom: 0.5rem;
-}
-
 button {
   border-radius: 0;
 }


### PR DESCRIPTION
- set label font-size and line-height for mobile and desktop
- set input text font-size and line-height for mobile and desktop
- set description font-size and line-height for mobile and desktop
- set helper text font-size and line-height for mobile and desktop
- add rem sass function to define the size with px value

https://www.figma.com/design/21801ytpBZM2hBkaxGdzgW/01.-Composants-Espace-Client?node-id=14952-80396&node-type=frame&t=5vBjx5TyXebe7JEy-0

<img width="783" alt="image" src="https://github.com/user-attachments/assets/52ff3b26-b941-4fd2-bda8-ad3ebce5a7c6">


> I'll probably have to rework the structure, right now I've just corrected the problem of type size on mobile and desktop.