### PR TITLE
feat(slash): add navbar props to MenuTitleWrapper and set position on click

### DIFF
--- a/apps/slash-stories/src/Layout/MenuTitleWrapper/MenuTitleWrapper.stories.tsx
+++ b/apps/slash-stories/src/Layout/MenuTitleWrapper/MenuTitleWrapper.stories.tsx
@@ -2,12 +2,11 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import {
   MenuTitleWrapper,
-  NavBar,
   NavBarItem,
 } from "@axa-fr/design-system-slash-react";
 
-const meta: Meta<typeof NavBar> = {
-  component: NavBar,
+const meta: Meta<typeof MenuTitleWrapper> = {
+  component: MenuTitleWrapper,
   title: "Components/Header/MenuTitleWrapper",
 };
 

--- a/slash/react/src/Layout/Header/MenuTitleWrapper/MenuTitleWrapper.tsx
+++ b/slash/react/src/Layout/Header/MenuTitleWrapper/MenuTitleWrapper.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useState } from "react";
-import { NavBar } from "../NavBar";
+import { useCallback, useState, type ComponentProps } from "react";
 import { HeaderTitle } from "../HeaderTitle/HeaderTitle";
+import { NavBar } from "../NavBar";
 
 type TMenuTitleWrapperProps = {
   children: React.ReactNode;
   menuVisible: boolean;
   subtitle: string;
   title: string;
+  navBarProps?: Partial<ComponentProps<typeof NavBar>>;
 };
 
 const MenuTitleWrapper = ({
@@ -14,6 +15,7 @@ const MenuTitleWrapper = ({
   menuVisible,
   subtitle,
   title,
+  navBarProps,
 }: TMenuTitleWrapperProps) => {
   const [isMenuVisible, setIsMenuVisible] = useState(menuVisible);
 
@@ -25,7 +27,7 @@ const MenuTitleWrapper = ({
 
   return (
     <>
-      <NavBar isVisible={isMenuVisible} onClick={handleClick}>
+      <NavBar isVisible={isMenuVisible} onClick={handleClick} {...navBarProps}>
         {children}
       </NavBar>
       <HeaderTitle title={title} subtitle={subtitle} toggleMenu={handleClick} />

--- a/slash/react/src/Layout/Header/NavBar/NavBar.tsx
+++ b/slash/react/src/Layout/Header/NavBar/NavBar.tsx
@@ -73,6 +73,7 @@ const NavBar = ({ positionInit = 0, children, ...otherProps }: Props) => {
           tabIndex: isCurrent ? 0 : -1,
           index,
           hasFocus: isMenuFocused && isCurrent,
+          onClick: () => setPosition(index),
         });
       })}
     </NavBarBase>


### PR DESCRIPTION
Allows passing NavBar props through MenuTitleWrapper to enable customization of properties such as "positionInit". 
Additionally, updates the position index upon clicking a NavLink, ensuring that the correct nav item is selected without requiring a page reload (example : when navigating between pages using React Router).

Before :

![before](https://github.com/user-attachments/assets/a6aa6ed9-d9bd-441f-abb0-8460d8065d56)

After :

![after](https://github.com/user-attachments/assets/873aee79-9653-4b70-b718-58022dcda24f)