### PR TITLE
fix(slash): fix format input date

### DIFF
--- a/slash/react/src/Form/Date/Date.tsx
+++ b/slash/react/src/Form/Date/Date.tsx
@@ -1,18 +1,12 @@
 import "@axa-fr/design-system-slash-css/dist/Form/Date/Date.scss";
-import { ComponentPropsWithRef, forwardRef, useMemo } from "react";
+import { ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../../utilities";
+import { formatDateInputValue } from "../../utilities/helpers/date";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "value"> & {
   classModifier?: string;
-  defaultValue?: Date;
-  value?: Date;
-};
-
-const formatDateValue = (dateValue: Date) => {
-  const formattedDateValue = new globalThis.Date(dateValue);
-  const monthFormatted = `0${formattedDateValue.getMonth() + 1}`.slice(-2);
-  const dayFormatted = `0${formattedDateValue.getDate()}`.slice(-2);
-  return `${formattedDateValue.getFullYear()}-${monthFormatted}-${dayFormatted}`;
+  defaultValue?: Date | string;
+  value?: Date | string;
 };
 
 const Date = forwardRef<HTMLInputElement, Props>(
@@ -23,20 +17,12 @@ const Date = forwardRef<HTMLInputElement, Props>(
       "af-form__input-date",
     );
 
-    const currentValue = useMemo(() => {
-      return value ? formatDateValue(value) : undefined;
-    }, [value]);
-
-    const currentDefaultValue = useMemo(() => {
-      return defaultValue ? formatDateValue(defaultValue) : undefined;
-    }, [defaultValue]);
-
     return (
       <input
         className={componentClassName}
         type="date"
-        defaultValue={currentDefaultValue}
-        value={currentValue}
+        defaultValue={formatDateInputValue(defaultValue)}
+        value={formatDateInputValue(value)}
         ref={ref}
         disabled={classModifier?.includes("disabled")}
         required={classModifier?.includes("required")}

--- a/slash/react/src/utilities/helpers/__tests__/date.test.ts
+++ b/slash/react/src/utilities/helpers/__tests__/date.test.ts
@@ -1,0 +1,22 @@
+import { formatDateInputValue } from "../date";
+
+describe("formatDateInputValue", () => {
+  it.each([
+    ["2023-10-05T00:00:00Z", "2023-10-05"],
+    ["2023-10-05", "2023-10-05"],
+    ["0002-10-05", "0002-10-05"],
+  ])("should format Date('%s') object to string '%s'", (date, expected) => {
+    const formattedDate = formatDateInputValue(new Date(date));
+    expect(formattedDate).toBe(expected);
+  });
+
+  it("should return the string value as is", () => {
+    const formattedDate = formatDateInputValue("2023-10-05");
+    expect(formattedDate).toStrictEqual("2023-10-05");
+  });
+
+  it("should return undefined if no value is provided", () => {
+    const formattedDate = formatDateInputValue();
+    expect(formattedDate).toBeUndefined();
+  });
+});

--- a/slash/react/src/utilities/helpers/date.ts
+++ b/slash/react/src/utilities/helpers/date.ts
@@ -1,0 +1,6 @@
+const MAXIMUM_SIZE_DATE = 10;
+
+export const formatDateInputValue = (value?: Date | string) =>
+  value instanceof Date
+    ? value.toISOString().slice(0, MAXIMUM_SIZE_DATE)
+    : value;


### PR DESCRIPTION
Correction de format date de l'input Date car un new Date('0002-01-01') été converti en string '2-01-01' qui est une date invalide pour un input.

Ajout de la possibilité d'envoyer une date de type Date ou string en fonction des ussages.

close #803 