### PR TITLE
fix(look&feel): radioselect checked and aria-checked always defined

### DIFF
--- a/look-and-feel/react/src/Form/Radio/RadioSelect.tsx
+++ b/look-and-feel/react/src/Form/Radio/RadioSelect.tsx
@@ -102,10 +102,8 @@ export const RadioSelect = forwardRef<HTMLInputElement, RadioSelectProps>(
                   name={name}
                   id={`${optionId}-${inputLabel}`}
                   onChange={onChange}
-                  {...(value && {
-                    "aria-checked": value === inputProps.value,
-                    checked: value === inputProps.value,
-                  })}
+                  aria-checked={value === inputProps.value}
+                  checked={value === inputProps.value}
                   ref={getRef(idx, ref, value, inputProps.value)}
                 />
                 <div className="af-radio__icons">


### PR DESCRIPTION
these props should always be defined in order to avoid comp to change from uncontrolled to controlled

> Similarly, if you pass checked to a checkbox, ensure it’s always a boolean.
https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable