### PR TITLE
fix(slash): passing className property to Button remove af-btn defaultClassName

### DIFF
--- a/slash/react/src/Button/Button.stories.tsx
+++ b/slash/react/src/Button/Button.stories.tsx
@@ -30,6 +30,7 @@ type StoryProps = Omit<
 > & {
   children: string;
   classModifier: string[];
+  className: string;
 };
 type Story = StoryObj<StoryProps>;
 
@@ -43,6 +44,7 @@ export const Playground: Story = {
   args: {
     children: "Button",
     classModifier: [] as string[],
+    className: "",
   },
   argTypes: {
     classModifier: {

--- a/slash/react/src/Button/Button.tsx
+++ b/slash/react/src/Button/Button.tsx
@@ -1,7 +1,7 @@
 import "@axa-fr/design-system-slash-css/dist/Button/Button.scss";
-import classNames from "classnames";
 
 import { ComponentPropsWithoutRef, PropsWithChildren } from "react";
+import { getComponentClassName } from "../utilities";
 
 type ButtonProps = {
   classModifier?: string;
@@ -13,17 +13,14 @@ export const Button = ({
   className,
   ...args
 }: PropsWithChildren<ButtonProps>) => {
-  const classes = classModifier
-    ?.split(" ")
-    .map((modifier) => `af-btn--${modifier}`)
-    .join(" ");
+  const componentClassName = getComponentClassName(
+    className,
+    classModifier,
+    "af-btn",
+  );
 
   return (
-    <button
-      className={classNames("af-btn", classes, className)}
-      type="button"
-      {...args}
-    >
+    <button className={componentClassName} type="button" {...args}>
       {children}
     </button>
   );

--- a/slash/react/src/Form/File/__tests__/__snapshots__/File.spec.tsx.snap
+++ b/slash/react/src/Form/File/__tests__/__snapshots__/File.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`<File.File> > renders File.File correctly 1`] = `
       </div>
     </div>
     <button
-      class="af-btn af-btn--file af-btn--hasIconLeft af-btn"
+      class="af-btn af-btn--file af-btn--hasIconLeft"
       type="button"
     >
       <i

--- a/slash/react/src/Form/File/__tests__/__snapshots__/FileInput.spec.tsx.snap
+++ b/slash/react/src/Form/File/__tests__/__snapshots__/FileInput.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`<FileInput> > renders FileInput correctly 1`] = `
             </div>
           </div>
           <button
-            class="af-btn af-btn--file af-btn--hasIconLeft af-btn"
+            class="af-btn af-btn--file af-btn--hasIconLeft"
             type="button"
           >
             <i


### PR DESCRIPTION
Fix https://github.com/AxaFrance/design-system/issues/691 