### PR TITLE
Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     target-branch: "main"
     ignore:
       - dependency-name: "*storybook*" # ignore all storybook packages
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "gh-actions"      

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
     if: github.repository_owner == 'AxaFrance'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: "*" # Use the LTS Node.js version
           cache: "npm"
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: "*" # Use the LTS Node.js version
           cache: "npm"

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -20,25 +20,25 @@ jobs:
       isStableRelease: ${{ steps.gitversion.outputs.preReleaseTag == '' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: "*" # Use the LTS Node.js version
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.0.0
+        uses: gittools/actions/gitversion/setup@b4372b9a14557a67171fe7292bf2f92b657c26a3 # v3.1.11
         with:
           versionSpec: "5.x"
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.0.0
+        uses: gittools/actions/gitversion/execute@b4372b9a14557a67171fe7292bf2f92b657c26a3 # v3.1.11
         with:
           useConfigFile: true
           configFilePath: "GitVersion-client.yml"
@@ -82,7 +82,7 @@ jobs:
           cp -R apps/apollo-stories/storybook-static/* artifact/apollo/react
           cp -R apps/look-and-feel-stories-css/storybook-static/* artifact/look-and-feel/css
           cp -R apps/look-and-feel-stories/storybook-static/* artifact/look-and-feel/react
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: storybooks
           path: |
@@ -96,19 +96,19 @@ jobs:
     name: Deploy new version of storybook to gh-pages
     steps:
       - name: Download storybooks
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: storybooks
 
       - name: Upload the latest apollo react storybook
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./apollo/react
           destination_dir: apollo/react/latest
 
       - name: Upload the apollo react storybook to its version folder
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./apollo/react
@@ -116,14 +116,14 @@ jobs:
             apollo/react/${{ needs.build.outputs.version }}
 
       - name: Upload the latest look-and-feel react storybook
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./look-and-feel/react
           destination_dir: look-and-feel/react/latest
 
       - name: Upload the look-and-feel react storybook to its version folder
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./look-and-feel/react
@@ -131,14 +131,14 @@ jobs:
             look-and-feel/react/${{ needs.build.outputs.version }}
 
       - name: Upload the latest look-and-feel css storybook
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./look-and-feel/css
           destination_dir: look-and-feel/css/latest
 
       - name: Upload the look-and-feel css to its version folder
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./look-and-feel/css

--- a/.github/workflows/publish-slash.yml
+++ b/.github/workflows/publish-slash.yml
@@ -19,22 +19,22 @@ jobs:
       version: ${{ steps.gitversion.outputs.fullSemVer }}
       isStableRelease: ${{ steps.gitversion.outputs.preReleaseTag == '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: "*" # Use the LTS Node.js version
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.0.0
+        uses: gittools/actions/gitversion/setup@b4372b9a14557a67171fe7292bf2f92b657c26a3 # v3.1.11
         with:
           versionSpec: "5.x"
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.0.0
+        uses: gittools/actions/gitversion/execute@b4372b9a14557a67171fe7292bf2f92b657c26a3 # v3.1.11
         with:
           useConfigFile: true
           configFilePath: "GitVersion-slash.yml"
@@ -60,7 +60,7 @@ jobs:
         run:
           cp -R apps/slash-stories-css/storybook-static/* artifact/css & cp -R
           apps/slash-stories/storybook-static/* artifact/react
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: storybooks
           path: |
@@ -74,29 +74,29 @@ jobs:
     name: Deploy new version of storybook to gh-pages
     steps:
       - name: Download storybooks
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: storybooks
       - name: Upload the latest react storybook
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./react
           destination_dir: slash/react/latest
       - name: Upload the react storybook to its version folder
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./react
           destination_dir: slash/react/${{ needs.build.outputs.version }}
       - name: Upload the latest css storybook
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./css
           destination_dir: slash/css/latest
       - name: Upload the css to its version folder
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./css


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hashes for security purposes.

Recently, a popular GitHub Action (tj-actions/changed-files) was compromised.

All tags were tampered with and pointed to a revision containing malicious code.
Although the issue was resolved, similar incidents could happen again.

To mitigate such risks, we should pin versions of GitHub Actions to full commit SHAs.

This is a recommended security practice for GitHub Actions:
[GitHub Docs: Security Hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

> Pin actions to a full-length commit SHA.  
> Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release.  
> Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.  

This PR also updates the `dependabot.yml` configuration to automate updates for GitHub Actions.  
By enabling Dependabot to manage GitHub Actions, it simplifies the process of keeping SHAs up to date.