### PR TITLE
Fix Storybook Publish CI Condition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,7 +153,7 @@ jobs:
           destination_dir: ${{ matrix.storybook.destination_dir }}/next
 
       - name: Upload the ${{ matrix.storybook.name }} storybook version latest
-        if: matrix.storybook.isStableRelease == 'true'
+        if: matrix.storybook.isStable == 'true'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
           destination_dir: ${{ matrix.storybook.destination_dir }}/latest
 
       - name: Upload the ${{ matrix.storybook.name }} storybook version ${{ matrix.storybook.version }}
-        if: matrix.storybook.isStableRelease == 'true'
+        if: matrix.storybook.isStable == 'true'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes an issue in the CI workflow for publishing Storybook.
The condition for uploading the "latest" and versioned Storybook was incorrectly checking isStableRelease instead of isStable in the matrix.
This update ensures that the correct condition is used, allowing the Storybook to be published as expected during stable releases.