### PR TITLE
fix(slash): change renderInput to render function to keep the ref

### DIFF
--- a/slash/react/src/Form/core/Field.tsx
+++ b/slash/react/src/Form/core/Field.tsx
@@ -45,7 +45,7 @@ export const Field = ({
   roleContainer,
   ariaLabelContainer,
   isLabelContainerLinkedToInput = true,
-  renderInput: Element,
+  renderInput,
 }: InputProps & {
   renderInput: (props: { id: string; classModifier: string }) => ReactNode;
 }) => {
@@ -92,7 +92,7 @@ export const Field = ({
       </div>
       <div className={classNameContainerInput}>
         <div className={fieldContainerClassName}>
-          <Element id={inputId} classModifier={inputClassModifier} />
+          {renderInput({ id: inputId, classModifier: inputClassModifier })}
           {children}
         </div>
         {forceDisplayMessage ? (


### PR DESCRIPTION
I had problems with react hook form because the ref wasn't correctly linked i think.
By render this way the problem is fixed.