### PR TITLE
fix(slash): la partie user link ne doit pas être souligné lorsqu'il n'y a pas de link

### DIFF
--- a/slash/css/src/Layout/Header/User/User.scss
+++ b/slash/css/src/Layout/Header/User/User.scss
@@ -5,7 +5,6 @@
   order: 2;
   font-weight: 600;
   text-align: left;
-  text-decoration: underline;
   color: common.$color-axa;
 
   &__name {
@@ -15,6 +14,10 @@
   &__profile {
     display: inline;
     margin-left: 0.3em;
+  }
+
+  &__link {
+    text-decoration: underline;
   }
 }
 


### PR DESCRIPTION
user without link :
![image](https://github.com/user-attachments/assets/0c4b771a-ef77-408c-8ef8-65fd1ceb72d9)

user with link :
![image](https://github.com/user-attachments/assets/059425e5-a655-47a8-a69a-18785a313816)

#1017