### PR TITLE
feat(look&feel): add required prop and accessibility tests

### DIFF
--- a/client/apollo/react/src/Form/TextInput/TextInputCommon.tsx
+++ b/client/apollo/react/src/Form/TextInput/TextInputCommon.tsx
@@ -77,6 +77,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             id={inputId}
             className={componentClassName}
             type="text"
+            required={required}
             ref={inputRef}
             aria-labelledby={idLabel}
             aria-errormessage={ariaErrormessage ?? idMessage}

--- a/client/apollo/react/src/Form/TextInput/__tests__/TextInputLF.test.tsx
+++ b/client/apollo/react/src/Form/TextInput/__tests__/TextInputLF.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { TextInput } from "../TextInputLF";
+
+describe("<TextInput />", () => {
+  describe("render", () => {
+    it("renders correctly label only", () => {
+      render(<TextInput label="foo" />);
+
+      const textinput = screen.getByLabelText("foo");
+      expect(textinput).toBeInTheDocument();
+    });
+
+    it("renders correctly full", () => {
+      render(
+        <TextInput
+          id="id"
+          label="foo"
+          name="name"
+          placeholder="placeholder"
+          helper="helper"
+          error="error"
+          value="value"
+          onChange={() => {}}
+          required
+          buttonLabel="buttonLabel"
+          description="description"
+          unit="unit"
+        />,
+      );
+
+      const textinput = screen.getByLabelText(/foo/);
+      expect(textinput).toBeInTheDocument();
+      expect(textinput).toHaveAccessibleDescription("helper");
+      expect(textinput).toHaveProperty("placeholder", "placeholder");
+      expect(textinput).toHaveAccessibleErrorMessage("error");
+      expect(textinput).toHaveValue("value");
+      expect(textinput).toHaveClass("af-form__input-text");
+      expect(textinput).toHaveAttribute("name", "name");
+      expect(textinput).toHaveAttribute("type", "text");
+      expect(textinput).toBeRequired();
+      expect(textinput).toHaveAttribute("id", "id");
+      screen.getByRole("button", { name: "buttonLabel" });
+      screen.getByText("description");
+      screen.getByText("unit");
+    });
+  });
+
+  describe("A11Y", () => {
+    it("shouldn't have an accessibility violation <TextInput />", async () => {
+      const { container } = render(<TextInput label="foo" />);
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/client/apollo/react/vitest.config.ts
+++ b/client/apollo/react/vitest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
 
@@ -6,7 +5,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
-// eslint-disable-next-line import/no-default-export
+
 export default defineConfig({
   plugins: [react()],
   test: {
@@ -14,7 +13,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./vitest.setup.ts",
     name: "apollo",
-    css: true,
     include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     coverage: {
       include: ["src/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],


### PR DESCRIPTION
I had to remove the `css: true` in vitest.config (because of a prob in the jsdom>nwsapi about selector has without parent see https://github.com/dperini/nwsapi/issues/123)
I also propagated the `required` prop that was not set on the input

fix #874