### PR TITLE
style(slash): change flex basis of restitution value

### DIFF
--- a/slash/css/src/Restitution/Restitution.scss
+++ b/slash/css/src/Restitution/Restitution.scss
@@ -114,7 +114,7 @@
     &-value {
       margin: 0;
       padding-left: 0.5rem;
-      flex-basis: 41%;
+      flex-basis: 50%;
       font-weight: 600;
       color: common.$color-azur;
     }


### PR DESCRIPTION
Le parent est de 100%
**L'item** prends 50%, mais la **value** est de 41%
Passage a 50%, 50%, pour être 100% 

L'issue avec les captures :
https://github.com/AxaFrance/design-system/issues/794