### PR TITLE
refactor(apollo, look&feel): pick properties types from ItemLabel instead of rewrite all of them

### DIFF
--- a/client/apollo/react/src/Form/TextArea/TextAreaCommon.tsx
+++ b/client/apollo/react/src/Form/TextArea/TextAreaCommon.tsx
@@ -10,21 +10,24 @@ import { getComponentClassName } from "../../utilities/getComponentClassName";
 import { ItemLabel } from "../ItemLabel/ItemLabelCommon";
 import { ItemMessage } from "../ItemMessage/ItemMessageCommon";
 
-type Props = ComponentPropsWithRef<"textarea"> & {
-  classModifier?: string;
-  sideButtonLabel: string;
-  onSideButtonClick?: MouseEventHandler<HTMLButtonElement>;
-  helper?: string;
-  error?: string;
-  description?: string;
-  label: ComponentProps<typeof ItemLabel>["label"];
-  ItemLabelComponent: ComponentType<
-    Omit<ComponentProps<typeof ItemLabel>, "ButtonComponent">
-  >;
-  ItemMessageComponent: ComponentType<ComponentProps<typeof ItemMessage>>;
-  buttonLabel?: string;
-  onButtonClick?: MouseEventHandler<HTMLButtonElement>;
-} & Partial<ComponentPropsWithRef<typeof ItemMessage>>;
+type Props = ComponentPropsWithRef<"textarea"> &
+  Pick<
+    ComponentProps<typeof ItemLabel>,
+    | "label"
+    | "description"
+    | "buttonLabel"
+    | "sideButtonLabel"
+    | "onSideButtonClick"
+  > & {
+    classModifier?: string;
+    helper?: string;
+    error?: string;
+    ItemLabelComponent: ComponentType<
+      Omit<ComponentProps<typeof ItemLabel>, "ButtonComponent">
+    >;
+    ItemMessageComponent: ComponentType<ComponentProps<typeof ItemMessage>>;
+    onButtonClick?: MouseEventHandler<HTMLButtonElement>;
+  } & Partial<ComponentPropsWithRef<typeof ItemMessage>>;
 
 const TextArea = forwardRef<HTMLTextAreaElement, Props>(
   (


### PR DESCRIPTION
The prop `sideButtonLabel` of TextArea was required while it is not the case in the component that use this prop.
I make it optional and remove all rewritten props types used for this component dependency to use directly the props types from the component.