### PR TITLE
ci(design-system): skip renovate and dependabot changes in Chromatic builds

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,6 +26,7 @@ jobs:
           buildScriptName: "build"
           workingDir: "apps/slash-stories"
           onlyChanged: true
+          skip: "@(renovate/**|dependabot/**)"
       - uses: chromaui/action@649b4fd73c3f7cd7a65bd0b9f131349335ec661b # v11.28.0
         name: Run Chromatic for design-system-slash-css
         with:
@@ -34,6 +35,7 @@ jobs:
           buildScriptName: "build"
           workingDir: "apps/slash-stories-css"
           onlyChanged: true
+          skip: "@(renovate/**|dependabot/**)"
       - uses: chromaui/action@649b4fd73c3f7cd7a65bd0b9f131349335ec661b # v11.28.0
         name: Run Chromatic for design-system-lookandfeel-react
         with:
@@ -42,6 +44,7 @@ jobs:
           buildScriptName: "build"
           workingDir: "apps/look-and-feel-stories"
           onlyChanged: true
+          skip: "@(renovate/**|dependabot/**)"
       - uses: chromaui/action@649b4fd73c3f7cd7a65bd0b9f131349335ec661b # v11.28.0
         name: Run Chromatic for design-system-lookandfeel-css
         with:
@@ -50,6 +53,7 @@ jobs:
           buildScriptName: "build"
           workingDir: "apps/look-and-feel-stories-css"
           onlyChanged: true
+          skip: "@(renovate/**|dependabot/**)"
       - uses: chromaui/action@649b4fd73c3f7cd7a65bd0b9f131349335ec661b # v11.28.0
         name: Run Chromatic for design-system-apollo-react
         with:
@@ -58,3 +62,4 @@ jobs:
           buildScriptName: "build"
           workingDir: "apps/apollo-stories"
           onlyChanged: true
+          skip: "@(renovate/**|dependabot/**)"


### PR DESCRIPTION
Ajout de l'option skip sur la ci de chromatic afin de skip les test chromatic pour les PR lié à dependabot/renovate.

Doc: https://www.chromatic.com/docs/github-actions/#skipping-builds-for-certain-branches

exemple de log:
![image](https://github.com/user-attachments/assets/8a59b6fb-efd6-4ebc-b4ec-9cf4f99a2a67)
