### PR TITLE
refactor(L&F): update ContentItemDuo to accept ReactNode as value

### DIFF
--- a/client/look-and-feel/react/src/List/ContentItemDuo/ContentItemDuo.tsx
+++ b/client/look-and-feel/react/src/List/ContentItemDuo/ContentItemDuo.tsx
@@ -1,13 +1,13 @@
 import checkIcon from "@material-symbols/svg-400/outlined/check.svg";
 import closeIcon from "@material-symbols/svg-400/outlined/close.svg";
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
+import { Button, Svg } from "../..";
 import { Variants } from "../../Button/Button";
 import { getComponentClassName } from "../../utilities";
-import { Button, Svg } from "../..";
 
 type ContentItemDuoProps = {
   label: string;
-  value: string;
+  value: ReactNode;
   isVertical?: boolean;
   className?: string;
   classModifier?: string;
@@ -56,7 +56,11 @@ export const ContentItemDuo = ({
         </div>
       )}
       <p className="af-content-item-duo__label">{label}</p>
-      <p className="af-content-item-duo__value">{value}</p>
+      {typeof value === "string" ? (
+        <p className="af-content-item-duo__value">{value}</p>
+      ) : (
+        <div className="af-content-item-duo__value">{value}</div>
+      )}
       {buttonText && (
         <div className="af-content-item-duo__button">
           <Button variant={Variants.ghost} onClick={onButtonClick}>

--- a/client/look-and-feel/react/src/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/client/look-and-feel/react/src/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -9,8 +9,8 @@ describe("ContentItemDuo", () => {
   it("should render label and value correctly", () => {
     render(<ContentItemDuo label={label} value={value} />);
 
-    expect(screen.getByText(label)).toBeInTheDocument();
-    expect(screen.getByText(value)).toBeInTheDocument();
+    expect(screen.getByText(label).tagName).toBe("P");
+    expect(screen.getByText(value).tagName).toBe("P");
   });
 
   it("should render button with correct text and call onClick handler", async () => {
@@ -69,5 +69,13 @@ describe("ContentItemDuo", () => {
     expect(svgElement?.parentElement).toHaveClass(
       "af-content-item-duo__icon--close",
     );
+  });
+
+  it("should render ReactNode value correctly", () => {
+    const reactNodeValue = <>Sample Value</>;
+
+    render(<ContentItemDuo label={label} value={reactNodeValue} />);
+
+    expect(screen.getByText("Sample Value").tagName).toBe("DIV");
   });
 });


### PR DESCRIPTION
Issue : https://github.com/AxaFrance/design-system/issues/902

Example of new possibilities : 
![image](https://github.com/user-attachments/assets/c02a5aa8-48a4-4e32-85cb-44c9f27d2bc5)
