### PR TITLE
fix(look&feel): radio and checkbox css clip-path for safari

### DIFF
--- a/client/look-and-feel/css/src/Form/Checkbox/Checkbox.scss
+++ b/client/look-and-feel/css/src/Form/Checkbox/Checkbox.scss
@@ -150,6 +150,7 @@
       & svg {
         background-color: var(--color-white);
         clip-path: inset(0.22rem round 2px);
+        -webkit-clip-path: inset(0.22rem round 2px);
       }
 
       & .af-checkbox__checked,

--- a/client/look-and-feel/css/src/Form/Radio/Radio.scss
+++ b/client/look-and-feel/css/src/Form/Radio/Radio.scss
@@ -151,6 +151,7 @@
       & svg {
         background-color: var(--color-white);
         clip-path: circle(0.72rem at 50% 50%);
+        -webkit-clip-path: circle(0.72rem at 50% 50%);
       }
 
       & .af-radio__checked,


### PR DESCRIPTION
on safari (at least on iPad and iPhone it seems) the checkbox and radio button svg are not displayed correctly.
this is because the css use clip-path to delimit the svg to allow only to set the background color to white properly.

![image](https://github.com/user-attachments/assets/b983489f-481c-4757-b8f7-d127e4ddc841)

thing is i have no safari able devices to test this myself, sorry.