### PR TITLE
feat(apollo): used af-item-label__label class name to style label instead of the label html tag

### DIFF
--- a/client/apollo/css/src/Form/ItemLabel/ItemLabelCommon.scss
+++ b/client/apollo/css/src/Form/ItemLabel/ItemLabelCommon.scss
@@ -31,7 +31,7 @@
       "more more";
   }
 
-  > label {
+  &__label {
     grid-area: label;
     font-size: calc(16 / var(--font-size-base) * 1rem);
     font-weight: 600;

--- a/client/apollo/react/src/Form/ItemLabel/ItemLabelCommon.tsx
+++ b/client/apollo/react/src/Form/ItemLabel/ItemLabelCommon.tsx
@@ -44,6 +44,7 @@ export const ItemLabel = ({
           htmlFor={inputId}
           id={idLabel}
           aria-describedby={description ? idDescription : undefined}
+          className="af-item-label__label"
         >
           {label} {required && <span aria-hidden="true"> *</span>}
         </label>


### PR DESCRIPTION
ajout du nom de classe af-item-label__label pour permettre la réutilisation des styles