### PR TITLE
fix(look&feel): adjust InputError styles to align to the top and avoid it to shrink

### DIFF
--- a/client/look-and-feel/css/src/Form/InputError/InputError.scss
+++ b/client/look-and-feel/css/src/Form/InputError/InputError.scss
@@ -1,10 +1,10 @@
 .af-input-error {
   display: flex;
-  align-items: center;
   gap: 0.25rem;
 
   &__icon {
     width: 1rem;
+    flex-shrink: 0;
     color: var(--color-red-700);
     fill: var(--color-red-700);
   }


### PR DESCRIPTION
Issue : https://github.com/AxaFrance/design-system/issues/940

Before : 

![image](https://github.com/user-attachments/assets/e7a3c696-f87e-4b56-8cd3-873fdcd1448b)

Now :

![image](https://github.com/user-attachments/assets/acc245dd-50be-49da-8530-4c0ad896b1d3)
