### PR TITLE
fix(apollo): sonar errors on BasePicture test links

### DIFF
--- a/client/apollo/react/src/BasePicture/__tests__/BasePicture.test.tsx
+++ b/client/apollo/react/src/BasePicture/__tests__/BasePicture.test.tsx
@@ -1,6 +1,6 @@
+import logo from "@axa-fr/design-system-look-and-feel-css/logo-axa.svg";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import logo from "@axa-fr/design-system-look-and-feel-css/logo-axa.svg";
 import { BasePicture } from "../BasePictureCommon";
 
 describe("BasePicture component", () => {
@@ -23,8 +23,8 @@ describe("BasePicture component", () => {
   });
 
   it("should render with set src", () => {
-    render(<BasePicture src="http://fake.no" />);
+    render(<BasePicture src="https://www.axa.fr/" />);
     const imgElement = screen.getByRole("presentation");
-    expect(imgElement).toHaveAttribute("src", "http://fake.no");
+    expect(imgElement).toHaveAttribute("src", "https://www.axa.fr/");
   });
 });


### PR DESCRIPTION
Fix sonar error on CI because of http links in a BasePicture test.

https://sonarcloud.io/project/security_hotspots?id=AxaFrance_design-system&sinceLeakPeriod=true

![image](https://github.com/user-attachments/assets/348a8e63-756f-4f9a-a356-5c9f2d4b9f7f)
