### PR TITLE
feat(look&feel): don't center loader on buttons

### DIFF
--- a/client/look-and-feel/css/src/Button/Button.scss
+++ b/client/look-and-feel/css/src/Button/Button.scss
@@ -146,5 +146,9 @@
       color: var(--color-btn-disabled-text);
       background-color: var(--color-gray-300);
     }
+
+    & > [aria-live] {
+      margin: unset;
+    }
   }
 }


### PR DESCRIPTION
Ne pas centrer le composant Loader quand il est dans un bouton afin d'éviter ce rendu :
![image](https://github.com/user-attachments/assets/5e4f4d2d-24d8-468f-8a6c-97f3174e5d7c)