### PR TITLE
fix(look&feel): remove last-child style in modal footer

### DIFF
--- a/client/look-and-feel/css/src/Modal/Modal.scss
+++ b/client/look-and-feel/css/src/Modal/Modal.scss
@@ -93,10 +93,6 @@
       .af-btn-client {
         min-width: 180px;
         flex-grow: inherit;
-
-        &:last-child {
-          width: 250px;
-        }
       }
     }
   }


### PR DESCRIPTION
Enlève le style inutile sur le dernier child du modal footer, ça causait une différence de taille de bouton

Nouveau rendu des boutons :
![image](https://github.com/user-attachments/assets/203777d9-7e54-4883-9cb6-12ba2ca5d846)
