### PR TITLE
fix(look&feel): set default size of svg to prevent brief content shift on load

### DIFF
--- a/look-and-feel/react/src/Svg/Svg.tsx
+++ b/look-and-feel/react/src/Svg/Svg.tsx
@@ -78,5 +78,13 @@ export const Svg = ({
     ) : null;
   }
 
-  return <svg ref={rootRef} data-src={src} {...props} />;
+  return (
+    <svg
+      ref={rootRef}
+      data-src={src}
+      width={width}
+      height={height}
+      {...props}
+    />
+  );
 };


### PR DESCRIPTION
Pull Request to fix a brief content shift when displaying some components with SVG icons (like the Alert component). This happens because, for a split second, the svg takes up all the space it needs to be displayed at 100% of its size.

Video showcasing the problem :

https://github.com/user-attachments/assets/2569af59-e885-4999-9fb6-1cef4e2a6bdd

