### PR TITLE
fix(slash-react-date): correct issue with formatDateValue

### DIFF
--- a/slash/react/src/Form/Date/Date.tsx
+++ b/slash/react/src/Form/Date/Date.tsx
@@ -9,9 +9,10 @@ type Props = Omit<ComponentPropsWithRef<"input">, "value"> & {
 };
 
 const formatDateValue = (dateValue: Date) => {
-  const monthFormatted = `0${dateValue.getMonth() + 1}`.slice(-2);
-  const dayFormatted = `0${dateValue.getDate()}`.slice(-2);
-  return `${dateValue.getFullYear()}-${monthFormatted}-${dayFormatted}`;
+  const formattedDateValue = new globalThis.Date(dateValue);
+  const monthFormatted = `0${formattedDateValue.getMonth() + 1}`.slice(-2);
+  const dayFormatted = `0${formattedDateValue.getDate()}`.slice(-2);
+  return `${formattedDateValue.getFullYear()}-${monthFormatted}-${dayFormatted}`;
 };
 
 const Date = forwardRef<HTMLInputElement, Props>(


### PR DESCRIPTION
Fix issue where "Date" component was not receiving the DateValue in the correct Format. Hence getMonth() was returning an exception:

![image](https://github.com/user-attachments/assets/80691866-4a33-43e7-88ff-cd214c0e5b71)
