### PR TITLE
fix(apollo, look&feel): ensure that the icon does not shrink in flex layout in ItemMessage

### DIFF
--- a/client/apollo/css/src/Form/ItemMessage/ItemMessageCommon.scss
+++ b/client/apollo/css/src/Form/ItemMessage/ItemMessageCommon.scss
@@ -9,6 +9,7 @@
 
   &__icon {
     width: var(--item-message-icon-size);
+    flex-shrink: 0;
     color: var(--item-message-color);
     fill: currentcolor;
   }

--- a/client/apollo/css/src/Form/ItemMessage/ItemMessageCommon.scss
+++ b/client/apollo/css/src/Form/ItemMessage/ItemMessageCommon.scss
@@ -9,6 +9,7 @@
 
   &__icon {
     width: var(--item-message-icon-size);
+    height: var(--item-message-icon-size);
     flex-shrink: 0;
     color: var(--item-message-color);
     fill: currentcolor;


### PR DESCRIPTION
This is a small fix to prevent the icon from shrinking in flex containers.

Previous :

![before](https://github.com/user-attachments/assets/c3016752-1375-4ecb-9aa9-438b7f275181)

Now :

![after](https://github.com/user-attachments/assets/8003b09a-84b6-49d0-b1db-59593c2aef2c)
