### PR TITLE
fix(look&feel): clip-path on svg to allow outline for accessibility t…

### DIFF
--- a/client/look-and-feel/css/src/Form/Checkbox/Checkbox.scss
+++ b/client/look-and-feel/css/src/Form/Checkbox/Checkbox.scss
@@ -167,8 +167,11 @@
       display: flex;
       align-items: center;
       gap: 0.75rem;
-      background-color: var(--color-white);
-      clip-path: inset(0.22rem round 2px);
+
+      & svg {
+        background-color: var(--color-white);
+        clip-path: inset(0.22rem round 2px);
+      }
 
       & .af-checkbox__checked,
       & .af-checkbox__unchecked {
@@ -243,11 +246,8 @@
   }
 
   & label input[type="checkbox"]:focus-visible ~ .af-checkbox__icons {
-    & .af-checkbox__unchecked,
-    & .af-checkbox__checked {
-      outline: 2px solid var(--color-blue-3);
-      outline-offset: 3px;
-    }
+    outline: 2px solid var(--color-blue-3);
+    outline-offset: 3px;
   }
 
   & label:hover:not(:has(input[type="checkbox"]:disabled)) {

--- a/client/look-and-feel/css/src/Form/Radio/Radio.scss
+++ b/client/look-and-feel/css/src/Form/Radio/Radio.scss
@@ -146,8 +146,11 @@
       display: flex;
       align-items: center;
       gap: 0.75rem;
-      background-color: var(--color-white);
-      clip-path: circle(0.72rem at 50% 50%);
+
+      & svg {
+        background-color: var(--color-white);
+        clip-path: circle(0.72rem at 50% 50%);
+      }
 
       & .af-radio__checked,
       & .af-radio__unchecked {
@@ -214,11 +217,8 @@
   }
 
   & label input[type="radio"]:focus-visible ~ .af-radio__icons {
-    & .af-radio__unchecked,
-    & .af-radio__checked {
-      outline: 2px solid var(--color-blue-3);
-      outline-offset: 3px;
-    }
+    outline: 2px solid var(--color-blue-3);
+    outline-offset: 3px;
   }
 
   & label:hover:not(:has(input[type="radio"]:disabled)) {


### PR DESCRIPTION
…o be visible

when using keyboard to navigate, outline was not visible anymore because of the region clipped, for both radio and checkboxes

before
![image](https://github.com/user-attachments/assets/241cb6a0-88cb-407d-9ed4-41d56e57ccf4)

after
![image](https://github.com/user-attachments/assets/6d4b0f86-0b2e-440b-9190-3abdc6db45b0)
