### PR TITLE
fix(look&feel): add filesListLabel, fix file display size and remove spans when empty

### DIFF
--- a/apps/look-and-feel-stories-css/src/FileUpload.stories.ts
+++ b/apps/look-and-feel-stories-css/src/FileUpload.stories.ts
@@ -33,6 +33,9 @@ export const Default: StoryObj = {
    </div>
    <small class="af-form__file-input-help">2 fichiers max. / pdf, png, jpg, jpeg, gif / 19 Mo par fichier</small>
    <div class="custom-table-file af-file-table">
+      <div className="af-form__group--label af-form__files-list-label">
+         ${args.filesListLabel}
+      </div>
       <ul class="af-form__file-list">
          <li class="af-form__file-line">
             <div class="af-form__file-line-container">
@@ -136,6 +139,7 @@ export const Default: StoryObj = {
     label: "Label",
     buttonLabel: "Importer fichier",
     dropZoneDescription: "Glissez/déposez vos fichiers",
+    filesListLabel: "Vos fichiers",
     required: true,
   },
   argTypes: {

--- a/apps/look-and-feel-stories/src/FIleUpload.stories.tsx
+++ b/apps/look-and-feel-stories/src/FIleUpload.stories.tsx
@@ -20,6 +20,7 @@ export const FileUploadStory: Story = {
     id: "file-input",
     className: "",
     label: "Label",
+    filesListLabel: "Vos fichiers",
     files: [
       {
         id: "1",

--- a/client/look-and-feel/css/src/Form/FileUpload/FileUpload.scss
+++ b/client/look-and-feel/css/src/Form/FileUpload/FileUpload.scss
@@ -1,12 +1,20 @@
 @use "../../common/common" as common;
 
 .af-form {
+  &__file-upload {
+    --row-gap: calc(32 / var(--font-size-base) * 1rem);
+  }
+
   &__group {
     &--label {
       font-size: common.rem(18);
       font-weight: 600;
       color: var(--color-gray-900);
     }
+  }
+
+  &__files-list-label {
+    margin-top: common.rem(32);
   }
 
   &__file {

--- a/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
@@ -18,9 +18,9 @@ function getReadableFileSizeString(fileSizeInBytes: number) {
   let fileSizeInBytesCopy = fileSizeInBytes;
   const byteUnits = [" Ko", " Mo", " Go"];
   do {
-    fileSizeInBytesCopy /= 1024;
+    fileSizeInBytesCopy /= 1000;
     i += 1;
-  } while (fileSizeInBytesCopy > 1024);
+  } while (fileSizeInBytesCopy > 1000);
 
   return Math.max(fileSizeInBytesCopy, 0.1).toFixed(1) + byteUnits[i];
 }
@@ -31,13 +31,14 @@ type Props = Omit<ComponentPropsWithRef<"input">, "required"> & {
   buttonLabel?: string;
   dropzoneDescription?: string;
   instructions?: string;
+  filesListLabel?: string;
   required?: boolean;
   globalError?: string;
   errors?: Array<{
     id?: string | undefined;
     message: string;
   }>;
-  files: Array<{
+  files?: Array<{
     id: string;
     name: string;
     size: number;
@@ -58,6 +59,7 @@ const FileUpload = ({
   buttonLabel,
   instructions,
   dropzoneDescription,
+  filesListLabel,
   required,
   files,
   errors,
@@ -118,80 +120,89 @@ const FileUpload = ({
         </Button>
       </div>
       {globalError && <InputError id={idError} message={globalError} />}
-      <small className="af-form__file-input-help">{instructions}</small>
+      {instructions && (
+        <small className="af-form__file-input-help">{instructions}</small>
+      )}
       <div className="custom-table-file af-file-table">
+        {filesListLabel && (
+          <div className="af-form__group--label af-form__files-list-label">
+            {filesListLabel}
+          </div>
+        )}
         <ul className="af-form__file-list">
-          {files.map(({ id: fileId, name, size, isLoading }) => {
-            const effectiveSize = getReadableFileSizeString(size);
+          {files &&
+            files.length !== 0 &&
+            files.map(({ id: fileId, name, size, isLoading }) => {
+              const effectiveSize = getReadableFileSizeString(size);
 
-            const isInError = errors
-              ? errors.some((fileError) => fileError.id === fileId)
-              : false;
+              const isInError = errors
+                ? errors.some((fileError) => fileError.id === fileId)
+                : false;
 
-            const errorMessage = errors?.find(
-              (fileError) => fileError.id === fileId,
-            )?.message;
+              const errorMessage = errors?.find(
+                (fileError) => fileError.id === fileId,
+              )?.message;
 
-            return (
-              <li key={fileId} className="af-form__file-line">
-                <div
-                  className={`af-form__file-line-container ${isInError ? "af-form__file-line-container--error" : ""}`}
-                >
-                  <div className="af-form__file-title">
-                    {getIcon(isInError, isLoading)}
-                    <div>
-                      <span className="af-form__file-name">{name}</span>
-                      <span className="af-form__file-size">
-                        {effectiveSize}
-                      </span>
+              return (
+                <li key={fileId} className="af-form__file-line">
+                  <div
+                    className={`af-form__file-line-container ${isInError ? "af-form__file-line-container--error" : ""}`}
+                  >
+                    <div className="af-form__file-title">
+                      {getIcon(isInError, isLoading)}
+                      <div>
+                        <span className="af-form__file-name">{name}</span>
+                        <span className="af-form__file-size">
+                          {effectiveSize}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="af-form__file-actions">
+                      {onView && (
+                        <Svg
+                          tabIndex={0}
+                          role="button"
+                          aria-label="Visualiser"
+                          onClick={() => onView(fileId)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              onView(fileId);
+                            }
+                          }}
+                          className="af-form__file-actions-icon"
+                          src={visibility}
+                        />
+                      )}
+                      {onDelete && (
+                        <Svg
+                          tabIndex={0}
+                          role="button"
+                          aria-label="Supprimer"
+                          onClick={() => onDelete(fileId)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              onDelete(fileId);
+                            }
+                          }}
+                          className="af-form__file-actions-icon"
+                          src={close}
+                        />
+                      )}
                     </div>
                   </div>
-                  <div className="af-form__file-actions">
-                    {onView && (
+                  {isInError && (
+                    <small className="af-form__file-error">
                       <Svg
-                        tabIndex={0}
-                        role="button"
-                        aria-label="Visualiser"
-                        onClick={() => onView(fileId)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            onView(fileId);
-                          }
-                        }}
-                        className="af-form__file-actions-icon"
-                        src={visibility}
+                        src={errorO}
+                        className="af-form__file-error-icon"
+                        width={18}
                       />
-                    )}
-                    {onDelete && (
-                      <Svg
-                        tabIndex={0}
-                        role="button"
-                        aria-label="Supprimer"
-                        onClick={() => onDelete(fileId)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            onDelete(fileId);
-                          }
-                        }}
-                        className="af-form__file-actions-icon"
-                        src={close}
-                      />
-                    )}
-                  </div>
-                </div>
-                {isInError && (
-                  <small className="af-form__file-error">
-                    <Svg
-                      src={errorO}
-                      className="af-form__file-error-icon"
-                      width={18}
-                    />
-                    {errorMessage}
-                  </small>
-                )}
-              </li>
-            );
-          })}
+                      {errorMessage}
+                    </small>
+                  )}
+                </li>
+              );
+            })}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
- Ajoute l'attribut filesListLabel pour avoir un Label au dessus de la liste des fichiers (cf ci dessous)

![image](https://github.com/user-attachments/assets/9b5c7a26-195d-419a-acfc-7098f7cd98c0)

- Corrige la conversion du poids affiché des fichiers
  - Il y a eu confusion entre ko/Mo et kio/Mio. Il y a 1000 octets dans 1 kilooctet et 1000 ko dans 1 mégaoctet, tandis qu'il y a 1024 octets dans 1 kibioctet et 1024 kio dans un mébioctet, ce qui causait une différence entre la taille du fichier et celle affichée.
  
- Enlève le span de la variable "instruction" et le map sur le tableau de fichiers s'ils sont undefined ou empty
