### PR TITLE
Add `titleLevel` prop to customize heading level

### DIFF
--- a/client/apollo/react/src/Stepper/StepperCommon.tsx
+++ b/client/apollo/react/src/Stepper/StepperCommon.tsx
@@ -1,4 +1,9 @@
-import { ComponentType, HTMLAttributes, useId } from "react";
+import {
+  ComponentType,
+  type ElementType,
+  type HTMLAttributes,
+  useId,
+} from "react";
 import { ProgressBarGroupProps } from "../ProgressBarGroup/ProgressBarGroupCommon";
 import { ItemMessage } from "../Form/ItemMessage/ItemMessageCommon";
 
@@ -10,6 +15,7 @@ export type StepperProps = {
   nbSteps?: 3 | 4 | 5 | 6 | 7 | 8;
   helper?: string;
   message?: string;
+  titleLevel?: 1 | 2 | 3;
   ProgressBarGroupComponent: ComponentType<
     Omit<ProgressBarGroupProps, "ProgressBarComponent">
   >;
@@ -25,16 +31,20 @@ export const Stepper = ({
   ProgressBarGroupComponent,
   helper,
   message,
+  titleLevel = 2,
   ...props
 }: StepperProps) => {
   const stepperId = useId();
+  const Title = `h${titleLevel}` as ElementType<
+    HTMLAttributes<HTMLHeadingElement>
+  >;
 
   return (
     <div className="af-stepper" {...props}>
       <div className="af-stepper__header">
-        <h2 className="af-stepper__title" aria-describedby={stepperId}>
+        <Title className="af-stepper__title" aria-describedby={stepperId}>
           {currentTitle}
-        </h2>
+        </Title>
         {Boolean(currentSubtitle) && (
           <p className="af-stepper__subtitle">{currentSubtitle}</p>
         )}

--- a/client/apollo/react/src/Stepper/__tests__/StepperCommon.test.tsx
+++ b/client/apollo/react/src/Stepper/__tests__/StepperCommon.test.tsx
@@ -94,4 +94,27 @@ describe("Stepper Component", () => {
     const progressBarGroup = screen.getByRole("group");
     expect(progressBarGroup).toHaveClass("custom-class");
   });
+
+  it.each([
+    [1, "H1"],
+    [2, "H2"],
+    [3, "H3"],
+  ])(
+    "should render the title as a %s according to titleLevel prop",
+    (level, tag) => {
+      render(
+        <Stepper
+          currentStep={1}
+          currentTitle={`Step Title ${tag}`}
+          nbSteps={4}
+          ProgressBarGroupComponent={ProgressBarGroup}
+          titleLevel={level as 1 | 2 | 3}
+        />,
+      );
+      const heading = screen.getByRole("heading", {
+        name: `Step Title ${tag}`,
+      });
+      expect(heading.tagName).toStrictEqual(tag);
+    },
+  );
 });


### PR DESCRIPTION
**Description:**  
This PR introduces a new `titleLevel` prop to the `Stepper` component, allowing consumers to specify the heading level (`h1`, `h2`, or `h3`) for the stepper title. This improves accessibility and flexibility when integrating the component into different page structures.

**Changes:**
- Added `titleLevel?: 1 | 2 | 3` to `StepperProps`.
- The stepper title is now rendered as the corresponding heading element (`h1`, `h2`, or `h3`) based on the `titleLevel` prop (default: `h2`).
- Updated tests to cover the new prop and ensure correct heading rendering.

**Motivation:**
This change allows better semantic structuring of pages and improves accessibility by letting users choose the appropriate heading level for the stepper title.

**Checklist:**
- [x] New prop is documented in the code
- [x] Unit tests updated and passing
- [x] No breaking changes

Let me know if you need any adjustments!