### PR TITLE
ci(design-system): remove double quotte for mkdir and cp command

### DIFF
--- a/.github/action/create-storybook-artifact/action.yaml
+++ b/.github/action/create-storybook-artifact/action.yaml
@@ -20,8 +20,8 @@ runs:
           app="apps/${folder%%/*}-stories-${folder#*/}/storybook-static/*"
           app=$(echo "$app" | sed 's/-react//')
           artifact="artifact/$folder"
-          mkdir -p "$artifact"
-          cp -R "$app" "$artifact"
+          mkdir -p $artifact
+          cp -R $app $artifact
         done
 
     - name: Upload ${{ inputs.artifact-name }} artifacts


### PR DESCRIPTION
ci(design-system): remove double quotte for mkdir and cp command