### PR TITLE
fix(design-system): separate DebugGrid  LF and Apollo to avoid CSS conflicts

### DIFF
--- a/client/apollo/react/src/Grid/DebugGridApollo.tsx
+++ b/client/apollo/react/src/Grid/DebugGridApollo.tsx
@@ -1,0 +1,33 @@
+import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+import { useState } from "react";
+import { CheckboxCard } from "../Form/checkbox/checkboxCard/CheckboxCardApollo";
+import { DebugGridCommon } from "./DebugGridCommon";
+
+export const DebugGrid = ({
+  cols = 12,
+  isCheckedByDefault = false,
+}: {
+  cols?: number;
+  isCheckedByDefault?: boolean;
+}) => {
+  const [checked, setChecked] = useState(isCheckedByDefault);
+
+  const handleChecked = () => setChecked(!checked);
+  return (
+    <>
+      <CheckboxCard
+        type="vertical"
+        options={[
+          {
+            name: "debuggrid",
+            label: "Grid",
+            checked,
+            onClick: handleChecked,
+          },
+        ]}
+      />
+
+      <DebugGridCommon cols={cols} />
+    </>
+  );
+};

--- a/client/apollo/react/src/Grid/DebugGridCommon.tsx
+++ b/client/apollo/react/src/Grid/DebugGridCommon.tsx
@@ -1,0 +1,13 @@
+import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+
+export const DebugGridCommon = ({ cols = 12 }: { cols?: number }) => {
+  return (
+    <div className="debug-grid">
+      <div className="grid">
+        {[...Array(cols).keys()].map((col: number) => (
+          <div key={col} className="cols" />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/apollo/react/src/Grid/DebugGridLF.tsx
+++ b/client/apollo/react/src/Grid/DebugGridLF.tsx
@@ -1,6 +1,7 @@
 import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
 import { useState } from "react";
-import { CheckboxCard } from "..";
+import { CheckboxCard } from "../Form/checkbox/checkboxCard/CheckboxCardLF";
+import { DebugGridCommon } from "./DebugGridCommon";
 
 export const DebugGrid = ({
   cols = 12,
@@ -26,13 +27,7 @@ export const DebugGrid = ({
         ]}
       />
 
-      <div className="debug-grid">
-        <div className="grid">
-          {[...Array(cols).keys()].map((col: number) => (
-            <div key={col} className="cols" />
-          ))}
-        </div>
-      </div>
+      <DebugGridCommon cols={cols} />
     </>
   );
 };

--- a/client/apollo/react/src/index.ts
+++ b/client/apollo/react/src/index.ts
@@ -16,7 +16,7 @@ export {
   type SpinnerVariants,
 } from "./Spinner/SpinnerApollo";
 export { Tag, type TagVariants, tagVariants } from "./Tag/TagApollo";
-export { DebugGrid } from "./Grid/DebugGrid";
+export { DebugGrid } from "./Grid/DebugGridApollo";
 export { ItemMessage } from "./Form/ItemMessage/ItemMessageApollo";
 export { ItemLabel } from "./Form/ItemLabel/ItemLabelApollo";
 export { TextArea } from "./Form/TextArea/TextAreaApollo";

--- a/client/apollo/react/src/indexLF.ts
+++ b/client/apollo/react/src/indexLF.ts
@@ -11,7 +11,7 @@ export {
   type SpinnerVariants,
 } from "./Spinner/SpinnerLF";
 export { Tag, type TagVariants, tagVariants } from "./Tag/TagLF";
-export { DebugGrid } from "./Grid/DebugGrid";
+export { DebugGrid } from "./Grid/DebugGridLF";
 export { ItemMessage } from "./Form/ItemMessage/ItemMessageLF";
 export { ItemLabel } from "./Form/ItemLabel/ItemLabelLF";
 export { Select } from "./Form/Select/SelectLF";


### PR DESCRIPTION
séparation en 2 composant LF / Apollo pour le composant `DebugGrid`

Sans ce correctif le composant DebugGrid crée un conflit au niveau des CSS importé
il utilisait le composant `CheckboxCard` du design Apollo. Ce qui par ricoché faisait importer l'ensemble du design apollo dans les projets utilisant look and feel, les 2 css étant chargé le design apollo écrasé le look and feel côté projet