### PR TITLE
Add production visibility control and generic prop to DebugGrid, fix console warning

### DIFF
--- a/apps/apollo-stories/src/fondations/Grid/DebugGrid.mdx
+++ b/apps/apollo-stories/src/fondations/Grid/DebugGrid.mdx
@@ -5,9 +5,12 @@ import * as DebugGridStories from "./DebugGrid.stories.tsx";
 
 ## DebugGrid
 
-Le composant DebuGrid permettant de visualiser les grilles du Design System est disponible (Il complète l'outil du navigateur).
+The DebugGrid component allows you to visualize the Design System grids (it complements the browser tool).
 
-Ce composant reprend les codes couleurs utilisés sur les maquettes et affiche les breakpoints en fonction de la taille de l'écran.
+This component uses the color codes from the mockups and displays the breakpoints according to the screen size.
+
+> **Info**
+> The DebugGrid component automatically hides itself in production mode.
 
 <Canvas of={DebugGridStories.Default} />
 <Controls of={DebugGridStories.Default} />

--- a/apps/apollo-stories/src/fondations/Grid/DebugGrid.stories.tsx
+++ b/apps/apollo-stories/src/fondations/Grid/DebugGrid.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 export const Default: StoryObj = {
   render: () => (
     <div style={{ height: "100svh", display: "block" }}>
-      <DebugGrid<{ forceVisible?: boolean }> isCheckedByDefaul forceVisible />
+      <DebugGrid<{ forceVisible?: boolean }> isCheckedByDefault forceVisible />
     </div>
   ),
 };

--- a/apps/apollo-stories/src/fondations/Grid/DebugGrid.stories.tsx
+++ b/apps/apollo-stories/src/fondations/Grid/DebugGrid.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 export const Default: StoryObj = {
   render: () => (
     <div style={{ height: "100svh", display: "block" }}>
-      <DebugGrid isCheckedByDefault />
+      <DebugGrid<{ forceVisible?: boolean }> isCheckedByDefaul forceVisible />
     </div>
   ),
 };

--- a/apps/look-and-feel-stories/src/fondations/Grid/DebugGrid.mdx
+++ b/apps/look-and-feel-stories/src/fondations/Grid/DebugGrid.mdx
@@ -5,9 +5,12 @@ import * as DebugGridStories from "./DebugGrid.stories.tsx";
 
 ## DebugGrid
 
-Le composant DebuGrid permettant de visualiser les grilles du Design System est disponible (Il complète l'outil du navigateur).
+The DebugGrid component allows you to visualize the Design System grids (it complements the browser tool).
 
-Ce composant reprend les codes couleurs utilisés sur les maquettes et affiche les breakpoints en fonction de la taille de l'écran.
+This component uses the color codes from the mockups and displays the breakpoints according to the screen size.
+
+> **Info**
+> The DebugGrid component automatically hides itself in production mode.
 
 <Canvas of={DebugGridStories.Default} />
 <Controls of={DebugGridStories.Default} />

--- a/apps/look-and-feel-stories/src/fondations/Grid/DebugGrid.stories.tsx
+++ b/apps/look-and-feel-stories/src/fondations/Grid/DebugGrid.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 export const Default: StoryObj = {
   render: () => (
     <div style={{ height: "100svh", display: "block" }}>
-      <DebugGrid<{ forceVisible?: boolean }> isCheckedByDefaul forceVisible />
+      <DebugGrid<{ forceVisible?: boolean }> isCheckedByDefault forceVisible />
     </div>
   ),
 };

--- a/apps/look-and-feel-stories/src/fondations/Grid/DebugGrid.stories.tsx
+++ b/apps/look-and-feel-stories/src/fondations/Grid/DebugGrid.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 export const Default: StoryObj = {
   render: () => (
     <div style={{ height: "100svh", display: "block" }}>
-      <DebugGrid isCheckedByDefault />
+      <DebugGrid<{ forceVisible?: boolean }> isCheckedByDefaul forceVisible />
     </div>
   ),
 };

--- a/client/apollo/react/src/Grid/DebugGridApollo.tsx
+++ b/client/apollo/react/src/Grid/DebugGridApollo.tsx
@@ -1,18 +1,29 @@
-import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
 import { useState } from "react";
 import { CardCheckbox } from "../Form/Checkbox/CardCheckbox/CardCheckboxApollo";
 import { DebugGridCommon } from "./DebugGridCommon";
 
-export const DebugGrid = ({
-  cols = 12,
-  isCheckedByDefault = false,
-}: {
+import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+
+type DebugGridProps<P = object> = P & {
   cols?: number;
   isCheckedByDefault?: boolean;
-}) => {
+};
+
+export const DebugGrid = <P = object,>({
+  cols = 12,
+  isCheckedByDefault = false,
+  ...props
+}: DebugGridProps<P>) => {
   const [checked, setChecked] = useState(isCheckedByDefault);
 
   const handleChecked = () => setChecked(!checked);
+
+  const forceVisible =
+    (props as { forceVisible?: boolean })?.forceVisible || false;
+  if (process.env.NODE_ENV === "production" && !forceVisible) {
+    return null;
+  }
+
   return (
     <>
       <CardCheckbox

--- a/client/apollo/react/src/Grid/DebugGridApollo.tsx
+++ b/client/apollo/react/src/Grid/DebugGridApollo.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { CardCheckbox } from "../Form/Checkbox/CardCheckbox/CardCheckboxApollo";
 import { DebugGridCommon } from "./DebugGridCommon";
 
@@ -14,10 +13,6 @@ export const DebugGrid = <P = object,>({
   isCheckedByDefault = false,
   ...props
 }: DebugGridProps<P>) => {
-  const [checked, setChecked] = useState(isCheckedByDefault);
-
-  const handleChecked = () => setChecked(!checked);
-
   const forceVisible =
     (props as { forceVisible?: boolean })?.forceVisible || false;
   if (process.env.NODE_ENV === "production" && !forceVisible) {
@@ -32,8 +27,7 @@ export const DebugGrid = <P = object,>({
           {
             name: "debuggrid",
             label: "Grid",
-            checked,
-            onClick: handleChecked,
+            defaultChecked: isCheckedByDefault,
           },
         ]}
       />

--- a/client/apollo/react/src/Grid/DebugGridApollo.tsx
+++ b/client/apollo/react/src/Grid/DebugGridApollo.tsx
@@ -1,38 +1,13 @@
 import { CardCheckbox } from "../Form/Checkbox/CardCheckbox/CardCheckboxApollo";
-import { DebugGridCommon } from "./DebugGridCommon";
+import { DebugGridCommon, type DebugGridCommonProps } from "./DebugGridCommon";
 
-import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+type DebugGridProps<P = object> = Omit<DebugGridCommonProps<P>, "CardCheckbox">;
 
-type DebugGridProps<P = object> = P & {
-  cols?: number;
-  isCheckedByDefault?: boolean;
-};
-
-export const DebugGrid = <P = object,>({
-  cols = 12,
-  isCheckedByDefault = false,
-  ...props
-}: DebugGridProps<P>) => {
-  const forceVisible =
-    (props as { forceVisible?: boolean })?.forceVisible || false;
-  if (process.env.NODE_ENV === "production" && !forceVisible) {
-    return null;
-  }
-
+export const DebugGrid = <P = object,>({ ...props }: DebugGridProps<P>) => {
   return (
-    <>
-      <CardCheckbox
-        type="horizontal"
-        options={[
-          {
-            name: "debuggrid",
-            label: "Grid",
-            defaultChecked: isCheckedByDefault,
-          },
-        ]}
-      />
-
-      <DebugGridCommon cols={cols} />
-    </>
+    <DebugGridCommon
+      {...props}
+      CardCheckbox={CardCheckbox as DebugGridCommonProps<P>["CardCheckbox"]}
+    />
   );
 };

--- a/client/apollo/react/src/Grid/DebugGridCommon.tsx
+++ b/client/apollo/react/src/Grid/DebugGridCommon.tsx
@@ -1,13 +1,48 @@
 import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+import type { ComponentProps, ComponentType } from "react";
+import type { CardCheckboxCommon } from "../Form/Checkbox/CardCheckbox/CardCheckboxCommon";
 
-export const DebugGridCommon = ({ cols = 12 }: { cols?: number }) => {
+export type DebugGridCommonProps<P = object> = P & {
+  cols?: number;
+  isCheckedByDefault?: boolean;
+  CardCheckbox: ComponentType<
+    Partial<ComponentProps<typeof CardCheckboxCommon>>
+  >;
+};
+
+export const DebugGridCommon = <P = object,>({
+  cols = 12,
+  isCheckedByDefault = false,
+  CardCheckbox,
+  ...props
+}: DebugGridCommonProps<P>) => {
+  // The forceVisible prop is a hidden prop to force the component's visibility when building the storybook
+  const forceVisible =
+    (props as { forceVisible?: boolean })?.forceVisible || false;
+  if (process.env.NODE_ENV === "production" && !forceVisible) {
+    return null;
+  }
+
   return (
-    <div className="debug-grid">
-      <div className="grid">
-        {[...Array(cols).keys()].map((col: number) => (
-          <div key={col} className="cols" />
-        ))}
+    <>
+      <CardCheckbox
+        type="horizontal"
+        options={[
+          {
+            name: "debuggrid",
+            label: "Grid",
+            defaultChecked: isCheckedByDefault,
+          },
+        ]}
+      />
+
+      <div className="debug-grid">
+        <div className="grid">
+          {[...Array(cols).keys()].map((col: number) => (
+            <div key={col} className="cols" />
+          ))}
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/client/apollo/react/src/Grid/DebugGridCommon.tsx
+++ b/client/apollo/react/src/Grid/DebugGridCommon.tsx
@@ -36,7 +36,7 @@ export const DebugGridCommon = <P = object,>({
         ]}
       />
 
-      <div className="debug-grid">
+      <div className="debug-grid" role="presentation">
         <div className="grid">
           {[...Array(cols).keys()].map((col: number) => (
             <div key={col} className="cols" />

--- a/client/apollo/react/src/Grid/DebugGridLF.tsx
+++ b/client/apollo/react/src/Grid/DebugGridLF.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { CardCheckbox } from "../Form/Checkbox/CardCheckbox/CardCheckboxLF";
 import { DebugGridCommon } from "./DebugGridCommon";
 
@@ -14,10 +13,6 @@ export const DebugGrid = <P = object,>({
   isCheckedByDefault = false,
   ...props
 }: DebugGridProps<P>) => {
-  const [checked, setChecked] = useState(isCheckedByDefault);
-
-  const handleChecked = () => setChecked(!checked);
-
   const forceVisible =
     (props as { forceVisible?: boolean })?.forceVisible || false;
   if (process.env.NODE_ENV === "production" && !forceVisible) {
@@ -32,8 +27,7 @@ export const DebugGrid = <P = object,>({
           {
             name: "debuggrid",
             label: "Grid",
-            checked,
-            onClick: handleChecked,
+            defaultChecked: isCheckedByDefault,
           },
         ]}
       />

--- a/client/apollo/react/src/Grid/DebugGridLF.tsx
+++ b/client/apollo/react/src/Grid/DebugGridLF.tsx
@@ -1,18 +1,28 @@
-import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
 import { useState } from "react";
 import { CardCheckbox } from "../Form/Checkbox/CardCheckbox/CardCheckboxLF";
 import { DebugGridCommon } from "./DebugGridCommon";
 
-export const DebugGrid = ({
-  cols = 12,
-  isCheckedByDefault = false,
-}: {
+import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+
+type DebugGridProps<P = object> = P & {
   cols?: number;
   isCheckedByDefault?: boolean;
-}) => {
+};
+
+export const DebugGrid = <P = object,>({
+  cols = 12,
+  isCheckedByDefault = false,
+  ...props
+}: DebugGridProps<P>) => {
   const [checked, setChecked] = useState(isCheckedByDefault);
 
   const handleChecked = () => setChecked(!checked);
+
+  const forceVisible =
+    (props as { forceVisible?: boolean })?.forceVisible || false;
+  if (process.env.NODE_ENV === "production" && !forceVisible) {
+    return null;
+  }
 
   return (
     <>

--- a/client/apollo/react/src/Grid/DebugGridLF.tsx
+++ b/client/apollo/react/src/Grid/DebugGridLF.tsx
@@ -1,38 +1,13 @@
 import { CardCheckbox } from "../Form/Checkbox/CardCheckbox/CardCheckboxLF";
-import { DebugGridCommon } from "./DebugGridCommon";
+import { DebugGridCommon, type DebugGridCommonProps } from "./DebugGridCommon";
 
-import "@axa-fr/design-system-apollo-css/dist/Grid/DebugGrid.scss";
+type DebugGridProps<P = object> = Omit<DebugGridCommonProps<P>, "CardCheckbox">;
 
-type DebugGridProps<P = object> = P & {
-  cols?: number;
-  isCheckedByDefault?: boolean;
-};
-
-export const DebugGrid = <P = object,>({
-  cols = 12,
-  isCheckedByDefault = false,
-  ...props
-}: DebugGridProps<P>) => {
-  const forceVisible =
-    (props as { forceVisible?: boolean })?.forceVisible || false;
-  if (process.env.NODE_ENV === "production" && !forceVisible) {
-    return null;
-  }
-
+export const DebugGrid = <P = object,>({ ...props }: DebugGridProps<P>) => {
   return (
-    <>
-      <CardCheckbox
-        type="horizontal"
-        options={[
-          {
-            name: "debuggrid",
-            label: "Grid",
-            defaultChecked: isCheckedByDefault,
-          },
-        ]}
-      />
-
-      <DebugGridCommon cols={cols} />
-    </>
+    <DebugGridCommon
+      {...props}
+      CardCheckbox={CardCheckbox as DebugGridCommonProps<P>["CardCheckbox"]}
+    />
   );
 };

--- a/client/apollo/react/src/Grid/__tests__/DebugGrid.test.tsx
+++ b/client/apollo/react/src/Grid/__tests__/DebugGrid.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CardCheckbox } from "../../Form/Checkbox/CardCheckbox/CardCheckboxApollo";
+import { DebugGridCommon, type DebugGridCommonProps } from "../DebugGridCommon";
+
+describe("DebugGridCommon", () => {
+  it("should render CardCheckbox checked when isCheckedByDefault is true", () => {
+    render(
+      <DebugGridCommon
+        CardCheckbox={CardCheckbox as DebugGridCommonProps["CardCheckbox"]}
+        isCheckedByDefault
+      />,
+    );
+    const cardCheckbox = screen.getByRole("checkbox");
+    expect(cardCheckbox).toBeInTheDocument();
+    expect(cardCheckbox).toBeChecked();
+  });
+
+  it("should render CardCheckbox unchecked by default", () => {
+    render(
+      <DebugGridCommon
+        CardCheckbox={CardCheckbox as DebugGridCommonProps["CardCheckbox"]}
+      />,
+    );
+    const cardCheckbox = screen.getByRole("checkbox");
+    expect(cardCheckbox).toBeInTheDocument();
+    expect(cardCheckbox).not.toBeChecked();
+  });
+
+  it("should not render DebugGrid in production without forceVisible", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    render(
+      <DebugGridCommon
+        CardCheckbox={CardCheckbox as DebugGridCommonProps["CardCheckbox"]}
+      />,
+    );
+    const cardCheckbox = screen.queryByRole("checkbox");
+    expect(cardCheckbox).not.toBeInTheDocument();
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it("should render DebugGrid in production when forceVisible is true", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    render(
+      <DebugGridCommon<{ forceVisible?: boolean }>
+        CardCheckbox={CardCheckbox as DebugGridCommonProps["CardCheckbox"]}
+        forceVisible
+      />,
+    );
+
+    const cardCheckbox = screen.getByRole("checkbox");
+    expect(cardCheckbox).toBeInTheDocument();
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it("should render the correct number of columns when cols prop is set", () => {
+    render(
+      <DebugGridCommon
+        CardCheckbox={CardCheckbox as DebugGridCommonProps["CardCheckbox"]}
+        cols={5}
+      />,
+    );
+    const grid = screen.getByRole("presentation");
+    const cols = grid.querySelectorAll(".cols");
+    expect(cols).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
**Description:**  
This PR introduces several improvements to the `DebugGrid` component:

- **Production visibility control:**  
  The `DebugGrid` is now hidden in production by default.

- **Generic prop hack for Storybook:**  
  A generic type parameter has been added to `DebugGrid` to allow passing the `forceVisible` prop in Storybook stories. This is a workaround to satisfy TypeScript and Storybook constraints.

- **State simplification and warning fix:**  
  The internal state management for the checkbox has been simplified. The `checked` prop has been replaced with `defaultChecked` to fix the React warning:  
  _"You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`."_

These changes improve the developer experience and prevent unwanted warnings in the console.