### PR TITLE
fix(look&feel): allow file upload to have desktop style without dropzone description

### DIFF
--- a/client/look-and-feel/css/src/Form/FileUpload/FileUpload.scss
+++ b/client/look-and-feel/css/src/Form/FileUpload/FileUpload.scss
@@ -13,10 +13,7 @@
     &-input {
       position: relative;
       display: flex;
-      margin-top: 0.5rem;
-      margin-bottom: 0.6rem;
-      padding: 1rem;
-      padding-bottom: 2rem;
+      padding: 2rem;
       border: 2px dashed var(--color-axa);
       border-radius: 8px;
       flex-direction: column;

--- a/client/look-and-feel/react/src/Form/FileUpload/FIleUpload.stories.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FIleUpload.stories.tsx
@@ -9,16 +9,13 @@ export default meta;
 
 type Story = StoryObj<typeof FileUpload>;
 
+const render = ({ ...args }: React.ComponentProps<typeof FileUpload>) => (
+  <FileUpload {...args} />
+);
+
 export const FileUploadStory: Story = {
   name: "FileUpload",
-  render: ({ onChange, onView, onDelete, ...args }) => (
-    <FileUpload
-      onChange={onChange}
-      onView={onView}
-      onDelete={onDelete}
-      {...args}
-    />
-  ),
+  render,
   args: {
     id: "file-input",
     className: "",
@@ -64,4 +61,10 @@ export const FileUploadStory: Story = {
     onView: { action: "onView" },
     onDelete: { action: "onDelete" },
   },
+};
+
+export const FileUploadWithPaddingAndWithoutDescription: Story = {
+  name: "FileUpload without drag&drop description and with padding",
+  render,
+  args: { buttonLabel: "Importer fichier", isWithPadding: true, files: [] },
 };

--- a/client/look-and-feel/react/src/Form/FileUpload/FIleUpload.stories.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FIleUpload.stories.tsx
@@ -66,5 +66,5 @@ export const FileUploadStory: Story = {
 export const FileUploadWithPaddingAndWithoutDescription: Story = {
   name: "FileUpload without drag&drop description and with padding",
   render,
-  args: { buttonLabel: "Importer fichier", isWithPadding: true, files: [] },
+  args: { buttonLabel: "Importer fichier", withPadding: true, files: [] },
 };

--- a/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
@@ -45,7 +45,7 @@ type Props = Omit<ComponentPropsWithRef<"input">, "required"> & {
   }>;
   accept?: string;
   isMobile?: boolean;
-  isWithPadding?: boolean;
+  withPadding?: boolean;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
   onView?: (id: string) => void;
@@ -63,7 +63,7 @@ const FileUpload = ({
   errors,
   globalError,
   isMobile,
-  isWithPadding = false,
+  withPadding = false,
   onView,
   onDelete,
   ...otherProps
@@ -92,7 +92,7 @@ const FileUpload = ({
         className={classNames(
           "af-form__file-input",
           globalError && "af-form__file-input--error",
-          (isMobile || (!isWithPadding && !dropzoneDescription)) && "is-mobile",
+          (isMobile || (!withPadding && !dropzoneDescription)) && "is-mobile",
         )}
       >
         <input

--- a/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
@@ -32,8 +32,8 @@ type Props = Omit<ComponentPropsWithRef<"input">, "required"> & {
   dropzoneDescription?: string;
   instructions?: string;
   required?: boolean;
-  globalError: string;
-  errors: Array<{
+  globalError?: string;
+  errors?: Array<{
     id?: string | undefined;
     message: string;
   }>;
@@ -43,8 +43,9 @@ type Props = Omit<ComponentPropsWithRef<"input">, "required"> & {
     size: number;
     isLoading: boolean;
   }>;
-  accept: string;
+  accept?: string;
   isMobile?: boolean;
+  isWithPadding?: boolean;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
   onView?: (id: string) => void;
@@ -62,6 +63,7 @@ const FileUpload = ({
   errors,
   globalError,
   isMobile,
+  isWithPadding = false,
   onView,
   onDelete,
   ...otherProps
@@ -90,7 +92,7 @@ const FileUpload = ({
         className={classNames(
           "af-form__file-input",
           globalError && "af-form__file-input--error",
-          (isMobile || !dropzoneDescription) && "is-mobile",
+          (isMobile || (!isWithPadding && !dropzoneDescription)) && "is-mobile",
         )}
       >
         <input
@@ -122,11 +124,11 @@ const FileUpload = ({
           {files.map(({ id: fileId, name, size, isLoading }) => {
             const effectiveSize = getReadableFileSizeString(size);
 
-            const isInError = errors.some(
-              (fileError) => fileError.id === fileId,
-            );
+            const isInError = errors
+              ? errors.some((fileError) => fileError.id === fileId)
+              : false;
 
-            const errorMessage = errors.find(
+            const errorMessage = errors?.find(
               (fileError) => fileError.id === fileId,
             )?.message;
 


### PR DESCRIPTION
Add withPadding parameter (default false) in order to not have the isMobile class on the component even without dropzoneDescription

![image](https://github.com/user-attachments/assets/412e8df0-a147-434f-b6fb-2081974d5eb4)
