### PR TITLE
feat(look&feel): add disabled prop and deprecate isDisabled prop

### DIFF
--- a/client/look-and-feel/react/src/List/ClickItem/ClickItem.tsx
+++ b/client/look-and-feel/react/src/List/ClickItem/ClickItem.tsx
@@ -16,6 +16,7 @@ export const ClickItem = ({
     </button>
   ),
   isDisabled = false,
+  disabled = isDisabled,
   className,
   classModifier = "",
   actionIcon = <Svg src={chevron} aria-hidden />,
@@ -26,16 +27,15 @@ export const ClickItem = ({
       getComponentClassName(
         "af-click-item",
         className,
-        `${classModifier}${isDisabled ? " disabled" : ""}`,
+        `${classModifier}${disabled ? " disabled" : ""}`,
       ),
-    [className, classModifier, isDisabled],
+    [className, classModifier, disabled],
   );
 
   return (
     <ClickComponent
       className={componentClassName}
-      disabled={isDisabled}
-      aria-disabled={isDisabled}
+      disabled={disabled}
       {...otherProps}
     >
       <div className="af-click-item__content">

--- a/client/look-and-feel/react/src/List/ClickItem/__tests__/ClickItem.test.tsx
+++ b/client/look-and-feel/react/src/List/ClickItem/__tests__/ClickItem.test.tsx
@@ -92,7 +92,7 @@ describe("ClickItem", () => {
     expect(linkElement).toHaveAttribute("href", href);
   });
 
-  it("should be a disabled anchor", () => {
+  it("should be a disabled anchor with isDisabled prop", () => {
     const label = "Sample Label";
     const href = "https://example.com";
     const disabled = true;
@@ -113,14 +113,48 @@ describe("ClickItem", () => {
     const anchorElement = screen.getByRole("link", { name: label });
 
     expect(anchorElement).toHaveClass("af-click-item--disabled");
-    expect(anchorElement).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("should be a disabled button", () => {
+  it("should be a disabled anchor with disabled prop", () => {
+    const label = "Sample Label";
+    const href = "https://example.com";
+    const disabled = true;
+
+    render(
+      <ClickItem
+        parentClickComponent={({ children, ...parentClickComponentProps }) => (
+          <a href={href} rel="noreferrer" {...parentClickComponentProps}>
+            {children}
+          </a>
+        )}
+        disabled={disabled}
+      >
+        {label}
+      </ClickItem>,
+    );
+
+    const anchorElement = screen.getByRole("link", { name: label });
+
+    expect(anchorElement).toHaveClass("af-click-item--disabled");
+  });
+
+  it("should be a disabled button with isDisabled prop", () => {
     const label = "Sample Label";
     const disabled = true;
 
     render(<ClickItem isDisabled={disabled}>{label}</ClickItem>);
+
+    const buttonElement = screen.getByRole("button", { name: label });
+
+    expect(buttonElement).toBeDisabled();
+    expect(buttonElement).toHaveClass("af-click-item--disabled");
+  });
+
+  it("should be a disabled button with disabled prop", () => {
+    const label = "Sample Label";
+    const disabled = true;
+
+    render(<ClickItem disabled={disabled}>{label}</ClickItem>);
 
     const buttonElement = screen.getByRole("button", { name: label });
 

--- a/client/look-and-feel/react/src/List/ClickItem/types.d.ts
+++ b/client/look-and-feel/react/src/List/ClickItem/types.d.ts
@@ -2,7 +2,11 @@ import type { ComponentProps, ReactNode } from "react";
 
 export type TClickItem = {
   classModifier?: string;
+  /**
+   * @deprecated Use the `disabled` prop instead.
+   */
   isDisabled?: boolean;
+  disabled?: boolean;
 } & Omit<ComponentProps<"button">, "disabled"> & {
     parentClickComponent?: (
       parentClickComponentProps: TParentClickComponentProps,


### PR DESCRIPTION
This PR add a `disabled` prop to the `ClickItem` component and make `isDisabled` prop deprecated.