### PR TITLE
fix(apollo, look&feel): CheckboxCard style

### DIFF
--- a/apps/apollo-stories/src/components/CheckboxCard/CheckboxCard.stories.tsx
+++ b/apps/apollo-stories/src/components/CheckboxCard/CheckboxCard.stories.tsx
@@ -1,7 +1,7 @@
 import { CheckboxCard } from "@axa-fr/design-system-apollo-react";
+import homeIcons from "@material-symbols/svg-400/outlined/home.svg";
 import { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
-import homeIcons from "@material-symbols/svg-400/outlined/home.svg";
 
 const meta: Meta = {
   title: "Components/Form/Checkbox/CheckboxCard",
@@ -32,6 +32,7 @@ export const CheckboxCardStory: StoryObj<ComponentProps<typeof CheckboxCard>> =
           description: "Capitale de la Belgique",
           name: "bruxelles",
           value: "bruxelles",
+          hasError: true,
           icon: homeIcons,
         },
         {

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxApollo.scss
@@ -14,13 +14,6 @@
     }
   }
 
-  input[type="checkbox"]:hover {
-    ~ .af-checkbox__icons {
-      --checkbox-border: 1px var(--axa-blue-100);
-      --checkbox-box-shadow-color: var(--axa-blue-100);
-    }
-  }
-
   input[type="checkbox"]:checked {
     ~ .af-checkbox__icons {
       --checkbox-border: 1px var(--axa-blue-100);
@@ -30,6 +23,13 @@
       & .af-checkbox__checked {
         --checkbox-check-fill: var(--white);
       }
+    }
+  }
+
+  input[type="checkbox"]:not([aria-invalid="true"]):hover {
+    ~ .af-checkbox__icons {
+      --checkbox-border: 1px var(--axa-blue-100);
+      --checkbox-box-shadow-color: var(--axa-blue-100);
     }
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
@@ -30,23 +30,23 @@
     opacity: 0;
     cursor: pointer;
 
-    &:hover {
+    &:checked {
+      ~ .af-checkbox__icons {
+        border: solid var(--checkbox-border);
+        background-color: var(--checkbox-background-color);
+        box-shadow: 0 0 0 1px var(--checkbox-box-shadow-color) inset;
+
+        & .af-checkbox__checked {
+          display: block;
+          fill: var(--checkbox-check-fill);
+        }
+      }
+    }
+
+    &:not([aria-invalid="true"]):hover {
       ~ .af-checkbox__icons {
         border: solid var(--checkbox-border);
         box-shadow: 0 0 0 1px var(--checkbox-box-shadow-color) inset;
-      }
-    }
-  }
-
-  input[type="checkbox"]:checked {
-    ~ .af-checkbox__icons {
-      border: solid var(--checkbox-border);
-      background-color: var(--checkbox-background-color);
-      box-shadow: 0 0 0 1px var(--checkbox-box-shadow-color) inset;
-
-      & .af-checkbox__checked {
-        display: block;
-        fill: var(--checkbox-check-fill);
       }
     }
   }

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxLF.scss
@@ -14,13 +14,6 @@
     }
   }
 
-  input[type="checkbox"]:hover {
-    ~ .af-checkbox__icons {
-      --checkbox-border: 2px var(--color-axa);
-      --checkbox-box-shadow-color: var(--color-axa);
-    }
-  }
-
   input[type="checkbox"]:checked {
     ~ .af-checkbox__icons {
       --checkbox-border: 2px var(--color-axa);
@@ -30,6 +23,13 @@
       & .af-checkbox__checked {
         --checkbox-check-fill: var(--color-white);
       }
+    }
+  }
+
+  input[type="checkbox"]:not([aria-invalid="true"]):hover {
+    ~ .af-checkbox__icons {
+      --checkbox-border: 2px var(--color-axa);
+      --checkbox-box-shadow-color: var(--color-axa);
     }
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardApollo.scss
@@ -7,36 +7,11 @@
   }
 
   &__label {
-    --checkbox-card-color: var(--color-gray-900);
+    --checkbox-card-color: var(--neutral-100);
   }
 
   &__description {
-    --checkbox-card-color: var(--color-gray-700);
-  }
-
-  &__content {
-    & > svg {
-      --checkbox-card-color: var(--color-axa);
-      --checkbox-card-fill: var(--color-axa);
-    }
-
-    &-description {
-      & > span:first-child {
-        --checkbox-card-color: var(--color-gray-900);
-      }
-
-      & > span:not(:first-child) {
-        --checkbox-card-color: var(--color-gray-700);
-      }
-    }
-  }
-
-  & ~ &__error {
-    --error-box-color: var(--color-red-700);
-
-    & > svg {
-      --error-box-color: var(--color-red-700);
-    }
+    --checkbox-card-color: var(--neutral-80);
   }
 
   &-group {

--- a/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardApollo.scss
@@ -39,52 +39,45 @@
     }
   }
 
-  &-group--horizontal {
-    --checkbox-card-flex-direction: column;
+  &-group {
+    &--horizontal {
+      --checkbox-card-flex-direction: column;
 
-    .af-checkbox-card-label {
-      --checkbox-card-flex-direction: row;
-
-      .af-checkbox-card-content {
+      .af-checkbox-card-label {
         --checkbox-card-flex-direction: row;
-        --checkbox-card-margin-left: calc(12 / var(--font-size-base) * 1rem);
 
-        .af-checkbox-card-content-description {
-          --checkbox-card-flex-direction: column;
-          --checkbox-card-align-item: flex-start;
+        .af-checkbox-card-content {
+          --checkbox-card-flex-direction: row;
+          --checkbox-card-margin-left: calc(12 / var(--font-size-base) * 1rem);
 
-          & > span:first-child {
-            --checkbox-card-label-text-color: var(--axa-blue-100);
+          .af-checkbox-card-content-description {
+            --checkbox-card-flex-direction: column;
+            --checkbox-card-align-item: flex-start;
+
+            & > span:first-child {
+              --checkbox-card-label-text-color: var(--axa-blue-100);
+            }
           }
         }
       }
     }
-  }
 
-  &-group--vertical {
-    --checkbox-card-flex-direction: row;
+    &--vertical {
+      --checkbox-card-flex-direction: row;
 
-    .af-checkbox-card-label {
-      --checkbox-card-flex-direction: column-reverse;
+      .af-checkbox-card-label {
+        --checkbox-card-flex-direction: column-reverse;
 
-      .af-checkbox-card-content {
-        --checkbox-card-flex-direction: column;
-        --checkbox-card-margin-left: calc(2 / var(--font-size-base) * 1rem);
-
-        .af-checkbox-card-content-description {
+        .af-checkbox-card-content {
           --checkbox-card-flex-direction: column;
-          --checkbox-card-align-item: center;
+          --checkbox-card-margin-left: calc(2 / var(--font-size-base) * 1rem);
+
+          .af-checkbox-card-content-description {
+            --checkbox-card-flex-direction: column;
+            --checkbox-card-align-item: center;
+          }
         }
       }
-    }
-  }
-
-  &-group--vertical,
-  &-group--horizontal {
-    .af-checkbox-card-label[aria-invalid="true"] {
-      --checkbox-card-background-color: var(--axa-red-4);
-      --checkbox-card-border: 1px var(--red-alert-100);
-      --checkbox-card-shadow-color: var(--red-alert-100);
     }
 
     .af-checkbox-card-label {
@@ -92,25 +85,40 @@
       --checkbox-card-border-radius: calc(8 / var(--font-size-base) * 1rem);
       --checkbox-card-align-items: center;
 
-      .af-checkbox-card-content {
-        .af-checkbox-card-content-description {
-          & > span:first-child {
-            --checkbox-card-label-text-color: var(--axa-blue-100);
-          }
+      .af-checkbox-card-content .af-checkbox-card-content-description > span {
+        &:first-child {
+          --checkbox-card-label-text-color: var(--axa-blue-100);
+        }
+
+        &:not(:first-child) {
+          --checkbox-card-label-text-color: var(--neutral-80);
         }
       }
 
-      &:hover {
+      &[aria-invalid="true"] {
+        --checkbox-card-background-color: var(--axa-red-4);
+        --checkbox-card-border: 1px var(--red-alert-100);
+        --checkbox-card-shadow-color: var(--red-alert-100);
+
+        .af-checkbox-card-content-description > span:first-child {
+          --checkbox-card-label-text-color: var(--neutral-80);
+        }
+      }
+
+      &:has(input:checked) {
         --checkbox-card-border: 1px var(--axa-blue-100);
         --checkbox-card-shadow-color: var(--axa-blue-100);
-        --checkbox-card-background-color: var(--white);
-      }
-    }
+        --checkbox-card-background-color: var(--axa-blue-4);
 
-    .af-checkbox-card-label:has(input:checked) {
-      --checkbox-card-border: 1px var(--axa-blue-100);
-      --checkbox-card-shadow-color: var(--axa-blue-100);
-      --checkbox-card-background-color: var(--axa-blue-4);
+        .af-checkbox-card-content-description > span:first-child {
+          --checkbox-card-label-text-color: var(--axa-blue-100);
+        }
+      }
+
+      &:not([aria-invalid="true"]):hover {
+        --checkbox-card-border: 1px var(--axa-blue-100);
+        --checkbox-card-shadow-color: var(--axa-blue-100);
+      }
     }
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardCommon.scss
@@ -70,49 +70,7 @@
     }
   }
 
-  &-group--horizontal {
-    flex-direction: var(--checkbox-card-flex-direction);
-
-    .af-checkbox-card-label {
-      flex-direction: var(--checkbox-card-flex-direction);
-      align-items: var(--checkbox-card-align-items);
-
-      .af-checkbox-card-content {
-        flex-direction: var(--checkbox-card-flex-direction);
-
-        .af-checkbox-card-content-description {
-          flex-direction: var(--checkbox-card-flex-direction);
-          align-items: var(--checkbox-card-align-item);
-          text-align: left;
-        }
-      }
-    }
-  }
-
-  &-group--vertical {
-    flex-direction: var(--checkbox-card-flex-direction);
-
-    .af-checkbox-card-label {
-      flex-direction: var(--checkbox-card-flex-direction);
-      align-items: var(--checkbox-card-align-items);
-      justify-content: var(--checkbox-card-justify-content);
-
-      .af-checkbox-card-content {
-        width: 100%;
-        flex: 1;
-        flex-direction: var(--checkbox-card-flex-direction);
-
-        .af-checkbox-card-content-description {
-          flex-direction: var(--checkbox-card-flex-direction);
-          align-items: var(--checkbox-card-align-item);
-          text-align: center;
-        }
-      }
-    }
-  }
-
-  &-group--vertical,
-  &-group--horizontal {
+  &-group {
     display: flex;
     align-items: stretch;
     gap: 1rem;
@@ -120,6 +78,47 @@
     font-style: normal;
     font-weight: 400;
     line-height: calc(20 / var(--font-size-base) * 1rem);
+
+    &--horizontal {
+      flex-direction: var(--checkbox-card-flex-direction);
+
+      .af-checkbox-card-label {
+        flex-direction: var(--checkbox-card-flex-direction);
+        align-items: var(--checkbox-card-align-items);
+
+        .af-checkbox-card-content {
+          flex-direction: var(--checkbox-card-flex-direction);
+
+          .af-checkbox-card-content-description {
+            flex-direction: var(--checkbox-card-flex-direction);
+            align-items: var(--checkbox-card-align-item);
+            text-align: left;
+          }
+        }
+      }
+    }
+
+    &--vertical {
+      flex-direction: var(--checkbox-card-flex-direction);
+
+      .af-checkbox-card-label {
+        flex-direction: var(--checkbox-card-flex-direction);
+        align-items: var(--checkbox-card-align-items);
+        justify-content: var(--checkbox-card-justify-content);
+
+        .af-checkbox-card-content {
+          width: 100%;
+          flex: 1;
+          flex-direction: var(--checkbox-card-flex-direction);
+
+          .af-checkbox-card-content-description {
+            flex-direction: var(--checkbox-card-flex-direction);
+            align-items: var(--checkbox-card-align-item);
+            text-align: center;
+          }
+        }
+      }
+    }
 
     .af-checkbox-card-label[aria-invalid="true"] {
       border: solid var(--checkbox-card-border);
@@ -172,17 +171,20 @@
         }
       }
 
-      &:hover {
+      &:has(input:checked) {
         border: solid var(--checkbox-card-border);
         background-color: var(--checkbox-card-background-color);
         box-shadow: 0 0 0 1px var(--checkbox-card-shadow-color) inset;
-      }
-    }
 
-    .af-checkbox-card-label:has(input:checked) {
-      border: solid var(--checkbox-card-border);
-      background-color: var(--checkbox-card-background-color);
-      box-shadow: 0 0 0 1px var(--checkbox-card-shadow-color) inset;
+        .af-checkbox-card-content-description > span:first-child {
+          font-weight: 600;
+        }
+      }
+
+      &:not([aria-invalid="true"]):hover {
+        border: solid var(--checkbox-card-border);
+        box-shadow: 0 0 0 1px var(--checkbox-card-shadow-color) inset;
+      }
     }
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardCommon.scss
@@ -31,45 +31,6 @@
     }
   }
 
-  &__content {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-
-    & > svg {
-      width: calc(28 / var(--font-size-base) * 1rem);
-      height: calc(28 / var(--font-size-base) * 1rem);
-      color: var(--checkbox-card-color);
-      fill: var(--checkbox-card-fill);
-    }
-
-    &-description {
-      display: flex;
-      flex-direction: column;
-      gap: calc(4 / var(--font-size-base) * 1rem);
-      line-height: calc(20 / var(--font-size-base) * 1rem);
-
-      & > span:first-child {
-        line-height: calc(24 / var(--font-size-base) * 1rem);
-        color: var(--checkbox-card-color);
-      }
-
-      & > span:not(:first-child) {
-        color: var(--checkbox-card-color);
-      }
-    }
-  }
-
-  & ~ &__error {
-    border: solid var(--color-red-700);
-
-    & > svg {
-      border: solid var(--color-red-700);
-    }
-  }
-
   &-group {
     display: flex;
     align-items: stretch;

--- a/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardLF.scss
@@ -13,32 +13,6 @@
     --checkbox-card-color: var(--color-gray-700);
   }
 
-  &__content {
-    & > svg {
-      --checkbox-card-color: var(--color-axa);
-      --checkbox-card-fill: var(--color-axa);
-    }
-
-    &-description {
-      & > span:first-child {
-        --checkbox-card-color: var(--color-gray-900);
-      }
-
-      & > span:not(:first-child) {
-        --checkbox-card-color: var(--color-gray-700);
-      }
-    }
-  }
-
-  & ~ &__error {
-    --error-box-color: var(--color-red-700);
-
-    & > svg {
-      --error-box-color: var(--color-red-700);
-      --error-box-fill: var(--color-red-700);
-    }
-  }
-
   &-group {
     &--horizontal {
       --checkbox-card-flex-direction: column;

--- a/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxCard/CheckboxCardLF.scss
@@ -39,80 +39,80 @@
     }
   }
 
-  &-group--horizontal {
-    --checkbox-card-flex-direction: column;
+  &-group {
+    &--horizontal {
+      --checkbox-card-flex-direction: column;
 
-    .af-checkbox-card-label {
-      --checkbox-card-flex-direction: row;
-      --checkbox-card-align-items: center;
-
-      .af-checkbox-card-content {
+      .af-checkbox-card-label {
         --checkbox-card-flex-direction: row;
-        --checkbox-card-margin-left: calc(12 / var(--font-size-base) * 1rem);
+        --checkbox-card-align-items: center;
 
-        .af-checkbox-card-content-description {
-          --checkbox-card-flex-direction: column;
-          --checkbox-card-align-item: flex-start;
+        .af-checkbox-card-content {
+          --checkbox-card-flex-direction: row;
+          --checkbox-card-margin-left: calc(12 / var(--font-size-base) * 1rem);
+
+          .af-checkbox-card-content-description {
+            --checkbox-card-flex-direction: column;
+            --checkbox-card-align-item: flex-start;
+          }
         }
       }
     }
-  }
 
-  &-group--vertical {
-    --checkbox-card-flex-direction: row;
-
-    .af-checkbox-card-label {
+    &--vertical {
       --checkbox-card-flex-direction: row;
-      --checkbox-card-align-items: flex-start;
-      --checkbox-card-justify-content: flex-start;
 
-      .af-checkbox {
-        position: absolute;
-      }
+      .af-checkbox-card-label {
+        --checkbox-card-flex-direction: row;
+        --checkbox-card-align-items: flex-start;
+        --checkbox-card-justify-content: flex-start;
 
-      .af-checkbox-card-content {
-        --checkbox-card-flex-direction: column;
-        --checkbox-card-margin-left: calc(2 / var(--font-size-base) * 1rem);
+        .af-checkbox {
+          position: absolute;
+        }
 
-        .af-checkbox-card-content-description {
+        .af-checkbox-card-content {
           --checkbox-card-flex-direction: column;
-          --checkbox-card-align-item: center;
+          --checkbox-card-margin-left: calc(2 / var(--font-size-base) * 1rem);
+
+          .af-checkbox-card-content-description {
+            --checkbox-card-flex-direction: column;
+            --checkbox-card-align-item: center;
+          }
         }
       }
     }
-  }
 
-  &-group--vertical,
-  &-group--horizontal {
     .af-checkbox-card-label[aria-invalid="true"] {
       --checkbox-card-background-color: var(--color-white);
-      --checkbox-card-border: 2px var(--color-red-700);
+      --checkbox-card-border: 1px var(--color-red-700);
       --checkbox-card-shadow-color: var(--color-red-700);
     }
 
     .af-checkbox-card-label {
-      --checkbox-card-border: 2px var(--color-gray-700);
+      --checkbox-card-border: 1px var(--color-gray-700);
       --checkbox-card-border-radius: calc(6 / var(--font-size-base) * 1rem);
 
-      .af-checkbox-card-content {
-        .af-checkbox-card-content-description {
-          & > span:first-child {
-            --checkbox-card-label-text-color: var(--color-black);
-          }
+      .af-checkbox-card-content-description > span {
+        &:first-child {
+          --checkbox-card-label-text-color: var(--color-gray-900);
+        }
+
+        &:not(:first-child) {
+          --checkbox-card-label-text-color: var(--color-gray-700);
         }
       }
 
-      &:hover {
-        --checkbox-card-border: 2px var(--color-axa);
+      &:has(input:checked) {
+        --checkbox-card-border: 1px var(--color-axa);
         --checkbox-card-shadow-color: var(--color-axa);
-        --checkbox-card-background-color: var(--color-white);
+        --checkbox-card-background-color: var(--color-blue-2);
       }
-    }
 
-    .af-checkbox-card-label:has(input:checked) {
-      --checkbox-card-border: 2px var(--color-axa);
-      --checkbox-card-shadow-color: var(--color-axa);
-      --checkbox-card-background-color: var(--color-blue-2);
+      &:not([aria-invalid="true"]):hover {
+        --checkbox-card-border: 1px var(--color-axa);
+        --checkbox-card-shadow-color: var(--color-axa);
+      }
     }
   }
 }

--- a/client/apollo/react/src/Grid/DebugGridApollo.tsx
+++ b/client/apollo/react/src/Grid/DebugGridApollo.tsx
@@ -16,7 +16,7 @@ export const DebugGrid = ({
   return (
     <>
       <CheckboxCard
-        type="vertical"
+        type="horizontal"
         options={[
           {
             name: "debuggrid",

--- a/client/apollo/react/src/Grid/DebugGridLF.tsx
+++ b/client/apollo/react/src/Grid/DebugGridLF.tsx
@@ -16,7 +16,7 @@ export const DebugGrid = ({
   return (
     <>
       <CheckboxCard
-        type="vertical"
+        type="horizontal"
         options={[
           {
             name: "debuggrid",


### PR DESCRIPTION
This pull request makes : 
- fix some styles problems to the CheckboxCard component 
- fix of the CheckboxCard type for the DebugGrid
- add an error CheckboxCard in the apollo story (like in the look&feel story)

I also reorganized the SCSS files of CheckboxCard to reduce the style a bit by removing unnecessary elements and reorganizing a little.