### PR TITLE
fix(look&feel): optional label for Select + styling

### DIFF
--- a/apps/look-and-feel-stories/src/Select.stories.tsx
+++ b/apps/look-and-feel-stories/src/Select.stories.tsx
@@ -31,8 +31,11 @@ export const SelectStory: Story = {
     disabled: false,
     required: false,
     placeholder: "Placeholder",
-    errorLabel: "",
+    error: "",
     value: "",
+    description: "Description Text",
+    sideButtonLabel: "Side Button",
+    buttonLabel: "ButtonLabel",
   },
   argTypes: {
     onChange: { action: "onChange" },

--- a/client/apollo/css/src/Form/Select/SelectCommon.scss
+++ b/client/apollo/css/src/Form/Select/SelectCommon.scss
@@ -1,3 +1,5 @@
+@use "../../common/breakpoints" as breakpoints;
+
 .af-form__select {
   &-label {
     display: inline-block;
@@ -11,9 +13,13 @@
     display: block;
     width: 100%;
     margin: calc(10 / var(--font-size-base) * 1rem) 0;
-    padding: calc(21 / var(--font-size-base) * 1rem);
+    padding: calc(16 / var(--font-size-base) * 1rem);
+    padding-right: calc(16 / var(--font-size-base) * 3rem);
     border: 1px solid var(--select-border-color);
     border-radius: var(--select-border-radius);
+    font-size: calc(16 / var(--font-size-base) * 1rem);
+    font-weight: 600;
+    line-height: 1.25em;
     text-overflow: ellipsis;
     white-space: nowrap;
     color: var(--select-color);
@@ -33,9 +39,9 @@
     }
 
     &:focus-visible {
-      box-shadow: 0 0 0 2px var(--select-box-shadow) inset;
-      outline: 2px;
-      outline-offset: 2px;
+      box-shadow: 0 0 0 1px var(--select-border-color) inset;
+      outline: 2px solid var(--select-outline-color);
+      outline-offset: 3px;
     }
 
     &:disabled {
@@ -46,8 +52,12 @@
 
     &:not(:disabled):hover,
     &:not(:disabled):active {
-      border: var(--select-border-radius) solid var(--select-border-color);
-      box-shadow: 0 0 0 1px var(--select-box-shadow) inset;
+      border: 1px solid var(--select-border-color);
+      box-shadow: 0 0 0 1px var(--select-border-color) inset;
+    }
+
+    &:has(option[value=""]:checked) {
+      font-weight: 400;
     }
 
     &-placeholder {
@@ -55,15 +65,11 @@
     }
 
     &--error {
-      border: 2px solid var(--select-border-color);
-      border-color: var(--select-border-color);
-      box-shadow: 0 0 0 1px var(--select-box-shadow) inset;
+      border: 1px solid var(--select-border-color);
+    }
 
-      &:not(:disabled):hover,
-      &:not(:disabled):active {
-        border-color: var(--select-border-color);
-        box-shadow: 0 0 0 1px var(--select-box-shadow) inset;
-      }
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      font-size: calc(18 / var(--font-size-base) * 1rem);
     }
   }
 }

--- a/client/apollo/css/src/Form/Select/SelectLF.scss
+++ b/client/apollo/css/src/Form/Select/SelectLF.scss
@@ -2,6 +2,8 @@
 
 .af-form__select {
   &-input {
+    --select-color: var(--color-gray-900);
+    --select-outline-color: var(--color-axa);
     --select-placeholder-color: var(--color-gray-700);
     --select-border-radius: var(--default-border-radius);
     --select-border-color: var(--color-gray-700);
@@ -12,15 +14,8 @@
       --select-background-open: url("@material-symbols/svg-400/outlined/arrow_drop_up.svg");
     }
 
-    option {
-      --select-option-color: var(--color-black);
-
-      &:disabled {
-        --select-option-disabled-color: var(--color-gray-500);
-      }
-    }
-
     &:focus-visible {
+      --select-outline-color: var(--color-blue-3);
       --select-border-color: var(--color-axa);
     }
 
@@ -29,30 +24,47 @@
       --select-border-color: var(--color-gray-400);
     }
 
-    &-placeholder {
-      --select-placeholder-color: var(--color-gray-700);
-    }
-
     &:not(:disabled):hover,
     &:not(:disabled):active {
-      --select-border-radius: 1px;
       --select-border-color: var(--color-axa);
       --select-box-shadow: var(--color-axa);
     }
 
+    &:has(option[value=""]:checked) {
+      --select-color: var(--color-gray-700);
+    }
+
+    &:has(option[value=""]:not(:checked)) {
+      --select-border-color: var(--color-axa);
+    }
+
+    option {
+      --select-color: var(--color-gray-900);
+
+      &:disabled {
+        --select-color: var(--color-gray-500);
+      }
+    }
+
+    &-placeholder {
+      --select-placeholder-color: var(--color-gray-700);
+    }
+
     &--error {
-      --select-border-color: var(--color-red);
+      --select-border-color: var(--color-red-700);
 
       &:focus-visible {
-        --select-box-shadow: var(--color-red);
-
-        outline: none;
+        --select-border-color: var(--color-red-700);
       }
 
       &:not(:disabled):hover,
       &:not(:disabled):active {
-        --select-border-color: var(--color-red);
-        --select-box-shadow: 0 0 0 1px var(--color-red) inset;
+        --select-border-color: var(--color-red-700);
+        --select-box-shadow: 0 0 0 1px var(--color-red-700) inset;
+      }
+
+      &:has(option[value=""]:not(:checked)) {
+        --select-border-color: var(--color-red-700);
       }
     }
   }

--- a/client/apollo/css/src/Form/TextInput/TextInputCommon.scss
+++ b/client/apollo/css/src/Form/TextInput/TextInputCommon.scss
@@ -23,6 +23,11 @@
       column-gap: calc(8 / var(--font-size-base) * 1rem);
     }
 
+    &:has(> input:focus-visible) {
+      outline: 2px solid var(--color-blue-3);
+      outline-offset: 3px;
+    }
+
     > input {
       all: unset;
       font-size: calc(16 / var(--font-size-base) * 1rem);

--- a/client/apollo/react/src/Form/ItemLabel/ItemLabelCommon.tsx
+++ b/client/apollo/react/src/Form/ItemLabel/ItemLabelCommon.tsx
@@ -9,7 +9,7 @@ import { Svg } from "../../Svg/Svg";
 import { Button } from "../../Button/ButtonCommon";
 
 type ItemLabelProps = {
-  label: string;
+  label?: string;
   description?: string;
   required?: boolean;
   inputId: string;
@@ -34,16 +34,20 @@ export const ItemLabel = ({
   ButtonComponent,
 }: ItemLabelProps) => {
   const idDescription = useId();
-
+  if (!label && !description && !buttonLabel && !sideButtonLabel) {
+    return null;
+  }
   return (
     <div className="af-item-label">
-      <label
-        htmlFor={inputId}
-        id={idLabel}
-        aria-describedby={description ? idDescription : undefined}
-      >
-        {label} {required && <span aria-hidden="true"> *</span>}
-      </label>
+      {label && (
+        <label
+          htmlFor={inputId}
+          id={idLabel}
+          aria-describedby={description ? idDescription : undefined}
+        >
+          {label} {required && <span aria-hidden="true"> *</span>}
+        </label>
+      )}
 
       {sideButtonLabel && (
         <ButtonComponent

--- a/client/apollo/react/src/Form/Select/SelectCommon.tsx
+++ b/client/apollo/react/src/Form/Select/SelectCommon.tsx
@@ -12,8 +12,7 @@ import { ItemMessage } from "../ItemMessage/ItemMessageCommon";
 type SelectProps = ComponentPropsWithRef<"select"> & {
   id?: string;
   classModifier?: string;
-  label: ComponentProps<typeof ItemLabel>["label"];
-  errorLabel?: string;
+  label?: ComponentProps<typeof ItemLabel>["label"];
   error?: string;
   success?: string;
   placeholder?: string;


### PR DESCRIPTION
fix for having an optional label for select + styling to be similar to textinput and added the focus-visible outring like the one on the button:

![image](https://github.com/user-attachments/assets/4b56ddcc-7bd6-4823-a2e1-c05cb43f55ce)
![image](https://github.com/user-attachments/assets/4b51aaca-037a-4e54-8a30-8e2358549344)
![image](https://github.com/user-attachments/assets/05296968-e26d-4612-9028-a1a97b9c6960)
