### PR TITLE
feat(ContentTabItem): use given components for buttons instead of Button props

### DIFF
--- a/look-and-feel/css/src/List/ContentTabList/ContentTabList.scss
+++ b/look-and-feel/css/src/List/ContentTabList/ContentTabList.scss
@@ -70,7 +70,7 @@
         color: common.$color-green-600;
       }
 
-      &__button-container {
+      &__action-container {
         margin: 0 0.625rem;
 
         svg {
@@ -143,10 +143,10 @@
         line-height: 1.25rem;
       }
 
-      &__button-container {
+      &__action-container {
         margin: 0;
 
-        button {
+        > * {
           padding: 0;
           gap: 0;
           font-size: 0;

--- a/look-and-feel/css/src/List/ContentTabList/ContentTabList.stories.ts
+++ b/look-and-feel/css/src/List/ContentTabList/ContentTabList.stories.ts
@@ -17,7 +17,7 @@ type TContentTabList = {
     subtitle?: string;
     tag?: string;
     date?: string;
-    buttons?: string[];
+    actions?: string[];
     value?: string;
   }[];
   isMobile?: boolean;
@@ -33,7 +33,7 @@ const template = ({ items, isMobile }: TContentTabList) => {
 
   ul.className = "af-list";
 
-  items.forEach(({ title, subtitle, date, tag, buttons = [], value }) => {
+  items.forEach(({ title, subtitle, date, tag, actions = [], value }) => {
     const item = document.createElement("li");
     item.className = "af-list__item";
 
@@ -119,14 +119,11 @@ const template = ({ items, isMobile }: TContentTabList) => {
       rightContainer.appendChild(additionalDataContainer);
     }
 
-    buttons.forEach((button) => {
-      const buttonsContainer = document.createElement("div");
-      buttonsContainer.className = "af-list-item__button-container";
-
-      const buttonElement = document.createElement("div");
-      buttonElement.innerHTML = button;
-      buttonsContainer.appendChild(buttonElement);
-      rightContainer.appendChild(buttonsContainer);
+    actions.forEach((action) => {
+      const actionContainer = document.createElement("div");
+      actionContainer.className = "af-list-item__action-container";
+      actionContainer.innerHTML = action;
+      rightContainer.appendChild(actionContainer);
     });
 
     if (value) {
@@ -154,7 +151,7 @@ export const ContentTabListWithButtons: StoryObj<TContentTabList> = {
         subtitle: "Titre onglet",
         tag: "En attente",
         date: "01/01/2024",
-        buttons: [
+        actions: [
           `<button class="af-btn-client af-btn-client--ghost" type="button">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#00008F" viewBox="0 0 24 24">
               <path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"></path>
@@ -166,7 +163,7 @@ export const ContentTabListWithButtons: StoryObj<TContentTabList> = {
       {
         title: "Remboursement soins",
         tag: "En attente",
-        buttons: [
+        actions: [
           `<button class="af-btn-client af-btn-client--ghost" type="button">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#00008F" viewBox="0 0 24 24">
               <path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"></path>

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabItem/ContentTabItem.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabItem/ContentTabItem.tsx
@@ -1,4 +1,4 @@
-import { Button, Tag } from "../../..";
+import { Tag } from "../../..";
 import type { TContentTabItem } from "./types";
 
 type TContentTabItemProps = TContentTabItem & {
@@ -61,9 +61,9 @@ export const ContentTabItem = ({
             )}
           </div>
         )}
-        {buttons.map((button) => (
-          <div className="af-list-item__button-container" key={button?.id}>
-            <Button {...button} />
+        {buttons.map(({ id, component }) => (
+          <div className="af-list-item__button-container" key={id}>
+            {component}
           </div>
         ))}
         {Boolean(value) && <span className="af-list-item__value">{value}</span>}

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabItem/ContentTabItem.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabItem/ContentTabItem.tsx
@@ -11,7 +11,7 @@ export const ContentTabItem = ({
   tag,
   tagProps,
   date,
-  buttons = [],
+  actions = [],
   value,
   isMobile = false,
 }: TContentTabItemProps) => (
@@ -44,7 +44,7 @@ export const ContentTabItem = ({
         </div>
       )}
     </div>
-    {(buttons.length > 0 ||
+    {(actions.length > 0 ||
       Boolean(tag) ||
       Boolean(date) ||
       Boolean(value)) && (
@@ -61,8 +61,8 @@ export const ContentTabItem = ({
             )}
           </div>
         )}
-        {buttons.map(({ id, component }) => (
-          <div className="af-list-item__button-container" key={id}>
+        {actions.map(({ id, component }) => (
+          <div className="af-list-item__action-container" key={id}>
             {component}
           </div>
         ))}

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabItem/__tests__/ContentTabItem.test.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabItem/__tests__/ContentTabItem.test.tsx
@@ -16,7 +16,7 @@ describe("ContentTabList", () => {
       subtitle: "Subtitle 1",
       tag: "Tag 1",
       date: "Date 1",
-      buttons: [
+      actions: [
         {
           id: "download_button",
           component: (

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabItem/__tests__/ContentTabItem.test.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabItem/__tests__/ContentTabItem.test.tsx
@@ -3,9 +3,12 @@ import visibility from "@material-symbols/svg-400/rounded/visibility-fill.svg";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ContentTabItem, type TContentTabItem } from "..";
-import { ButtonVariants, Svg } from "../../../..";
+import { Button, ButtonVariants, Svg } from "../../../..";
 
 describe("ContentTabList", () => {
+  const onDownload = vi.fn();
+  const onDisplay = vi.fn();
+
   const items: TContentTabItem[] = [
     {
       id: "1",
@@ -16,17 +19,27 @@ describe("ContentTabList", () => {
       buttons: [
         {
           id: "download_button",
-          children: "Télécharger",
-          variant: ButtonVariants.ghost,
-          iconLeft: <Svg src={download} fill="#00008F" />,
-          onClick: vi.fn(),
+          component: (
+            <Button
+              variant={ButtonVariants.ghost}
+              iconLeft={<Svg src={download} fill="#00008F" />}
+              onClick={onDownload}
+            >
+              Télécharger
+            </Button>
+          ),
         },
         {
           id: "display_button",
-          children: "Afficher",
-          variant: ButtonVariants.ghost,
-          iconLeft: <Svg src={visibility} fill="#00008F" />,
-          onClick: vi.fn(),
+          component: (
+            <Button
+              variant={ButtonVariants.ghost}
+              iconLeft={<Svg src={visibility} fill="#00008F" />}
+              onClick={onDisplay}
+            >
+              Afficher
+            </Button>
+          ),
         },
       ],
     },
@@ -105,7 +118,7 @@ describe("ContentTabList", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /Télécharger$/ }));
 
-    expect(items?.[0]?.buttons?.[0].onClick).toHaveBeenCalled();
+    expect(onDownload).toHaveBeenCalled();
   });
 
   it("should call onDisplay when display button is clicked", async () => {
@@ -113,6 +126,6 @@ describe("ContentTabList", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /Afficher$/ }));
 
-    expect(items?.[0]?.buttons?.[1].onClick).toHaveBeenCalled();
+    expect(onDownload).toHaveBeenCalled();
   });
 });

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabItem/types.d.ts
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabItem/types.d.ts
@@ -1,5 +1,5 @@
-import type { ComponentProps } from "react";
-import { Button, Tag } from "../../..";
+import type { ComponentProps, ReactNode } from "react";
+import { Tag } from "../../..";
 
 export type TContentTabItem = {
   id?: string;
@@ -8,6 +8,6 @@ export type TContentTabItem = {
   tag?: string;
   tagProps?: ComponentProps<typeof Tag>;
   date?: string;
-  buttons?: Array<ComponentProps<typeof Button>>;
+  buttons?: Array<{ id: string; component: ReactNode }>;
   value?: string;
 };

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabItem/types.d.ts
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabItem/types.d.ts
@@ -8,6 +8,6 @@ export type TContentTabItem = {
   tag?: string;
   tagProps?: ComponentProps<typeof Tag>;
   date?: string;
-  buttons?: Array<{ id: string; component: ReactNode }>;
+  actions?: Array<{ id: string; component: ReactNode }>;
   value?: string;
 };

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabList.mdx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabList.mdx
@@ -25,13 +25,18 @@ const MyComponentWithButtons = () => (
         subtitle: "Titre onglet",
         tag: "En attente",
         date: "01/01/2024",
-        buttons: [
+        actions: [
           {
             id: "download_button",
-            children: "Télécharger",
-            variant: ButtonVariants.ghost,
-            iconLeft: <Svg src={download} />,
-            onClick,
+            component: (
+              <Button
+                variant={ButtonVariants.ghost}
+                iconLeft={<Svg src={download} />}
+                onClick={fn()}
+              >
+                Télécharger
+              </Button>
+            ),
           },
         ],
       },
@@ -39,20 +44,30 @@ const MyComponentWithButtons = () => (
         id: "2",
         title: "Remboursement soins",
         tag: "En attente",
-        buttons: [
+        actions: [
           {
             id: "download_button",
-            children: "Télécharger",
-            variant: ButtonVariants.ghost,
-            iconLeft: <Svg src={download} />,
-            onClick,
+            component: (
+              <Button
+                variant={ButtonVariants.ghost}
+                iconLeft={<Svg src={download} />}
+                onClick={fn()}
+              >
+                Télécharger
+              </Button>
+            ),
           },
           {
             id: "display_button",
-            children: "Afficher",
-            variant: ButtonVariants.ghost,
-            iconLeft: <Svg src={visibility} />,
-            onClick,
+            component: (
+              <Button
+                variant={ButtonVariants.ghost}
+                iconLeft={<Svg src={visibility} />}
+                onClick={fn()}
+              >
+                Afficher
+              </Button>
+            ),
           },
         ],
       },

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabList.stories.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabList.stories.tsx
@@ -29,7 +29,7 @@ export const ContentTabListWithButtons: StoryObj<
         subtitle: "Titre onglet",
         tag: "En attente",
         date: "01/01/2024",
-        buttons: [
+        actions: [
           {
             id: "download_button",
             component: (
@@ -48,7 +48,7 @@ export const ContentTabListWithButtons: StoryObj<
         id: "2",
         title: "Remboursement soins",
         tag: "En attente",
-        buttons: [
+        actions: [
           {
             id: "download_button",
             component: (

--- a/look-and-feel/react/src/List/ContentTabList/ContentTabList.stories.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/ContentTabList.stories.tsx
@@ -1,8 +1,9 @@
 import download from "@material-symbols/svg-400/rounded/download_2-fill.svg";
 import visibility from "@material-symbols/svg-400/rounded/visibility-fill.svg";
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import type { ComponentProps } from "react";
-import { ButtonVariants, Svg } from "../..";
+import { Button, ButtonVariants, Svg } from "../..";
 import { ContentTabList } from "./ContentTabList";
 
 const meta: Meta<typeof ContentTabList> = {
@@ -31,10 +32,15 @@ export const ContentTabListWithButtons: StoryObj<
         buttons: [
           {
             id: "download_button",
-            children: "Télécharger",
-            variant: ButtonVariants.ghost,
-            iconLeft: <Svg src={download} />,
-            onClick: () => {},
+            component: (
+              <Button
+                variant={ButtonVariants.ghost}
+                iconLeft={<Svg src={download} />}
+                onClick={fn()}
+              >
+                Télécharger
+              </Button>
+            ),
           },
         ],
       },
@@ -45,17 +51,27 @@ export const ContentTabListWithButtons: StoryObj<
         buttons: [
           {
             id: "download_button",
-            children: "Télécharger",
-            variant: ButtonVariants.ghost,
-            iconLeft: <Svg src={download} />,
-            onClick: () => {},
+            component: (
+              <Button
+                variant={ButtonVariants.ghost}
+                iconLeft={<Svg src={download} />}
+                onClick={fn()}
+              >
+                Télécharger
+              </Button>
+            ),
           },
           {
             id: "display_button",
-            children: "Afficher",
-            variant: ButtonVariants.ghost,
-            iconLeft: <Svg src={visibility} />,
-            onClick: () => {},
+            component: (
+              <Button
+                variant={ButtonVariants.ghost}
+                iconLeft={<Svg src={visibility} />}
+                onClick={fn()}
+              >
+                Afficher
+              </Button>
+            ),
           },
         ],
       },

--- a/look-and-feel/react/src/List/ContentTabList/__tests__/ContentTabList.test.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/__tests__/ContentTabList.test.tsx
@@ -1,7 +1,7 @@
 import download from "@material-symbols/svg-400/rounded/download_2-fill.svg";
 import visibility from "@material-symbols/svg-400/rounded/visibility-fill.svg";
 import { render, screen } from "@testing-library/react";
-import { ButtonVariants, Svg } from "../../..";
+import { Button, ButtonVariants, Svg } from "../../..";
 import type { TContentTabItem } from "../ContentTabItem";
 import { ContentTabList } from "../ContentTabList";
 
@@ -16,17 +16,27 @@ describe("ContentTabList", () => {
       buttons: [
         {
           id: "download_button",
-          children: "Télécharger",
-          variant: ButtonVariants.ghost,
-          iconLeft: <Svg src={download} fill="#00008F" />,
-          onClick: vi.fn(),
+          component: (
+            <Button
+              variant={ButtonVariants.ghost}
+              iconLeft={<Svg src={download} fill="#00008F" />}
+              onClick={vi.fn()}
+            >
+              Télécharger
+            </Button>
+          ),
         },
         {
           id: "display_button",
-          children: "Afficher",
-          variant: ButtonVariants.ghost,
-          iconLeft: <Svg src={visibility} fill="#00008F" />,
-          onClick: vi.fn(),
+          component: (
+            <Button
+              variant={ButtonVariants.ghost}
+              iconLeft={<Svg src={visibility} fill="#00008F" />}
+              onClick={vi.fn()}
+            >
+              Afficher
+            </Button>
+          ),
         },
       ],
     },

--- a/look-and-feel/react/src/List/ContentTabList/__tests__/ContentTabList.test.tsx
+++ b/look-and-feel/react/src/List/ContentTabList/__tests__/ContentTabList.test.tsx
@@ -13,7 +13,7 @@ describe("ContentTabList", () => {
       subtitle: "Subtitle 1",
       tag: "Tag 1",
       date: "Date 1",
-      buttons: [
+      actions: [
         {
           id: "download_button",
           component: (


### PR DESCRIPTION
Issue : https://github.com/AxaFrance/design-system/issues/588

BREAKING CHANGE :
Instead of giving the Button props, the developer will give the component directly.