### PR TITLE
fix(slash): fix console warning when using Infos component when id is not provided

### DIFF
--- a/slash/react/src/Layout/Header/Infos/Infos.tsx
+++ b/slash/react/src/Layout/Header/Infos/Infos.tsx
@@ -1,6 +1,8 @@
 import { Fragment, ReactNode } from "react";
-import "@axa-fr/design-system-slash-css/dist/Layout/Header/Infos/Infos.scss";
 import { getComponentClassName } from "../../../utilities";
+import { generateId } from "../../../utilities/helpers/generateId";
+
+import "@axa-fr/design-system-slash-css/dist/Layout/Header/Infos/Infos.scss";
 
 const defaultClassName = "af-contrat";
 
@@ -28,7 +30,7 @@ const Infos = ({ infos, className, classModifier }: InfosProps) => {
       <i className="glyphicon glyphicon-info-sign" />
       <dl className={`${defaultClassName}__list`}>
         {infos.map((info) => (
-          <Fragment key={`info-${info.id}`}>
+          <Fragment key={`info-${generateId(info)}`}>
             <dt className={`${defaultClassName}__word`}>{info.word}</dt>
             <dd className={`${defaultClassName}__def`}>{info.definition}</dd>
           </Fragment>

--- a/slash/react/src/utilities/helpers/__tests__/generateId.test.ts
+++ b/slash/react/src/utilities/helpers/__tests__/generateId.test.ts
@@ -1,0 +1,21 @@
+import { generateId } from "../generateId";
+
+describe("generateKey", () => {
+  it("should generate a unique id for each object", () => {
+    const obj1 = {};
+    const obj2 = {};
+    const key1 = generateId(obj1);
+    const key2 = generateId(obj2);
+
+    expect(key1).toBe("id-1");
+    expect(key2).toBe("id-2");
+  });
+
+  it("should return the same id for the same object", () => {
+    const obj = {};
+    const key1 = generateId(obj);
+    const key2 = generateId(obj);
+
+    expect(key1).toBe(key2);
+  });
+});

--- a/slash/react/src/utilities/helpers/generateId.ts
+++ b/slash/react/src/utilities/helpers/generateId.ts
@@ -1,0 +1,14 @@
+let counter = 1;
+
+const map = new WeakMap<object, number>();
+
+export const generateId = (item: object): string => {
+  if (!map.has(item)) {
+    map.set(item, counter);
+    counter += 1;
+
+    return generateId(item);
+  }
+
+  return `id-${map.get(item)}`;
+};


### PR DESCRIPTION
close #648

In order to fix the warning I propose to set up a basic id generator.
This generator generates a unique id for each ref of a js object thanks to the `WeakMap`