### PR TITLE
fix(look&feel): convert clickable svg to button in file upload

### DIFF
--- a/client/look-and-feel/css/src/Form/FileUpload/FileUpload.scss
+++ b/client/look-and-feel/css/src/Form/FileUpload/FileUpload.scss
@@ -169,12 +169,6 @@
       justify-content: center;
       gap: 1rem;
       cursor: pointer;
-
-      &-icon {
-        path {
-          fill: var(--color-gray-700);
-        }
-      }
     }
   }
 }

--- a/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
+++ b/client/look-and-feel/react/src/Form/FileUpload/FileUpload.tsx
@@ -156,33 +156,19 @@ const FileUpload = ({
                     </div>
                     <div className="af-form__file-actions">
                       {onView && (
-                        <Svg
-                          tabIndex={0}
-                          role="button"
+                        <Button
                           aria-label="Visualiser"
                           onClick={() => onView(fileId)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              onView(fileId);
-                            }
-                          }}
-                          className="af-form__file-actions-icon"
-                          src={visibility}
+                          variant="ghost"
+                          iconLeft={<Svg src={visibility} />}
                         />
                       )}
                       {onDelete && (
-                        <Svg
-                          tabIndex={0}
-                          role="button"
+                        <Button
                           aria-label="Supprimer"
                           onClick={() => onDelete(fileId)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              onDelete(fileId);
-                            }
-                          }}
-                          className="af-form__file-actions-icon"
-                          src={close}
+                          variant="ghost"
+                          iconLeft={<Svg src={close} />}
                         />
                       )}
                     </div>


### PR DESCRIPTION
Dans les infobulles des fichiers importés, remplace les SVG cliquables avec le rôle 'button' par des Button avec le SVG en icône

![image](https://github.com/user-attachments/assets/a4b2df9a-415c-499b-92e8-70af269a86e8)
