### PR TITLE
feat(slash): ajoute des aria-label cohérents sur le Pager

### DIFF
--- a/apps/slash-stories/src/Table.mdx
+++ b/apps/slash-stories/src/Table.mdx
@@ -100,7 +100,14 @@ import { Table } from "@axa-fr/design-system-slash-react";
 const MyPaginatedTable = () => (
   <>
     <Table>{/* Table content */}</Table>
-    <Paging currentPage={3} numberItems={10} numberPages={9} mode="default" />
+    <Paging
+      currentPage={3}
+      numberItems={10}
+      numberPages={9}
+      mode="default"
+      elementsLabel="éléments"
+      selectPageSizeLabel="Nombre d'éléments à afficher"
+    />
   </>
 );
 ```

--- a/apps/slash-stories/src/Table.stories.tsx
+++ b/apps/slash-stories/src/Table.stories.tsx
@@ -44,7 +44,15 @@ export const Simple: StoryObj<typeof Table> = {
 
 export const WithPagination: StoryObj<typeof Paging> = {
   name: "Table with pagination",
-  render: ({ currentPage, numberItems, numberPages, mode, ...args }) => (
+  render: ({
+    currentPage,
+    numberItems,
+    numberPages,
+    mode,
+    elementsLabel,
+    selectPageSizeLabel,
+    ...args
+  }) => (
     <>
       <Table>
         <Table.THead>
@@ -74,22 +82,53 @@ export const WithPagination: StoryObj<typeof Paging> = {
         numberItems={numberItems}
         numberPages={numberPages}
         mode={mode}
+        elementsLabel={elementsLabel}
+        selectPageSizeLabel={selectPageSizeLabel}
         {...args}
       />
     </>
   ),
   args: {
     currentPage: 3,
-    numberItems: 10,
+    numberItems: 1000,
     numberPages: 10,
     mode: "default",
+    elementsLabel: "sinistres",
     items: [5, 10, 50, 100],
   },
   argTypes: {
-    currentPage: { control: { type: "number" } },
-    numberItems: { control: { type: "number" } },
-    numberPages: { control: { type: "number" } },
-    mode: { options: ["default", "light"], control: { type: "radio" } },
+    currentPage: {
+      control: { type: "number" },
+      description: "Numéro de page actuelle",
+    },
+    numberItems: {
+      control: { type: "number" },
+      description: "Nombre d'élément à afficher",
+    },
+    numberPages: {
+      control: { type: "number" },
+      description: "Nombre de pages",
+    },
+    mode: {
+      options: ["default", "light"],
+      control: { type: "radio" },
+      description: "Choix du mode d'affichage",
+    },
+    elementsLabel: {
+      type: "string",
+      description:
+        "Label utilisé dans les liens vers les page. Doit représenter ce que contient le tableau associé",
+    },
+    selectPageSizeLabel: {
+      description:
+        "Label du select pour choisir le nombre d'éléments à afficher",
+      control: { type: "text" },
+      type: "string",
+    },
+    items: {
+      description:
+        "Les différentes options de choix pour le nombre d'élément à afficher",
+    },
     onChange: { table: { disable: true } },
   },
 };

--- a/slash/react/src/Table/Pagination/Items.tsx
+++ b/slash/react/src/Table/Pagination/Items.tsx
@@ -11,7 +11,7 @@ export type Props = {
    */
   displayLabel?: string;
   /**
-   * Text displayed after the per-page select
+   * Text displayed after the per-page select and used in page selection links label
    */
   elementsLabel?: string;
   /**

--- a/slash/react/src/Table/Pagination/Li.tsx
+++ b/slash/react/src/Table/Pagination/Li.tsx
@@ -5,11 +5,12 @@ type LiProps = {
   isVisible?: boolean;
   active?: boolean;
   value: number;
+  pageLinkLabel: string;
   onChange: (e: { value: number }) => void;
 };
 
 const onClick =
-  ({ onChange, value }: LiProps) =>
+  ({ onChange, value }: Pick<LiProps, "onChange" | "value">) =>
   (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     onChange({
@@ -17,7 +18,7 @@ const onClick =
     });
   };
 
-const Li = ({ isVisible, active, value, ...props }: LiProps) => {
+const Li = ({ isVisible, active, value, pageLinkLabel, onChange }: LiProps) => {
   if (!isVisible) {
     return null;
   }
@@ -30,7 +31,8 @@ const Li = ({ isVisible, active, value, ...props }: LiProps) => {
       <a
         className="af-pager__item-link"
         href="/#"
-        onClick={onClick({ ...props, value })}
+        aria-label={`Page ${value} des ${pageLinkLabel}`}
+        onClick={onClick({ onChange, value })}
       >
         <span>{value}</span>
       </a>

--- a/slash/react/src/Table/Pagination/Pager.tsx
+++ b/slash/react/src/Table/Pagination/Pager.tsx
@@ -35,6 +35,10 @@ export type PagerComponentProps = Pick<
    */
   nextLabel?: string;
   /**
+   * Label for page links and select
+   */
+  elementsLabel?: string;
+  /**
    * Label for text betweeen current page a total number of pages. Only used in "light" mode
    * @default "sur"
    */
@@ -50,6 +54,7 @@ const Pager = ({
   mode = "default",
   previousLabel = "« Précédent",
   nextLabel = "Suivant »",
+  elementsLabel = "éléments",
   ofLabel = "sur",
 }: PagerComponentProps) => {
   const hasNext = currentPage < numberPages;
@@ -70,6 +75,7 @@ const Pager = ({
             value={currentPage - 1}
             active={hasPrevious}
             isVisible
+            ariaLabel={`Page précédente des ${elementsLabel}`}
           >
             <i
               className="glyphicon glyphicon-chevron-left"
@@ -84,6 +90,7 @@ const Pager = ({
             value={currentPage + 1}
             active={hasNext}
             isVisible
+            ariaLabel={`Page suivante des ${elementsLabel}`}
           >
             <i
               className="glyphicon glyphicon-chevron-right"
@@ -103,6 +110,7 @@ const Pager = ({
           value={currentPage - 1}
           active={hasPrevious}
           isVisible
+          ariaLabel={`Page précédente des ${elementsLabel}`}
         >
           {previousLabel}
         </PaginationButton>
@@ -111,29 +119,34 @@ const Pager = ({
           onChange={onChange}
           value={1}
           isVisible={numberPages > 1 && currentPage > 1}
+          pageLinkLabel={elementsLabel}
         />
         <LiPoint isVisible={currentPage > 3}>...</LiPoint>
         <Li
           onChange={onChange}
           value={currentPage - 1}
           isVisible={numberPages > 2 && currentPage > 2}
+          pageLinkLabel={elementsLabel}
         />
         <Li
           onChange={onChange}
           value={currentPage}
           active
           isVisible={numberPages > 0}
+          pageLinkLabel={elementsLabel}
         />
         <Li
           onChange={onChange}
           value={currentPage + 1}
           isVisible={currentPage < numberPages - 1}
+          pageLinkLabel={elementsLabel}
         />
         <LiPoint isVisible={currentPage < numberPages - 2}>...</LiPoint>
         <Li
           onChange={onChange}
           value={numberPages}
           isVisible={currentPage < numberPages}
+          pageLinkLabel={elementsLabel}
         />
 
         <PaginationButton
@@ -141,6 +154,7 @@ const Pager = ({
           value={currentPage + 1}
           active={hasNext}
           isVisible
+          ariaLabel={`Page suivante des ${elementsLabel}`}
         >
           {nextLabel}
         </PaginationButton>

--- a/slash/react/src/Table/Pagination/PaginationButton.tsx
+++ b/slash/react/src/Table/Pagination/PaginationButton.tsx
@@ -6,6 +6,7 @@ type PaginationButtonProps = {
   children?: ReactNode;
   value: number;
   onChange: (e: { value: number }) => void;
+  ariaLabel: string;
 };
 
 const PaginationButton = ({
@@ -14,6 +15,7 @@ const PaginationButton = ({
   children,
   value,
   onChange,
+  ariaLabel,
 }: PaginationButtonProps) => {
   if (!isVisible) {
     return null;
@@ -25,6 +27,7 @@ const PaginationButton = ({
           className="af-pager__item-link"
           href="/#"
           role="button"
+          aria-label={ariaLabel}
           onClick={(e) => {
             e.preventDefault();
             onChange({ value });

--- a/slash/react/src/Table/Pagination/Paging.tsx
+++ b/slash/react/src/Table/Pagination/Paging.tsx
@@ -21,6 +21,7 @@ const Paging = ({
   displayLabel,
   selectAriaLabel,
   elementsLabel,
+  selectPageSizeLabel,
   id,
   mode,
   nextLabel,
@@ -67,6 +68,7 @@ const Paging = ({
           displayLabel={displayLabel}
           selectAriaLabel={selectAriaLabel}
           elementsLabel={elementsLabel}
+          selectPageSizeLabel={selectPageSizeLabel}
           items={items}
         />
       </div>
@@ -77,6 +79,7 @@ const Paging = ({
           numberPages={numberPages}
           previousLabel={previousLabel}
           nextLabel={nextLabel}
+          elementsLabel={elementsLabel}
           ofLabel={ofLabel}
           mode={mode}
         />

--- a/slash/react/src/Table/Pagination/__tests__/Paging.spec.tsx
+++ b/slash/react/src/Table/Pagination/__tests__/Paging.spec.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { Paging } from "../Paging";
+
+describe("<Paging>", () => {
+  it("renders Paging with specific labels correctly", () => {
+    const { asFragment } = render(
+      <Paging
+        currentPage={2}
+        elementsLabel="sinistres"
+        items={[5, 10]}
+        selectPageSizeLabel="Nombre de sinistres à afficher"
+        numberPages={10}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/slash/react/src/Table/Pagination/__tests__/__snapshots__/Paging.spec.tsx.snap
+++ b/slash/react/src/Table/Pagination/__tests__/__snapshots__/Paging.spec.tsx.snap
@@ -1,0 +1,166 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<Paging> > renders Paging with specific labels correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="af-paging"
+  >
+    <div
+      class="af-paging__limit"
+    >
+      <div
+        class="af-paging__limit"
+      >
+        <form
+          class="af-paging__form"
+        >
+          <div
+            class="af-form__group"
+          >
+            <div
+              class="col col-sm-2 col-md-2 col-lg-2 col-xl-2"
+            >
+              <label
+                class="af-form__group-label"
+                for=":r0:"
+              >
+                Afficher
+              </label>
+            </div>
+            <div
+              class="col col-sm-10 col-md-10 col-lg-10 col-xl-10"
+            >
+              <div
+                class="af-form__select-container"
+              >
+                <select
+                  aria-label="Nombre de sinistres à afficher"
+                  class="af-form__input-select"
+                  id=":r0:"
+                >
+                  <option
+                    value="5"
+                  >
+                    5
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    10
+                  </option>
+                </select>
+                <span
+                  aria-controls=":r0:"
+                  class="glyphicon glyphicon-menu-down"
+                />
+              </div>
+              <span
+                class="af-form__input-cmplt"
+              >
+                sinistres
+              </span>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div
+      class="af-paging__pager"
+    >
+      <nav
+        class="af-pager"
+      >
+        <ul
+          class="af-pager__pagination"
+        >
+          <li
+            class="af-pager__item"
+          >
+            <a
+              aria-label="Page précédente des sinistres"
+              class="af-pager__item-link"
+              href="/#"
+              role="button"
+            >
+              « Précédent
+            </a>
+          </li>
+          <li
+            class="af-pager__item"
+          >
+            <a
+              aria-label="Page 1 des sinistres"
+              class="af-pager__item-link"
+              href="/#"
+            >
+              <span>
+                1
+              </span>
+            </a>
+          </li>
+          <li
+            class="af-pager__item af-pager__item--active"
+          >
+            <a
+              aria-label="Page 2 des sinistres"
+              class="af-pager__item-link"
+              href="/#"
+            >
+              <span>
+                2
+              </span>
+            </a>
+          </li>
+          <li
+            class="af-pager__item"
+          >
+            <a
+              aria-label="Page 3 des sinistres"
+              class="af-pager__item-link"
+              href="/#"
+            >
+              <span>
+                3
+              </span>
+            </a>
+          </li>
+          <li
+            class="af-pager__item af-pager__item--disabled"
+          >
+            <span
+              class="af-pager__item-link"
+            >
+              ...
+            </span>
+          </li>
+          <li
+            class="af-pager__item"
+          >
+            <a
+              aria-label="Page 10 des sinistres"
+              class="af-pager__item-link"
+              href="/#"
+            >
+              <span>
+                10
+              </span>
+            </a>
+          </li>
+          <li
+            class="af-pager__item"
+          >
+            <a
+              aria-label="Page suivante des sinistres"
+              class="af-pager__item-link"
+              href="/#"
+              role="button"
+            >
+              Suivant »
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
fixes: #938

- les liens de pages (1, 2, 3) deviennent (Page 1 des éléments, Page 2 des éléments...)
- les liens `< Précédent" et "Suivant >` deviennent `Page précédente des éléments` et `Page suivante des éléments`
- La sélection du nombre d'éléments affichés a maintenant un aria-label `Nombre de éléments à afficher`
- Le mot "éléments" est remplaçable par n'importe quel texte via la propriété `elementsLabel`