### PR TITLE
fix: use @forward because Sass @import rules are deprecated and will …

### DIFF
--- a/client/look-and-feel/css/src/common/common.scss
+++ b/client/look-and-feel/css/src/common/common.scss
@@ -1,4 +1,4 @@
-@import "./mixins";
+@forward "./mixins";
 
 $font-family-sans-serif: "Source Sans Pro", arial, sans-serif !default;
 $font-family-serif: georgia, times, "Times New Roman", serif !default;


### PR DESCRIPTION
…be removed in Dart Sass 3.0.0

to avoid having following when using ds in a project

![image](https://github.com/user-attachments/assets/921de5af-59ad-4d8f-9c7c-d56174c9d584)
