### PR TITLE
feat(apollo,look&feel): vertical spacing

### DIFF
--- a/client/apollo/css/src/Form/ItemLabel/ItemLabelCommon.scss
+++ b/client/apollo/css/src/Form/ItemLabel/ItemLabelCommon.scss
@@ -9,14 +9,26 @@
     "more more";
   grid-template-columns: 1fr auto;
   place-items: end start;
-  row-gap: calc(2 / var(--font-size-base) * 1rem);
-
-  &:has(> .af-item-label__description) {
-    row-gap: calc(4 / var(--font-size-base) * 1rem);
-  }
+  row-gap: calc(4 / var(--font-size-base) * 1rem);
 
   &:has(> .af-item-label__sidebutton) {
     column-gap: calc(12 / var(--font-size-base) * 1rem);
+  }
+
+  &:not(:has(> .af-item-label__description), * ~ .af-item-label__more) {
+    grid-template-areas: "label sidebutton";
+  }
+
+  &:not(:has(> .af-item-label__more)):has(* ~ .af-item-label__description) {
+    grid-template-areas:
+      "label sidebutton"
+      "description sidebutton";
+  }
+
+  &:not(:has(> .af-item-label__description)):has(* ~ .af-item-label__more) {
+    grid-template-areas:
+      "label sidebutton"
+      "more more";
   }
 
   > label {


### PR DESCRIPTION
fix vertical spacing when elements missing

<img width="582" alt="image" src="https://github.com/user-attachments/assets/8ba2fa23-f12f-4933-a3ea-d5950946c835" />

<img width="584" alt="image" src="https://github.com/user-attachments/assets/73c160c9-96a9-4ebc-a822-a449f398a3e2" />

<img width="584" alt="image" src="https://github.com/user-attachments/assets/87335893-ef03-447e-96f7-1ce43102954f" />

<img width="582" alt="image" src="https://github.com/user-attachments/assets/885afdfe-e0f8-4d8e-8686-8a487f0f9c28" />


