### PR TITLE
fix(slash): update header subtitle color

### DIFF
--- a/slash/css/src/common/common.scss
+++ b/slash/css/src/common/common.scss
@@ -257,7 +257,7 @@ $color-dark-indigo: #3b3fd8 !default;
 $color-blue-lighter: #494df4 !default;
 $color-blue-alert: #30b8dc !default;
 $color-blue-alert-dark: #218eab !default;
-$color-blue-subtitle: #e4e4ff !default;
+$color-blue-subtitle: #c1c4ff !default;
 $color-pink: #fe3951 !default;
 $color-pink-dark: #c0203a !default;
 $color-orange: #f1b531 !default;


### PR DESCRIPTION
Suite au PT, la color dans l'issue était pas la bonne. 
Voilà la bonne

fixe https://github.com/AxaFrance/design-system/issues/1011