### PR TITLE
fix(look&feel): text focus and outline

### DIFF
--- a/client/look-and-feel/css/src/Form/Text/Text.scss
+++ b/client/look-and-feel/css/src/Form/Text/Text.scss
@@ -93,15 +93,12 @@
     align-items: center;
     background-color: var(--color-white);
 
-    &:focus-within,
-    &:active,
-    &:focus {
-      outline: none;
+    &:has(> input:is(:focus-visible)) {
+      outline: 2px solid var(--color-focus);
+      outline-offset: 3px;
     }
 
-    &:hover,
-    &:focus,
-    &:active {
+    &:has(> input:is(:hover, :focus, :active)) {
       border: 1px solid var(--color-axa);
       box-shadow: 0 0 0 1px var(--color-axa) inset;
     }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/6e397a46-3d96-48f6-896e-60c88ef897a7)
added outline like the other inputs on focus-visible
added blue border when focus/editing the input (targeting the right input event)
(it is normal to be displayed when focused as described here: https://github.com/WICG/focus-visible/issues/131)