### PR TITLE
Enhance package.json exports for development and default environments

### DIFF
--- a/client/look-and-feel/css/package.json
+++ b/client/look-and-feel/css/package.json
@@ -7,7 +7,10 @@
   "exports": {
     "./logo-axa.svg": "./files/assets/logo-axa.svg",
     "./dist/common/assets/logo-axa.svg": "./files/assets/logo-axa.svg",
-    "./dist/*": "./dist/*"
+    "./dist/*": {
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "files": [
     "dist",

--- a/client/look-and-feel/react/package.json
+++ b/client/look-and-feel/react/package.json
@@ -6,12 +6,22 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "development": {
+        "import": "./src/index.ts"
+      },
+      "default": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      }
     },
     "./utilities": {
-      "import": "./dist/utilities.js",
-      "types": "./dist/utilities.d.ts"
+      "development": {
+        "import": "./src/utilities.ts"
+      },
+      "default": {
+        "import": "./dist/utilities.js",
+        "types": "./dist/utilities.d.ts"
+      }
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "url": "git+https://github.com/AxaFrance/design-system.git"
   },
   "scripts": {
-    "dev": "turbo dev --filter=!./samples/vite",
-    "dev:look-and-feel": "turbo dev --filter=./client/look-and-feel/* --filter=@axa-fr/look-and-feel-stories-css --filter=@axa-fr/look-and-feel-stories",
-    "dev:slash": "turbo dev --filter=./slash/* --filter=@axa-fr/slash-stories-css --filter=@axa-fr/slash-stories",
+    "dev": "turbo dev --filter=./apps/*",
+    "dev:look-and-feel": "turbo dev --filter=@axa-fr/look-and-feel-stories-css --filter=@axa-fr/look-and-feel-stories",
+    "dev:slash": "turbo dev --filter=@axa-fr/slash-stories-css --filter=@axa-fr/slash-stories",
     "build": "turbo build --filter=!./samples/vite",
     "build:slash": "turbo build --filter=./apps/slash-stories --filter=./apps/slash-stories-css",
     "build:look-and-feel": "turbo build --filter=./apps/look-and-feel-stories --filter=./apps/look-and-feel-stories-css",

--- a/slash/css/package.json
+++ b/slash/css/package.json
@@ -7,7 +7,10 @@
   "exports": {
     "./logo-axa.svg": "./files/assets/logo-axa.svg",
     "./dist/common/assets/logo-axa.svg": "./files/assets/logo-axa.svg",
-    "./dist/*": "./dist/*"
+    "./dist/*": {
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "files": [
     "dist",

--- a/slash/react/package.json
+++ b/slash/react/package.json
@@ -6,12 +6,22 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "development": {
+        "import": "./src/index.ts"
+      },
+      "default": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      }
     },
     "./utilities": {
-      "import": "./dist/utilities.js",
-      "types": "./dist/utilities.d.ts"
+      "development": {
+        "import": "./src/utilities.ts"
+      },
+      "default": {
+        "import": "./dist/utilities.js",
+        "types": "./dist/utilities.d.ts"
+      }
     }
   },
   "files": [

--- a/turbo.json
+++ b/turbo.json
@@ -17,13 +17,6 @@
                 "^build"
             ]
         },
-        "start": {
-            "persistent": true,
-            "cache": false,
-            "dependsOn": [
-                "^build"
-            ]
-        },
         "dev": {
             "persistent": true,
             "cache": false,


### PR DESCRIPTION
Petite mise à jours des exports des packages css et react des 2 DS afin de facilité l'expérience de dev.

Maintenant les apps storiebook sont capable de builder les scss et tsx depuis le src des packages et non plus depuis les dist.
L'autocomplétions tien aussi compte de cette update.