### PR TITLE
Feat/add livret a icon

### DIFF
--- a/packages/look-and-feel-react/src/LivretAIcon.tsx
+++ b/packages/look-and-feel-react/src/LivretAIcon.tsx
@@ -5,17 +5,25 @@ const LivretA: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
   <Icon 
     viewBox="0 0 32 32"
     role="img"
-    aria-hidden="true"
+    aria-hidden={props['aria-hidden'] ?? "true"}  // Improved accessibility control
     {...props}
     style={{
       color: 'currentColor',
       width: '1em',
       height: '1em',
+      verticalAlign: 'middle', // Added for better alignment
       ...props.style,
     }}
   >
-    <path d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2Zm0 26a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"/>
-    <path d="M20.5 11.5h-9a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-9a1 1 0 0 0-1-1Zm-1 9h-7v-7h7Z"/>
+    {/* Explicitly set fill for path elements */}
+    <path 
+      fill="currentColor" 
+      d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2Zm0 26a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"
+    />
+    <path
+      fill="currentColor"
+      d="M20.5 11.5h-9a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-9a1 1 0 0 0-1-1Zm-1 9h-7v-7h7Z"
+    />
   </Icon>
 );
 

--- a/packages/look-and-feel-react/src/LivretAIcon.tsx
+++ b/packages/look-and-feel-react/src/LivretAIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Icon from './Icon';
+
+const LivretA: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <Icon 
+    viewBox="0 0 32 32"
+    role="img"
+    aria-hidden="true"
+    {...props}
+    style={{
+      color: 'currentColor',
+      width: '1em',
+      height: '1em',
+      ...props.style,
+    }}
+  >
+    <path d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2Zm0 26a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"/>
+    <path d="M20.5 11.5h-9a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-9a1 1 0 0 0-1-1Zm-1 9h-7v-7h7Z"/>
+  </Icon>
+);
+
+export default LivretA;

--- a/packages/look-and-feel-react/src/icons/livret-a.svg
+++ b/packages/look-and-feel-react/src/icons/livret-a.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path fill="currentColor" d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2Zm0 26a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"/>
+  <path fill="currentColor" d="M20.5 11.5h-9a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-9a1 1 0 0 0-1-1Zm-1 9h-7v-7h7Z"/>
+</svg>

--- a/packages/look-and-feel-react/src/index.ts
+++ b/packages/look-and-feel-react/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./LivretAIcon";
+export * from './LivretAIcon';
+export { default as LivretA } from './LivretAIcon';

--- a/packages/look-and-feel-react/stories/Icons.stories.tsx
+++ b/packages/look-and-feel-react/stories/Icons.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { LivretAIcon } from '../src';
+
+export default {
+  title: 'Components/Icons',
+  component: LivretAIcon,
+};
+
+const Template = (args) => <LivretAIcon {...args} />;
+
+export const LivretA = Template.bind({});


### PR DESCRIPTION
## Livret A Savings Account Icon

Resolves #873

### Changes
- Added SVG icon file
- Created React component
- Integrated with Storybook
- Follows AXA design system patterns

### Verification
- [ ] Icon renders correctly
- [ ] Color inheritance works
- [ ] Accessibility attributes present

**Maintainers:** Please verify Storybook integration.