### PR TITLE
fix(svgInjector): add null check for SVGSVGElement

### DIFF
--- a/look-and-feel/react/src/Svg/svgInjector.ts
+++ b/look-and-feel/react/src/Svg/svgInjector.ts
@@ -42,6 +42,10 @@ export const svgInjector = (
   element: HTMLElement | SVGSVGElement | null,
   { beforeEach = () => {}, ...options }: Options = {},
 ) => {
+  if (!element) {
+    return;
+  }
+
   SVGInjector(element, {
     ...options,
     beforeEach: (svg) => {


### PR DESCRIPTION
We have errors that trigger randomly when we test pages with SVG :

![image](https://github.com/user-attachments/assets/7b249867-65c0-4675-9d99-3ccf1f96063f)
