### PR TITLE
fix(design-system): jsdoc is exported alongside components

### DIFF
--- a/client/apollo/react/tsconfig.json
+++ b/client/apollo/react/tsconfig.json
@@ -64,7 +64,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    "removeComments": true /* Disable emitting comments. */,
+    "removeComments": false /* We want to keep the JSDoc. */,
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */

--- a/samples/vite/src/Agent.tsx
+++ b/samples/vite/src/Agent.tsx
@@ -13,6 +13,7 @@ import {
   Name,
   Paging,
   Popover,
+  SelectBase,
   SliderInput,
   Svg,
   THead,
@@ -255,6 +256,11 @@ const Agent = () => {
         >
           Title with content
         </Title>
+      </article>
+
+      <article>
+        <Title heading="h3">Deprecated stuff</Title>
+        <SelectBase />
       </article>
     </section>
   );

--- a/slash/react/tsconfig.json
+++ b/slash/react/tsconfig.json
@@ -60,7 +60,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    "removeComments": true /* Disable emitting comments. */,
+    "removeComments": false /* We want to keep the JSDoc. */,
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */


### PR DESCRIPTION
JSDoc was stripped during the build, and therefore information such as deprecation warning was not available when installing the packages.

I've changed the tsconfig file to keep these comments.
