### PR TITLE
fix(slash): repalced aria-describedby with aria-label.

### DIFF
--- a/client/look-and-feel/react/src/Modal/ModalCore.tsx
+++ b/client/look-and-feel/react/src/Modal/ModalCore.tsx
@@ -19,7 +19,7 @@ const ModalCore = forwardRef<HTMLDialogElement, ModalCoreProps>(
   ) => (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
     <dialog
-      aria-describedby={title}
+      aria-label={title}
       className={["af-modal", className].filter(Boolean).join(" ")}
       onClick={onOutsideTap}
       ref={ref}

--- a/client/look-and-feel/react/src/Modal/__tests__/Modal.test.tsx
+++ b/client/look-and-feel/react/src/Modal/__tests__/Modal.test.tsx
@@ -101,6 +101,13 @@ describe("Modal", () => {
     expectModalClosed();
   });
 
+  it("Should have an aria-label", () => {
+    const ariaLabelValue = "My Aria Label Value";
+    render(<ModalDemo {...defaultProps} aria-label={ariaLabelValue} />);
+    const dialog = getDialog();
+    expect(dialog).toHaveAttribute("aria-label", ariaLabelValue);
+  });
+
   it("Should close modal when click outside", async () => {
     render(<ModalDemo {...defaultProps} />);
     const dialog = getDialog();

--- a/slash/react/src/ModalAgent/Modal.tsx
+++ b/slash/react/src/ModalAgent/Modal.tsx
@@ -34,7 +34,7 @@ const Modal = forwardRef<HTMLDialogElement, ModalProps>(
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
       <dialog
-        aria-describedby={title}
+        aria-label={title}
         className={componentClassName}
         onClick={onOutsideTap}
         ref={ref}


### PR DESCRIPTION
Replaced `aria-describedby` with `aria-label` for modal.
Fixes #908 