### PR TITLE
fix(apollo,look&feel): forward ref correctly

### DIFF
--- a/client/apollo/react/src/Form/DateInput/DateInputApollo.tsx
+++ b/client/apollo/react/src/Form/DateInput/DateInputApollo.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/DateInput/DateInputApollo.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelApollo";
 import { ItemMessage } from "../ItemMessage/ItemMessageApollo";
 import { DateInput as DateInputCommon } from "./DateInputCommon";
 
-export const DateInput = (
-  props: Omit<
+export const DateInput = forwardRef<
+  HTMLInputElement,
+  Omit<
     ComponentProps<typeof DateInputCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <DateInputCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+DateInput.displayName = "DateInput";

--- a/client/apollo/react/src/Form/DateInput/DateInputLF.tsx
+++ b/client/apollo/react/src/Form/DateInput/DateInputLF.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/DateInput/DateInputLF.scss";
-import { ComponentProps } from "react";
+import { ComponentProps, forwardRef } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelLF";
 import { ItemMessage } from "../ItemMessage/ItemMessageLF";
 import { DateInput as DateInputCommon } from "./DateInputCommon";
 
-export const DateInput = (
-  props: Omit<
+export const DateInput = forwardRef<
+  HTMLInputElement,
+  Omit<
     ComponentProps<typeof DateInputCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <DateInputCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+DateInput.displayName = "DateInput";

--- a/client/apollo/react/src/Form/Select/SelectApollo.tsx
+++ b/client/apollo/react/src/Form/Select/SelectApollo.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/Select/SelectApollo.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelApollo";
 import { ItemMessage } from "../ItemMessage/ItemMessageApollo";
 import { Select as SelectCommon } from "./SelectCommon";
 
-export const Select = (
-  props: Omit<
+export const Select = forwardRef<
+  HTMLSelectElement,
+  Omit<
     ComponentProps<typeof SelectCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <SelectCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+Select.displayName = "Select";

--- a/client/apollo/react/src/Form/Select/SelectLF.tsx
+++ b/client/apollo/react/src/Form/Select/SelectLF.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/Select/SelectLF.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelLF";
 import { ItemMessage } from "../ItemMessage/ItemMessageLF";
 import { Select as SelectCommon } from "./SelectCommon";
 
-export const Select = (
-  props: Omit<
+export const Select = forwardRef<
+  HTMLSelectElement,
+  Omit<
     ComponentProps<typeof SelectCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <SelectCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+Select.displayName = "Select";

--- a/client/apollo/react/src/Form/TextArea/TextAreaApollo.tsx
+++ b/client/apollo/react/src/Form/TextArea/TextAreaApollo.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/TextArea/TextAreaApollo.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelApollo";
 import { ItemMessage } from "../ItemMessage/ItemMessageApollo";
 import { TextArea as TextAreaCommon } from "./TextAreaCommon";
 
-export const TextArea = (
-  props: Omit<
+export const TextArea = forwardRef<
+  HTMLTextAreaElement,
+  Omit<
     ComponentProps<typeof TextAreaCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <TextAreaCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+TextArea.displayName = "TextArea";

--- a/client/apollo/react/src/Form/TextArea/TextAreaLF.tsx
+++ b/client/apollo/react/src/Form/TextArea/TextAreaLF.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/TextArea/TextAreaLF.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelLF";
 import { ItemMessage } from "../ItemMessage/ItemMessageLF";
 import { TextArea as TextAreaCommon } from "./TextAreaCommon";
 
-export const TextArea = (
-  props: Omit<
+export const TextArea = forwardRef<
+  HTMLTextAreaElement,
+  Omit<
     ComponentProps<typeof TextAreaCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <TextAreaCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+TextArea.displayName = "TextArea";

--- a/client/apollo/react/src/Form/TextInput/TextInputApollo.tsx
+++ b/client/apollo/react/src/Form/TextInput/TextInputApollo.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/TextInput/TextInputApollo.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelApollo";
 import { ItemMessage } from "../ItemMessage/ItemMessageApollo";
 import { TextInput as TextInputCommon } from "./TextInputCommon";
 
-export const TextInput = (
-  props: Omit<
+export const TextInput = forwardRef<
+  HTMLInputElement,
+  Omit<
     ComponentProps<typeof TextInputCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <TextInputCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+TextInput.displayName = "TextInput";

--- a/client/apollo/react/src/Form/TextInput/TextInputLF.tsx
+++ b/client/apollo/react/src/Form/TextInput/TextInputLF.tsx
@@ -1,18 +1,22 @@
 import "@axa-fr/design-system-apollo-css/dist/Form/TextInput/TextInputLF.scss";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 import { ItemLabel } from "../ItemLabel/ItemLabelLF";
 import { ItemMessage } from "../ItemMessage/ItemMessageLF";
 import { TextInput as TextInputCommon } from "./TextInputCommon";
 
-export const TextInput = (
-  props: Omit<
+export const TextInput = forwardRef<
+  HTMLInputElement,
+  Omit<
     ComponentProps<typeof TextInputCommon>,
     "ItemLabelComponent" | "ItemMessageComponent"
-  >,
-) => (
+  >
+>((props, ref) => (
   <TextInputCommon
     {...props}
+    ref={ref}
     ItemLabelComponent={ItemLabel}
     ItemMessageComponent={ItemMessage}
   />
-);
+));
+
+TextInput.displayName = "TextInput";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12711,6 +12711,22 @@
         "react": ">= 16.8"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.56.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.1.tgz",
+      "integrity": "sha512-qWAVokhSpshhcEuQDSANHx3jiAEFzu2HAaaQIzi/r9FNPm1ioAvuJSD4EuZzWd7Al7nTRKcKPnBKO7sRn+zavQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
@@ -15844,6 +15860,7 @@
         "@material-symbols/svg-400": "^0.31.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.56.1",
         "react-router": "^7.5.1"
       },
       "devDependencies": {

--- a/samples/vite/package.json
+++ b/samples/vite/package.json
@@ -11,11 +11,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@axa-fr/design-system-slash-react": "*",
     "@axa-fr/design-system-look-and-feel-react": "*",
+    "@axa-fr/design-system-slash-react": "*",
     "@material-symbols/svg-400": "^0.31.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.1",
     "react-router": "^7.5.1"
   },
   "devDependencies": {

--- a/samples/vite/src/Client.tsx
+++ b/samples/vite/src/Client.tsx
@@ -3,34 +3,78 @@ import {
   buttonVariants as ButtonClientVariants,
   Svg,
   TextInput,
+  Select,
 } from "@axa-fr/design-system-look-and-feel-react";
 import acUnit from "@material-symbols/svg-400/outlined/ac_unit.svg";
 
-const Client = () => (
-  <section className="design-section">
-    <header>
-      <h1>Client sample</h1>
-    </header>
-    <p className="af-test-token-css">Test de token CSS</p>
-    <article>
-      <TextInput
-        classModifier="error"
-        label="Name"
-        description="Description"
-        error="This field is required"
-      />
-    </article>
+import { SubmitHandler, useForm } from "react-hook-form";
 
-    <article>
-      <ButtonClient
-        id="button"
-        variant={ButtonClientVariants.secondary}
-        onClick={() => console.log("click")}
-      >
-        Button <Svg src={acUnit} />
-      </ButtonClient>
-    </article>
-  </section>
-);
+type Inputs = {
+  exampleTextInput: string;
+  exampleSelect: string;
+};
+
+const Client = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Inputs>({
+    defaultValues: {
+      exampleTextInput: "",
+      exampleSelect: "",
+    },
+  });
+  const onSubmit: SubmitHandler<Inputs> = (data) => console.log(data);
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <section className="design-section">
+        <header>
+          <h1>Client sample</h1>
+        </header>
+        <p className="af-test-token-css">Test de token CSS</p>
+        <article>
+          <TextInput
+            {...register("exampleTextInput", {
+              required: "This field is required",
+            })}
+            label="Name"
+            description="Description"
+            error={errors.exampleTextInput?.message}
+          />
+        </article>
+
+        <article>
+          <Select
+            label="Name"
+            {...register("exampleSelect", {
+              required: "This field is required",
+            })}
+            description="Description"
+            error={errors.exampleSelect?.message}
+          >
+            <option disabled value="">
+              Select a country
+            </option>
+            <option value="FR">France</option>
+            <option value="ES">Espagne</option>
+            <option value="JP">Japon</option>
+          </Select>
+        </article>
+
+        <article>
+          <ButtonClient
+            id="button"
+            variant={ButtonClientVariants.secondary}
+            onClick={() => console.log("click")}
+            type="submit"
+          >
+            Submit <Svg src={acUnit} />
+          </ButtonClient>
+        </article>
+      </section>
+    </form>
+  );
+};
 
 export default Client;


### PR DESCRIPTION
fix #1167

i also added, in a separated commit, react-hook-form in sample project in order to see if TextInput and Select components works correctly and as expected (error validation and display, value passed correctly onsubmit ...) 

Error on submit
![image](https://github.com/user-attachments/assets/626400cd-643a-439e-b514-2fd539c5880f)

submitted value in console.log
![image](https://github.com/user-attachments/assets/2011956a-eda6-46e3-ad14-cde116efad4e)
