### PR TITLE
refactor(slash): change path to glyphicons from icons file

### DIFF
--- a/slash/css/src/common/icons.scss
+++ b/slash/css/src/common/icons.scss
@@ -2,16 +2,12 @@
   font-family: icons;
   font-style: normal;
   font-weight: 400;
-  src: url("@axa-fr/design-system-slash-css/dist/common/glyphicons/icons.eot");
+  src: url("../common/glyphicons/icons.eot");
   src:
-    url("@axa-fr/design-system-slash-css/dist/common/glyphicons/icons.eot?#iefix")
-      format("embedded-opentype"),
-    url("@axa-fr/design-system-slash-css/dist/common/glyphicons/icons.woff")
-      format("woff"),
-    url("@axa-fr/design-system-slash-css/dist/common/glyphicons/icons.ttf")
-      format("truetype"),
-    url("@axa-fr/design-system-slash-css/dist/common/glyphicons/icons.svg#icons")
-      format("svg");
+    url("../common/glyphicons/icons.eot?#iefix") format("embedded-opentype"),
+    url("../common/glyphicons/icons.woff") format("woff"),
+    url("../common/glyphicons/icons.ttf") format("truetype"),
+    url("../common/glyphicons/icons.svg#icons") format("svg");
 }
 
 .glyphicon {


### PR DESCRIPTION
closes #882 

In some specific cases, the previous method to copy raw assets doesn't work with specific url resolver.

It challenges https://github.com/AxaFrance/design-system/pull/912 with a simpler approach but a strange DX in my opinion. 

Only one of this two PR have to be merged, we can choose the better one.