### PR TITLE
feat(slash): add version in footer

### DIFF
--- a/apps/slash-stories/src/Layout/Footer.mdx
+++ b/apps/slash-stories/src/Layout/Footer.mdx
@@ -15,7 +15,7 @@ import { Footer } from "@axa-fr/design-system-slash-react";
 
 ```tsx title="test.js"
 export const MyComponent = () => (
-  <Footer icon={logo_asset} href="https://www.axa.fr/">
+  <Footer icon={logo_asset} href="https://www.axa.fr/" version="1.0.0">
     © 2021 AXA All right right reserved
   </Footer>
 );

--- a/apps/slash-stories/src/Layout/Footer.stories.tsx
+++ b/apps/slash-stories/src/Layout/Footer.stories.tsx
@@ -22,8 +22,8 @@ export const FooterStory: Story = {
 
 export const FooterCoreStory: Story = {
   name: "Core with HTML children",
-  render: () => (
-    <Footer>
+  render: ({ ...args }) => (
+    <Footer {...args}>
       <a href="https://www.axa.fr/" target="blank">
         <strong>@ {new Date().getFullYear()} AXA</strong>
       </a>

--- a/slash/css/src/Layout/Footer/Footer.scss
+++ b/slash/css/src/Layout/Footer/Footer.scss
@@ -18,8 +18,13 @@ $logo-size: 22px;
     }
   }
 
-  &-content {
+  &-content,
+  &-version {
     font-weight: 600;
     color: common.$color-axa;
+  }
+
+  &-version {
+    margin-left: auto;
   }
 }

--- a/slash/react/src/Layout/Footer/Footer.tsx
+++ b/slash/react/src/Layout/Footer/Footer.tsx
@@ -8,6 +8,7 @@ type FooterProps = {
   alt?: string;
   icon?: string;
   className?: string;
+  version?: string;
 };
 
 export const Footer = forwardRef<
@@ -21,6 +22,7 @@ export const Footer = forwardRef<
       title = "Site Axa",
       icon = logo,
       alt = "Logo Axa",
+      version,
       children = `© ${new Date().getFullYear()} AXA Tous droits réservés`,
       ...props
     },
@@ -40,6 +42,9 @@ export const Footer = forwardRef<
           </a>
         )}
         <div className="af-footer-content">{children}</div>
+        {version && (
+          <span className="af-footer-version">Version {version}</span>
+        )}
       </div>
     </footer>
   ),

--- a/slash/react/src/Layout/Footer/__tests__/Footer.test.tsx
+++ b/slash/react/src/Layout/Footer/__tests__/Footer.test.tsx
@@ -19,6 +19,9 @@ describe("Footer component", () => {
         `© ${new Date().getFullYear()} AXA Tous droits réservés`,
       ),
     ).toBeInTheDocument();
+
+    const version = screen.queryByText("Version");
+    expect(version).not.toBeInTheDocument();
   });
 
   it("should render children", () => {
@@ -42,6 +45,7 @@ describe("Footer component", () => {
         href="/new-route"
         alt="new-alt"
         title="new-title"
+        version="1.8.0"
       />,
     );
 
@@ -57,6 +61,7 @@ describe("Footer component", () => {
         `© ${new Date().getFullYear()} AXA Tous droits réservés`,
       ),
     ).toBeInTheDocument();
+    expect(screen.getByText("Version 1.8.0")).toBeInTheDocument();
   });
 
   it("should not have an accessibility violation", async () => {


### PR DESCRIPTION
fixes: #809 

Exemple avec `<Footer version="1.32" />`

![image](https://github.com/user-attachments/assets/e9ca438e-4771-431a-a499-22cba6bc0be9)
