### PR TITLE
feat(slash): refactor headerTitle to add contentLeft and informations next to the title

### DIFF
--- a/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.mdx
+++ b/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.mdx
@@ -39,9 +39,10 @@ export default TitleComponent;
 <Canvas of={HeaderTitleStories.ComplexTitle} />
 <Controls of={HeaderTitleStories.ComplexTitle} />
 
-### Complex Title with ContentLeft
+### Complex Title with Content and Children
 
-When you need to add an action to the title to handle a back button for example, you can use the `contentLeft` property. The property accepts a ReactNode to give you the flexibility to add any content you want.
+When you need to handle a navigation action , a back button for example, you can use the `contentLeft` property. For other others actions you should put them the right side of the title bar with the `contentRight` property. Passing children allows you to add additional content after the title and subtitle.
+The properties accepts a ReactNode to give you the flexibility to add any content you want.
 
-<Canvas of={HeaderTitleStories.ComplexTitleWithContentLeft} />
-<Controls of={HeaderTitleStories.ComplexTitleWithContentLeft} />
+<Canvas of={HeaderTitleStories.ComplexTitleWithContentAndChildren} />
+<Controls of={HeaderTitleStories.ComplexTitleWithContentAndChildren} />

--- a/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.mdx
+++ b/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.mdx
@@ -38,3 +38,8 @@ export default TitleComponent;
 
 <Canvas of={HeaderTitleStories.ComplexTitle} />
 <Controls of={HeaderTitleStories.ComplexTitle} />
+
+### Complex Title with LefSection
+
+<Canvas of={HeaderTitleStories.ComplexTitleWithLeftSection} />
+<Controls of={HeaderTitleStories.ComplexTitleWithLeftSection} />

--- a/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.mdx
+++ b/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.mdx
@@ -39,7 +39,9 @@ export default TitleComponent;
 <Canvas of={HeaderTitleStories.ComplexTitle} />
 <Controls of={HeaderTitleStories.ComplexTitle} />
 
-### Complex Title with LefSection
+### Complex Title with ContentLeft
 
-<Canvas of={HeaderTitleStories.ComplexTitleWithLeftSection} />
-<Controls of={HeaderTitleStories.ComplexTitleWithLeftSection} />
+When you need to add an action to the title to handle a back button for example, you can use the `contentLeft` property. The property accepts a ReactNode to give you the flexibility to add any content you want.
+
+<Canvas of={HeaderTitleStories.ComplexTitleWithContentLeft} />
+<Controls of={HeaderTitleStories.ComplexTitleWithContentLeft} />

--- a/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.stories.tsx
+++ b/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.stories.tsx
@@ -1,4 +1,9 @@
-import { Action, HeaderTitle, Svg } from "@axa-fr/design-system-slash-react";
+import {
+  Action,
+  Badge,
+  HeaderTitle,
+  Svg,
+} from "@axa-fr/design-system-slash-react";
 import deleteIcon from "@material-symbols/svg-400/outlined/delete.svg";
 import mailIcon from "@material-symbols/svg-400/outlined/mail.svg";
 import saveIcon from "@material-symbols/svg-400/outlined/save.svg";
@@ -67,7 +72,7 @@ export const DefaultTitle: StoryObj<typeof HeaderTitle> = {};
 
 export const ComplexTitle: StoryObj<typeof HeaderTitle> = {
   args: {
-    children: (
+    contentRight: (
       <div className="af-title-bar__actions">
         {actions.map(({ icon, id, title }: ComponentProps<typeof Action>) => (
           <a
@@ -85,39 +90,41 @@ export const ComplexTitle: StoryObj<typeof HeaderTitle> = {
   },
 };
 
-export const ComplexTitleWithContentLeft: StoryObj<typeof HeaderTitle> = {
-  args: {
-    contentLeft: (
-      <div className="af-title-bar__actions">
-        {leftActions.map(
-          ({ icon, id, title }: ComponentProps<typeof Action>) => (
+export const ComplexTitleWithContentAndChildren: StoryObj<typeof HeaderTitle> =
+  {
+    args: {
+      contentLeft: (
+        <div className="af-title-bar__actions">
+          {leftActions.map(
+            ({ icon, id, title }: ComponentProps<typeof Action>) => (
+              <a
+                key={id}
+                href="/#"
+                role="button"
+                title={title}
+                className="btn  af-btn--circle"
+              >
+                <Svg src={icon} />
+              </a>
+            ),
+          )}
+        </div>
+      ),
+      children: <Badge classModifier="success"> Statut OK </Badge>,
+      contentRight: (
+        <div className="af-title-bar__actions">
+          {actions.map(({ icon, id, title }: ComponentProps<typeof Action>) => (
             <a
               key={id}
               href="/#"
               role="button"
               title={title}
-              className="btn  af-btn--circle"
+              className="btn af-btn--circle"
             >
               <Svg src={icon} />
             </a>
-          ),
-        )}
-      </div>
-    ),
-    children: (
-      <div className="af-title-bar__actions">
-        {actions.map(({ icon, id, title }: ComponentProps<typeof Action>) => (
-          <a
-            key={id}
-            href="/#"
-            role="button"
-            title={title}
-            className="btn af-btn--circle"
-          >
-            <Svg src={icon} />
-          </a>
-        ))}
-      </div>
-    ),
-  },
-};
+          ))}
+        </div>
+      ),
+    },
+  };

--- a/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.stories.tsx
+++ b/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.stories.tsx
@@ -85,9 +85,9 @@ export const ComplexTitle: StoryObj<typeof HeaderTitle> = {
   },
 };
 
-export const ComplexTitleWithLeftSection: StoryObj<typeof HeaderTitle> = {
+export const ComplexTitleWithContentLeft: StoryObj<typeof HeaderTitle> = {
   args: {
-    leftSection: (
+    contentLeft: (
       <div className="af-title-bar__actions">
         {leftActions.map(
           ({ icon, id, title }: ComponentProps<typeof Action>) => (

--- a/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.stories.tsx
+++ b/apps/slash-stories/src/Layout/HeaderTitle/HeaderTitle.stories.tsx
@@ -2,6 +2,8 @@ import { Action, HeaderTitle, Svg } from "@axa-fr/design-system-slash-react";
 import deleteIcon from "@material-symbols/svg-400/outlined/delete.svg";
 import mailIcon from "@material-symbols/svg-400/outlined/mail.svg";
 import saveIcon from "@material-symbols/svg-400/outlined/save.svg";
+import homeIcon from "@material-symbols/svg-400/outlined/home.svg";
+import chevronLeftIcon from "@material-symbols/svg-400/outlined/chevron_left.svg";
 import { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 import { ComponentProps } from "react";
@@ -48,10 +50,60 @@ const actions = [
   },
 ];
 
+const leftActions = [
+  {
+    id: "001",
+    icon: homeIcon,
+    title: "Accueil",
+  },
+  {
+    id: "002",
+    icon: chevronLeftIcon,
+    title: "Retour",
+  },
+];
+
 export const DefaultTitle: StoryObj<typeof HeaderTitle> = {};
 
 export const ComplexTitle: StoryObj<typeof HeaderTitle> = {
   args: {
+    children: (
+      <div className="af-title-bar__actions">
+        {actions.map(({ icon, id, title }: ComponentProps<typeof Action>) => (
+          <a
+            key={id}
+            href="/#"
+            role="button"
+            title={title}
+            className="btn af-btn--circle"
+          >
+            <Svg src={icon} />
+          </a>
+        ))}
+      </div>
+    ),
+  },
+};
+
+export const ComplexTitleWithLeftSection: StoryObj<typeof HeaderTitle> = {
+  args: {
+    leftSection: (
+      <div className="af-title-bar__actions">
+        {leftActions.map(
+          ({ icon, id, title }: ComponentProps<typeof Action>) => (
+            <a
+              key={id}
+              href="/#"
+              role="button"
+              title={title}
+              className="btn  af-btn--circle"
+            >
+              <Svg src={icon} />
+            </a>
+          ),
+        )}
+      </div>
+    ),
     children: (
       <div className="af-title-bar__actions">
         {actions.map(({ icon, id, title }: ComponentProps<typeof Action>) => (

--- a/slash/css/src/Layout/Header/HeaderTitle/HeaderTitle.scss
+++ b/slash/css/src/Layout/Header/HeaderTitle/HeaderTitle.scss
@@ -5,8 +5,8 @@
   margin-bottom: 2rem;
   padding: 1rem 0;
   overflow: auto;
-  color: common.$white;
-  background: common.$brand-primary;
+  color: var(--white);
+  background: var(--axablue80);
 
   &--sticky {
     position: sticky;
@@ -31,32 +31,38 @@
     }
   }
 
+  &__leftSection {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
   &__title {
     display: inline-block;
     margin: 0;
     font-weight: 600;
-    color: common.$white;
+    color: var(--white);
   }
 
   &__subtitle {
     margin-left: 0.25rem;
     font-weight: 400;
-    color: common.$color-blue-subtitle;
+    color: var(--bluesubtitle);
   }
 
   &__actions {
     display: flex;
 
     .btn {
-      fill: common.$white;
-      transition: fill 0.3s;
       display: flex;
-      align-items: center;
       flex-direction: column;
+      align-items: center;
       justify-content: center;
+      transition: fill 0.3s;
+      fill: var(--white);
 
       &:hover {
-        fill: common.$brand-primary;
+        fill: var(--axablue80);
       }
 
       svg {
@@ -69,12 +75,12 @@
       vertical-align: middle;
 
       .injected-svg {
-        color: common.$white;
+        color: var(--white);
       }
 
       &:focus {
-        color: common.$white;
-        box-shadow: 0 0 6px common.$white;
+        color: var(--white);
+        box-shadow: 0 0 6px var(--white);
       }
     }
   }

--- a/slash/css/src/Layout/Header/HeaderTitle/HeaderTitle.scss
+++ b/slash/css/src/Layout/Header/HeaderTitle/HeaderTitle.scss
@@ -37,6 +37,11 @@
     gap: 1rem;
   }
 
+  &__rightSection {
+    display: flex;
+    align-items: center;
+  }
+
   &__title {
     display: inline-block;
     margin: 0;

--- a/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.spec.tsx
+++ b/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.spec.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { HeaderTitle } from "./HeaderTitle";
+
+describe("HeaderTitle", () => {
+  test("should render title and subtitle", async () => {
+    const { container } = render(
+      <HeaderTitle title="Main Title" subtitle="Subtitle" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+    expect(
+      screen.getByRole("heading", { name: /main title/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Subtitle")).toBeInTheDocument();
+  });
+
+  test("should render leftSection", async () => {
+    const { container } = render(
+      <HeaderTitle
+        title="Title"
+        leftSection={<span data-testid="left-section">Left</span>}
+      />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+    expect(screen.getByTestId("left-section")).toHaveTextContent("Left");
+  });
+
+  test("should render children", async () => {
+    const { container } = render(
+      <HeaderTitle title="Title">
+        <div data-testid="child">Child content</div>
+      </HeaderTitle>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+    expect(screen.getByTestId("child")).toHaveTextContent("Child content");
+  });
+});

--- a/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.spec.tsx
+++ b/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.spec.tsx
@@ -16,22 +16,19 @@ describe("HeaderTitle", () => {
 
   test("should render leftSection", async () => {
     const { container } = render(
-      <HeaderTitle
-        title="Title"
-        leftSection={<span data-testid="left-section">Left</span>}
-      />,
+      <HeaderTitle title="Title" contentLeft={<span>Left</span>} />,
     );
     expect(await axe(container)).toHaveNoViolations();
-    expect(screen.getByTestId("left-section")).toHaveTextContent("Left");
+    expect(screen.getByText("Left")).toBeInTheDocument();
   });
 
   test("should render children", async () => {
     const { container } = render(
       <HeaderTitle title="Title">
-        <div data-testid="child">Child content</div>
+        <div>Child content</div>
       </HeaderTitle>,
     );
     expect(await axe(container)).toHaveNoViolations();
-    expect(screen.getByTestId("child")).toHaveTextContent("Child content");
+    expect(screen.getByText("Child content")).toBeInTheDocument();
   });
 });

--- a/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.spec.tsx
+++ b/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { HeaderTitle } from "./HeaderTitle";
+import { Badge } from "../../../Badge/Badge";
 
 describe("HeaderTitle", () => {
   test("should render title and subtitle", async () => {
@@ -14,7 +15,7 @@ describe("HeaderTitle", () => {
     expect(screen.getByText("Subtitle")).toBeInTheDocument();
   });
 
-  test("should render leftSection", async () => {
+  test("should render contentLeft", async () => {
     const { container } = render(
       <HeaderTitle title="Title" contentLeft={<span>Left</span>} />,
     );
@@ -22,13 +23,21 @@ describe("HeaderTitle", () => {
     expect(screen.getByText("Left")).toBeInTheDocument();
   });
 
+  test("should render contentRight", async () => {
+    const { container } = render(
+      <HeaderTitle title="Title" contentRight={<span>Right</span>} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+    expect(screen.getByText("Right")).toBeInTheDocument();
+  });
+
   test("should render children", async () => {
     const { container } = render(
       <HeaderTitle title="Title">
-        <div>Child content</div>
+        <Badge classModifier="success"> Lorem ipsum </Badge>
       </HeaderTitle>,
     );
     expect(await axe(container)).toHaveNoViolations();
-    expect(screen.getByText("Child content")).toBeInTheDocument();
+    expect(screen.getByText("Lorem ipsum")).toBeInTheDocument();
   });
 });

--- a/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.tsx
+++ b/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.tsx
@@ -13,7 +13,7 @@ type Props = {
   classModifier?: string;
   className?: string;
   isSticky?: boolean;
-  leftSection?: ReactNode;
+  contentLeft?: ReactNode;
   subtitle?: string;
   title: string;
   toggleMenu?: () => void;
@@ -24,7 +24,7 @@ const HeaderTitle = ({
   classModifier,
   className,
   isSticky = true,
-  leftSection,
+  contentLeft,
   subtitle,
   title,
   toggleMenu,
@@ -51,7 +51,7 @@ const HeaderTitle = ({
           </div>
         )}
         <div className={`${defaultClassName}__leftSection`}>
-          {leftSection}
+          {contentLeft}
           <h1 className={`${defaultClassName}__title`}>
             {title}
             {subtitle && (

--- a/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.tsx
+++ b/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.tsx
@@ -13,6 +13,7 @@ type Props = {
   classModifier?: string;
   className?: string;
   isSticky?: boolean;
+  leftSection?: ReactNode;
   subtitle?: string;
   title: string;
   toggleMenu?: () => void;
@@ -23,6 +24,7 @@ const HeaderTitle = ({
   classModifier,
   className,
   isSticky = true,
+  leftSection,
   subtitle,
   title,
   toggleMenu,
@@ -48,12 +50,17 @@ const HeaderTitle = ({
             </ToggleButton>
           </div>
         )}
-        <h1 className={`${defaultClassName}__title`}>
-          {title}
-          {subtitle && (
-            <span className={`${defaultClassName}__subtitle`}>{subtitle}</span>
-          )}
-        </h1>
+        <div className={`${defaultClassName}__leftSection`}>
+          {leftSection}
+          <h1 className={`${defaultClassName}__title`}>
+            {title}
+            {subtitle && (
+              <span className={`${defaultClassName}__subtitle`}>
+                {subtitle}
+              </span>
+            )}
+          </h1>
+        </div>
         {children}
       </div>
     </div>

--- a/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.tsx
+++ b/slash/react/src/Layout/Header/HeaderTitle/HeaderTitle.tsx
@@ -14,6 +14,7 @@ type Props = {
   className?: string;
   isSticky?: boolean;
   contentLeft?: ReactNode;
+  contentRight?: ReactNode;
   subtitle?: string;
   title: string;
   toggleMenu?: () => void;
@@ -25,6 +26,7 @@ const HeaderTitle = ({
   className,
   isSticky = true,
   contentLeft,
+  contentRight,
   subtitle,
   title,
   toggleMenu,
@@ -60,8 +62,13 @@ const HeaderTitle = ({
               </span>
             )}
           </h1>
+          {children}
         </div>
-        {children}
+        {contentRight && (
+          <div className={`${defaultClassName}__rightSection`}>
+            {contentRight}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Ajoute la possibilité de mettre un composant React selon l'usage à gauche du titre dans le composant HeaderTitle. Le cas d'usage classique est l'ajout d'une icone Home ou BackButton dans les maquettes UX.

![image](https://github.com/user-attachments/assets/82fc7f42-4757-41c4-bff5-77d7750f4a52)
