### PR TITLE
fix(look&feel): select, padding moved to allow onclick on whole comp

### DIFF
--- a/client/look-and-feel/css/src/Form/Select/Select.scss
+++ b/client/look-and-feel/css/src/Form/Select/Select.scss
@@ -36,6 +36,7 @@
 
   &__input-select {
     min-height: unset !important;
+    padding: 0.75rem 1rem;
     font-size: 1.125rem;
     color: var(--color-gray-700);
 
@@ -45,7 +46,6 @@
     }
 
     &-container {
-      padding: 0.75rem 1rem;
       border: 1px solid var(--color-gray-700);
       border-radius: var(--default-border-radius);
       color: var(--color-gray-700);


### PR DESCRIPTION
it was previously not possible to click on this region on the select to open and display the options because of the padding:
![image](https://github.com/user-attachments/assets/971a265e-3da3-4e3e-9053-899a5afe48d7)

it has been moved to be included and clickable. 