### PR TITLE
ci(design-system): set max-parallel to 1 for storybook downloads

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -109,6 +109,7 @@ jobs:
           - next
           - latest
           - ${{ needs.build.outputs.version }}
+      max-parallel: 1
 
     steps:
       - name: Download storybooks

--- a/.github/workflows/publish-slash.yml
+++ b/.github/workflows/publish-slash.yml
@@ -84,6 +84,7 @@ jobs:
           - next
           - latest
           - ${{ needs.build.outputs.version }}
+      max-parallel: 1
 
     steps:
       - name: Download storybooks


### PR DESCRIPTION
Fix sur les ci de publish qui ne peuvent pas être parallélisé 