### PR TITLE
feat(look&feel): set max width for content item duo label

### DIFF
--- a/client/look-and-feel/css/src/List/ContentItemDuo/ContentItemDuo.scss
+++ b/client/look-and-feel/css/src/List/ContentItemDuo/ContentItemDuo.scss
@@ -166,3 +166,9 @@
     }
   }
 }
+
+@media (width >= #{common.$breakpoint-lg}) {
+  .af-content-item-duo__label {
+    max-width: common.rem(230);
+  }
+}


### PR DESCRIPTION
La partie label (gauche) du Content Item Duo doit avoir une largeur max de 230 px sur destop large.
