### PR TITLE
feat(apollo,look&feel): button padding and focus

### DIFF
--- a/client/apollo/css/src/Button/ButtonApollo.scss
+++ b/client/apollo/css/src/Button/ButtonApollo.scss
@@ -10,13 +10,11 @@
   --button-radius: var(--radius-32);
   --button-shadow-color: var(--axa-blue-100);
   --button-padding: calc(12 / var(--font-size-base) * 1rem)
-    calc(16 / var(--font-size-base) * 1rem);
+    calc(24 / var(--font-size-base) * 1rem);
   --button-line-height: calc(24 / var(--font-size-base) * 1rem);
   --button-font-size: calc(16 / var(--font-size-base) * 1rem);
 
   @media (width > #{breakpoints.$breakpoint-lg}) {
-    --button-padding: calc(12 / var(--font-size-base) * 1rem)
-      calc(24 / var(--font-size-base) * 1rem);
     --button-line-height: calc(32 / var(--font-size-base) * 1rem);
     --button-font-size: calc(18 / var(--font-size-base) * 1rem);
   }
@@ -45,14 +43,14 @@
     --button-bg-color-default: var(--warning-100);
     --button-text-color-default: var(--white);
 
-    &:active {
-      --button-bg-color-default: var(--warning-80);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-bg-color-default: var(--warning-120);
+    }
+
+    &:active {
+      --button-bg-color-default: var(--warning-80);
     }
   }
 
@@ -60,16 +58,16 @@
     --button-bg-color-default: var(--white);
     --button-text-color-default: var(--axa-blue-100);
 
-    &:active {
-      --button-bg-color-default: var(--neutral-5);
-      --button-text-color-default: var(--axa-blue-80);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-bg-color-default: var(--neutral-14);
       --button-text-color-default: var(--axa-blue-120);
+    }
+
+    &:active {
+      --button-bg-color-default: var(--neutral-5);
+      --button-text-color-default: var(--axa-blue-80);
     }
   }
 
@@ -78,15 +76,15 @@
     --button-text-color-default: var(--axa-blue-100);
     --button-padding: 0;
 
-    &:active {
-      --button-text-color-default: var(--axa-blue-80);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-text-color-default: var(--axa-blue-120);
       --button-bg-color-default: transparent;
+    }
+
+    &:active {
+      --button-text-color-default: var(--axa-blue-80);
     }
 
     &:disabled,
@@ -99,18 +97,18 @@
     --button-bg-color-default: var(--white);
     --button-text-color-default: var(--axa-blue-100);
 
-    &:active {
-      --button-bg-color-default: var(--axa-blue-80);
-      --button-text-color-default: var(--white);
-      --button-shadow-color: var(--axa-blue-80);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-bg-color-default: var(--axa-blue-120);
       --button-text-color-default: var(--white);
       --button-shadow-color: var(--axa-blue-120);
+    }
+
+    &:active {
+      --button-bg-color-default: var(--axa-blue-80);
+      --button-text-color-default: var(--white);
+      --button-shadow-color: var(--axa-blue-80);
     }
   }
 
@@ -119,12 +117,6 @@
     --button-text-color-default: var(--white);
     --button-shadow-color: var(--white);
 
-    &:active {
-      --button-bg-color-default: var(--neutral-5);
-      --button-text-color-default: var(--axa-blue-80);
-      --button-shadow-color: var(--neutral-5);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
@@ -132,21 +124,27 @@
       --button-text-color-default: var(--axa-blue-120);
       --button-shadow-color: var(--neutral-14);
     }
+
+    &:active {
+      --button-bg-color-default: var(--neutral-5);
+      --button-text-color-default: var(--axa-blue-80);
+      --button-shadow-color: var(--neutral-5);
+    }
   }
 
   &--tertiary {
     --button-bg-color-default: var(--axa-blue-8);
     --button-text-color-default: var(--axa-blue-100);
 
-    &:active {
-      --button-bg-color-default: var(--axa-blue-80);
-      --button-text-color-default: var(--white);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-bg-color-default: var(--axa-blue-120);
+      --button-text-color-default: var(--white);
+    }
+
+    &:active {
+      --button-bg-color-default: var(--axa-blue-80);
       --button-text-color-default: var(--white);
     }
   }

--- a/client/apollo/css/src/Button/ButtonCommon.scss
+++ b/client/apollo/css/src/Button/ButtonCommon.scss
@@ -1,5 +1,3 @@
-/* Apollo first and mobile first approch */
-
 @use "../common/breakpoints" as breakpoints;
 
 .af-btn-client {
@@ -9,18 +7,22 @@
   border-radius: var(--button-radius);
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: calc(12 / var(--font-size-base) * 1rem);
   font-family: var(--font-family-base);
   font-size: var(--button-font-size);
   font-weight: 600;
   line-height: var(--button-line-height);
   color: var(--button-text-color-default);
   background-color: var(--button-bg-color-default);
-  transition-duration: var(--transition-duration);
+  transition-duration: var(--transition-duration, 150ms);
   transition-property:
     width, height, border, color, background-color, outline, box-shadow;
   transition-timing-function: linear;
   user-select: none;
+
+  &:focus {
+    outline-color: transparent;
+  }
 
   &:focus-visible {
     outline: 2px solid var(--button-outline-color);

--- a/client/apollo/css/src/Button/ButtonLF.scss
+++ b/client/apollo/css/src/Button/ButtonLF.scss
@@ -7,14 +7,14 @@
   --button-text-color-default: var(--color-white);
   --button-radius: var(--radius-8);
   --button-shadow-color: var(--color-axa);
-  --button-padding: calc(16 / var(--font-size-base) * 1rem)
-    calc(61.5 / var(--font-size-base) * 1rem);
-  --button-line-height: calc(20 / var(--font-size-base) * 1rem);
+  --button-padding: calc(16 / var(--font-size-base) * 1rem);
+  --button-line-height: calc(24 / var(--font-size-base) * 1rem);
   --button-font-size: calc(16 / var(--font-size-base) * 1rem);
 
   @media (width > #{breakpoints.$breakpoint-lg}) {
-    --button-line-height: calc(22.5 / var(--font-size-base) * 1rem);
     --button-font-size: calc(18 / var(--font-size-base) * 1rem);
+    --button-padding: calc(16 / var(--font-size-base) * 1rem)
+      calc(24 / var(--font-size-base) * 1rem);
   }
 
   &:hover {
@@ -53,16 +53,16 @@
     --button-text-color-default: var(--color-axa);
     --button-bg-color-default: var(--color-white);
 
-    &:active {
-      --button-bg-color-default: var(--color-white);
-      --button-text-color-default: var(--color-btn-business-light);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-bg-color-default: var(--color-white);
       --button-text-color-default: var(--color-blue-1);
+    }
+
+    &:active {
+      --button-bg-color-default: var(--color-white);
+      --button-text-color-default: var(--color-btn-business-light);
     }
   }
 
@@ -75,15 +75,15 @@
       --button-font-size: calc(16 / var(--font-size-base) * 1rem);
     }
 
-    &:active {
-      --button-text-color-default: var(--color-btn-light);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-text-color-default: var(--color-blue-1);
       --button-bg-color-default: transparent;
+    }
+
+    &:active {
+      --button-text-color-default: var(--color-btn-light);
     }
 
     &:disabled,
@@ -121,18 +121,18 @@
 
     box-shadow: 0 0 0 2px var(--button-shadow-color) inset;
 
-    &:active {
-      --button-bg-color-default: var(--color-gray-200);
-      --button-text-color-default: var(--color-btn-light);
-      --button-shadow-color: var(--color-gray-200);
-    }
-
     &:hover,
     &:focus,
     &:focus-visible {
       --button-bg-color-default: var(--color-gray-400);
       --button-text-color-default: var(--color-blue-1);
       --button-shadow-color: var(--color-gray-400);
+    }
+
+    &:active {
+      --button-bg-color-default: var(--color-gray-200);
+      --button-text-color-default: var(--color-btn-light);
+      --button-shadow-color: var(--color-gray-200);
     }
   }
 


### PR DESCRIPTION
Retours UX

- l'espacement entre le texte et l'icône doit être de 12 px au lieu de 16 px.
- L’état "active" est manquant sur tous les buttons, à l'exception du button primaire.
- La hauteur des Primary, Secondary, Tertiary doivent être à minimum 56px (mob et desk)
- Sur Look&Feel, le padding devrait être de 24px sur desk et 16px sur mobile. 
   Sur Apollo le padding devrait etre de 24px partout