### PR TITLE
chore(design-system): remove rc-slider from apollo and l&f, and add it to slash css

### DIFF
--- a/client/apollo/react/package.json
+++ b/client/apollo/react/package.json
@@ -67,8 +67,7 @@
     "@fontsource/source-sans-pro": "^5.0.8",
     "@tanem/svg-injector": "^10.1.68",
     "classnames": "^2.5.1",
-    "dompurify": "^3.1.5",
-    "rc-slider": "^11.1.7"
+    "dompurify": "^3.1.5"
   },
   "lint-staged": {
     "*.(js|jsx|ts|tsx)": "eslint --fix",

--- a/client/look-and-feel/react/package.json
+++ b/client/look-and-feel/react/package.json
@@ -68,8 +68,7 @@
     "@fontsource/source-sans-pro": "^5.0.8",
     "@tanem/svg-injector": "^10.1.68",
     "classnames": "^2.5.1",
-    "dompurify": "^3.1.5",
-    "rc-slider": "^11.1.7"
+    "dompurify": "^3.1.5"
   },
   "lint-staged": {
     "*.(js|jsx|ts|tsx)": "eslint --fix",

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,8 +353,7 @@
         "@fontsource/source-sans-pro": "^5.0.8",
         "@tanem/svg-injector": "^10.1.68",
         "classnames": "^2.5.1",
-        "dompurify": "^3.1.5",
-        "rc-slider": "^11.1.7"
+        "dompurify": "^3.1.5"
       },
       "peerDependencies": {
         "@material-symbols/svg-400": ">= 0.19.0",
@@ -388,8 +387,7 @@
         "@fontsource/source-sans-pro": "^5.0.8",
         "@tanem/svg-injector": "^10.1.68",
         "classnames": "^2.5.1",
-        "dompurify": "^3.1.5",
-        "rc-slider": "^11.1.7"
+        "dompurify": "^3.1.5"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
@@ -5729,16 +5727,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
-      "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.1.tgz",
+      "integrity": "sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/typescript-estree": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/typescript-estree": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5754,14 +5752,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
-      "integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
+      "integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0"
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5772,9 +5770,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
-      "integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
+      "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5786,14 +5784,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
-      "integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
+      "integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5813,13 +5811,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
-      "integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
+      "integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
+        "@typescript-eslint/types": "8.26.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -18858,6 +18856,9 @@
       "name": "@axa-fr/design-system-slash-css",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "rc-slider": "^11.1.7"
+      },
       "peerDependencies": {
         "@material-symbols/svg-400": ">= 0.19.0"
       },

--- a/slash/css/package.json
+++ b/slash/css/package.json
@@ -64,5 +64,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "dependencies": {
+    "rc-slider": "^11.1.7"
   }
 }


### PR DESCRIPTION
This PR will remove unnecessary install of rc-slider for apollo and look-and-feel and add it to slash css which use it.