### PR TITLE
fix(look&feel): white background for inputs + div wrapping

### DIFF
--- a/client/look-and-feel/css/src/Form/Checkbox/Checkbox.scss
+++ b/client/look-and-feel/css/src/Form/Checkbox/Checkbox.scss
@@ -146,6 +146,8 @@
       display: flex;
       align-items: center;
       gap: 0.75rem;
+      background-color: var(--color-white);
+      clip-path: inset(0.22rem round 2px);
 
       & .af-checkbox__checked,
       & .af-checkbox__unchecked {
@@ -183,6 +185,10 @@
     & .af-checkbox__unchecked {
       display: none;
     }
+  }
+
+  &-select label:has(input[type="checkbox"]) {
+    background-color: var(--color-white);
   }
 
   &-select label:has(input[type="checkbox"]:checked) {

--- a/client/look-and-feel/css/src/Form/Radio/Radio.scss
+++ b/client/look-and-feel/css/src/Form/Radio/Radio.scss
@@ -147,6 +147,8 @@
       display: flex;
       align-items: center;
       gap: 0.75rem;
+      background-color: var(--color-white);
+      clip-path: circle(0.72rem at 50% 50%);
 
       & .af-radio__checked,
       & .af-radio__unchecked {
@@ -193,6 +195,10 @@
       color: var(--color-gray-500);
       fill: var(--color-gray-500);
     }
+  }
+
+  &-select[aria-invalid="false"] label:has(input[type="radio"]) {
+    background-color: var(--color-white);
   }
 
   &-select[aria-invalid="false"] label:has(input[type="radio"]:checked) {

--- a/client/look-and-feel/css/src/Form/Text/Text.scss
+++ b/client/look-and-feel/css/src/Form/Text/Text.scss
@@ -85,11 +85,13 @@
     }
 
     display: grid;
+    width: 100%;
     padding: 1rem;
     border: 1px solid var(--color-gray);
     border-radius: var(--default-border-radius);
-    grid-template-columns: auto auto;
+    grid-template-columns: auto min-content;
     align-items: center;
+    background-color: var(--color-white);
 
     &:focus-within,
     &:active,

--- a/client/look-and-feel/css/src/Form/TextArea/TextArea.scss
+++ b/client/look-and-feel/css/src/Form/TextArea/TextArea.scss
@@ -10,6 +10,7 @@
   font-size: common.rem(16);
   line-height: common.rem(20);
   color: var(--color-gray-900);
+  background-color: var(--color-white);
 
   @media (width > #{common.$breakpoint-md}) {
     font-size: common.rem(18);

--- a/client/look-and-feel/react/src/Form/Checkbox/Checkbox.tsx
+++ b/client/look-and-feel/react/src/Form/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     inputId = inputProps.id || inputId;
 
     return (
-      <>
+      <div>
         <div className={classNames("af-checkbox", className)}>
           <label key={inputProps.name} htmlFor={inputId}>
             <input
@@ -49,7 +49,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             {errorMessage}
           </div>
         )}
-      </>
+      </div>
     );
   },
 );

--- a/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
@@ -82,7 +82,7 @@ const FileUpload = ({
   };
 
   return (
-    <>
+    <div>
       <label className="af-form__group--label" htmlFor={id}>
         {label} {required ? "*" : ""}
       </label>
@@ -192,7 +192,7 @@ const FileUpload = ({
           })}
         </ul>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/client/look-and-feel/react/src/Form/Radio/Radio.tsx
+++ b/client/look-and-feel/react/src/Form/Radio/Radio.tsx
@@ -17,7 +17,7 @@ const Radio = forwardRef<HTMLInputElement, RadioProps>(
     const idError = useId();
 
     return (
-      <>
+      <div>
         <div
           className="af-radio"
           role="radiogroup"
@@ -37,7 +37,7 @@ const Radio = forwardRef<HTMLInputElement, RadioProps>(
           </label>
         </div>
         {errorMessage && <InputError id={idError} message={errorMessage} />}
-      </>
+      </div>
     );
   },
 );

--- a/client/look-and-feel/react/src/Form/Select/Select.tsx
+++ b/client/look-and-feel/react/src/Form/Select/Select.tsx
@@ -57,7 +57,7 @@ const Select = forwardRef<
     inputId = id || inputId;
 
     return (
-      <>
+      <div>
         {label && (
           <label htmlFor={inputId} className="af-form__select-label">
             {label}
@@ -120,7 +120,7 @@ const Select = forwardRef<
           ref={inputRef}
         />
         {errorLabel && <InputError id={idError} message={errorLabel} />}
-      </>
+      </div>
     );
   },
 );


### PR DESCRIPTION
multi fix to have white background by default on inputs, wrap them in div and fix text input grid to adjust to content of unit