### PR TITLE
refactor(slash): migrate from popperjs to floating-ui for Popover component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2835,6 +2835,34 @@
         "@floating-ui/utils": "^0.2.8"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.2.tgz",
+      "integrity": "sha512-k/yP6a9K9QwhLfIu87iUZxCH6XN5z5j/VUHHq0dEnbZYY2Y9jz68E/LXFtK8dkiaYltS2WYohnyKC0VcwVneVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
@@ -3242,16 +3270,6 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.19.2",
@@ -16174,33 +16192,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -18206,6 +18203,12 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
@@ -19785,15 +19788,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -20673,14 +20667,13 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/react": "^0.27.2",
         "@fontsource/source-sans-pro": "^5.0.8",
-        "@popperjs/core": "^2.11.8",
         "@tanem/svg-injector": "^10.1.68",
         "classnames": "^2.5.1",
         "dompurify": "^3.1.5",
         "rc-slider": "^11.1.7",
         "react-dropzone": "^11.5.3",
-        "react-popper": "^2.3.0",
         "react-select": "^5.9.0"
       },
       "devDependencies": {

--- a/slash/css/src/Popover/Popover.scss
+++ b/slash/css/src/Popover/Popover.scss
@@ -1,8 +1,6 @@
 @use "sass:color";
 @use "../common/common" as common;
 
-$arrow-size: 16px;
-$arrow-offset: -4px;
 $padding-popover: 0.5rem 1rem;
 
 .af-popover {
@@ -26,8 +24,10 @@ $padding-popover: 0.5rem 1rem;
       width: calc(260 / 16 * 1rem);
       padding: $padding-popover;
       border-radius: 3px;
-      color: common.$white;
-      background: common.$color-azur;
+      line-height: 1.125rem;
+      color: common.$color-azur;
+      background: common.$white;
+      box-shadow: 0 0 9px 0 rgba(0, 0, 0, 18%);
 
       .af-subtitle {
         font-size: 2em;
@@ -46,38 +46,6 @@ $padding-popover: 0.5rem 1rem;
           height: 2rem;
         }
       }
-    }
-
-    .af-popover__arrow {
-      position: absolute;
-      z-index: -1;
-      width: $arrow-size;
-      height: $arrow-size;
-
-      &::before {
-        position: absolute;
-        width: $arrow-size;
-        height: $arrow-size;
-        background: common.$color-azur;
-        transform: rotate(45deg);
-        content: "";
-      }
-    }
-
-    [data-popper-placement^="top"] > .af-popover__arrow {
-      bottom: $arrow-offset;
-    }
-
-    [data-popper-placement^="bottom"] > .af-popover__arrow {
-      top: $arrow-offset;
-    }
-
-    [data-popper-placement^="right"] > .af-popover__arrow {
-      left: $arrow-offset;
-    }
-
-    [data-popper-placement^="left"] > .af-popover__arrow {
-      right: $arrow-offset;
     }
   }
 }

--- a/slash/react/package.json
+++ b/slash/react/package.json
@@ -55,14 +55,13 @@
     }
   },
   "dependencies": {
+    "@floating-ui/react": "^0.27.2",
     "@fontsource/source-sans-pro": "^5.0.8",
-    "@popperjs/core": "^2.11.8",
     "@tanem/svg-injector": "^10.1.68",
     "classnames": "^2.5.1",
     "dompurify": "^3.1.5",
     "rc-slider": "^11.1.7",
     "react-dropzone": "^11.5.3",
-    "react-popper": "^2.3.0",
     "react-select": "^5.9.0"
   },
   "devDependencies": {

--- a/slash/react/src/HelpButton/demo.scss
+++ b/slash/react/src/HelpButton/demo.scss
@@ -6,15 +6,7 @@
     &__container-pop {
       width: 300px;
       background: white;
-      box-shadow: 2px 0 5px 0 rgba(0, 0, 0, 0.2);
       padding: 0;
-
-      &[data-popper-placement^="top"] > .af-popover__arrow::before,
-      &[data-popper-placement^="right"] > .af-popover__arrow::before,
-      &[data-popper-placement^="left"] > .af-popover__arrow::before {
-        background: white;
-        box-shadow: -2px 0 5px 0px rgba(0, 0, 0, 0.2);
-      }
     }
   }
 }

--- a/slash/react/src/Popover/AnimatedPopover.tsx
+++ b/slash/react/src/Popover/AnimatedPopover.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Placement } from "@popperjs/core";
-import React from "react";
-import { usePopper } from "react-popper";
+import React, { useRef } from "react";
+import {
+  arrow,
+  FloatingArrow,
+  offset,
+  Placement,
+  useFloating,
+} from "@floating-ui/react";
 import { getComponentClassName } from "../utilities";
 
 const defaultClassName = "af-popover__container";
@@ -35,23 +40,12 @@ export const AnimatedPopover = ({
 
   const [referenceElement, setReferenceElement] = React.useState(null);
   const [popperElement, setPopperElement] = React.useState(null);
-  const [arrowElement, setArrowElement] = React.useState(null);
-  const { styles, attributes } = usePopper(referenceElement, popperElement, {
-    modifiers: [
-      {
-        name: "arrow",
-        options: {
-          element: arrowElement,
-        },
-      },
-      {
-        name: "offset",
-        options: {
-          offset: [0, 8],
-        },
-      },
-    ],
+  const arrowRef = useRef(null);
+
+  const { floatingStyles, context } = useFloating({
     placement,
+    elements: { reference: referenceElement, floating: popperElement },
+    middleware: [offset(12), arrow({ element: arrowRef })],
   });
 
   return (
@@ -69,17 +63,12 @@ export const AnimatedPopover = ({
           ref={setPopperElement as any}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
-          style={styles.popper}
+          style={floatingStyles}
           data-popper-placement={placement}
           className="af-popover__container-pop"
-          {...attributes.popper}
         >
           <div>{children}</div>
-          <div
-            ref={setArrowElement as any}
-            style={styles.arrow}
-            className="af-popover__arrow"
-          />
+          <FloatingArrow ref={arrowRef} context={context} fill="white" />
         </div>
       )}
     </div>

--- a/slash/react/src/Popover/Popover.mdx
+++ b/slash/react/src/Popover/Popover.mdx
@@ -45,8 +45,8 @@ const MyComponent = () => (
       <td>Placement of the popover</td>
       <td>top</td>
       <td>
-        List of options is available on the [Popperjs
-        docs](https://popper.js.org/docs/v2/constructors/#options)
+        List of options is available on the [FloatingUI
+        docs](https://floating-ui.com/docs/getting-started)
       </td>
     </tr>
     <tr>

--- a/slash/react/src/Popover/Popover.stories.tsx
+++ b/slash/react/src/Popover/Popover.stories.tsx
@@ -44,9 +44,6 @@ export const Default: StoryObj<typeof Popover> = {
   argTypes: {
     placement: {
       options: [
-        "auto",
-        "auto-start",
-        "auto-end",
         "top",
         "top-start",
         "top-end",

--- a/slash/react/src/Popover/Popover.tsx
+++ b/slash/react/src/Popover/Popover.tsx
@@ -1,5 +1,5 @@
-import { Placement } from "@popperjs/core";
 import React from "react";
+import { Placement } from "@floating-ui/react";
 import { PopoverModes } from "./Popover.types";
 import { PopoverClick } from "./PopoverClick";
 import { PopoverOver } from "./PopoverOver";

--- a/slash/react/src/Popover/Popover.types.ts
+++ b/slash/react/src/Popover/Popover.types.ts
@@ -1,4 +1,4 @@
-import { Placement } from "@popperjs/core";
+import { Placement } from "@floating-ui/react";
 
 export type PopoverModes = "hover" | "click";
 

--- a/slash/react/src/Popover/PopoverBase.tsx
+++ b/slash/react/src/Popover/PopoverBase.tsx
@@ -1,5 +1,5 @@
-import { Placement } from "@popperjs/core";
 import React from "react";
+import { Placement } from "@floating-ui/react";
 import { AnimatedPopover } from "./AnimatedPopover";
 
 import "@axa-fr/design-system-slash-css/dist/Popover/Popover.scss";
@@ -20,7 +20,7 @@ type Props = {
 const PopoverBase = ({
   children,
   isOpen,
-  placement = "auto",
+  placement = "right",
   className = defaultClassName,
   classModifier,
   element,

--- a/slash/react/src/Popover/index.ts
+++ b/slash/react/src/Popover/index.ts
@@ -1,4 +1,4 @@
 export { Popover } from "./Popover";
 
-export { type Placement } from "@popperjs/core";
+export { type Placement } from "@floating-ui/react";
 export { type PopoverModes } from "./Popover.types";


### PR DESCRIPTION
Fix https://github.com/AxaFrance/design-system/issues/719

Migrating to this package is a prerequisite to migrate to React 19 in the end.

**Regression** : 
I couldn't find a way to set a box-shadow around the arrow as we use the FloatingArrow component from the package. It makes a visual regression when we use a rich html element inside the popped element. @samuel-gomez do you think it is problematic like that ?
![image](https://github.com/user-attachments/assets/9bd7ed37-26a2-4620-866f-43ea606dcd63)
