### PR TITLE
chore(design-system): update copilot commit message generation instructions

### DIFF
--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,53 @@
+# Git Commit Instructions
+
+## Conventional Commits Format
+
+Use the following format for commit messages:
+
+```text
+<type>[scope]: <description>
+```
+
+### Allowed Types
+
+- feat
+- fix
+- chore
+- docs
+- refactor
+- test
+
+### Allowed Scopes
+
+- slash: commits related to the Slash design system (UI kit, components, styles, etc. in the `slash/` folder)
+- look&feel: commits related to the Look & Feel design system (UI kit, components, styles, etc. in the `look-and-feel/` folder)
+- apollo: commits related to the Apollo design system (UI kit, components, styles, etc. in the `apollo/` folder)
+- design-system: commits that affect the overall monorepo, shared tooling, documentation, or general project configuration (not specific to a single design system)
+
+If the commit affects two or more design systems, separate scopes with a comma, e.g.:
+
+```text
+fix(look&feel,apollo): fix styles and icons
+```
+
+For general project changes, use the `design-system` scope.
+
+> **Note:** The scopes `deps`, `deps-dev`, and `release` are reserved and must NOT be used.
+
+### Guidelines
+
+- Use imperative mood: "Add feature" not "Added feature".
+- Keep subject line under 70 characters if possible.
+- For breaking changes, add a `!` after the scope (e.g., `feat(slash)!: ...`) and include a `BREAKING CHANGE:` section in the footer describing the breaking change.
+- Do not add a body or footer unless necessary.
+
+### Valid Examples
+
+```text
+feat(slash): add new component
+fix(look&feel,apollo): fix styles and icons
+chore(design-system): update dependencies
+feat(slash)!: remove classModifiers
+
+BREAKING CHANGE: classModifiers prop has been removed from all components.
+```

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -17,23 +17,20 @@ Use the following format for commit messages:
 - refactor
 - test
 
-### Allowed Scopes
-
-- slash: for any change in the Slash design system (`slash/` folder or its stories in `apps/slash-stories/`)
-- look&feel: for any change in the Look & Feel design system (`look-and-feel/` folder or its stories in `apps/look-and-feel-stories/`)
-- apollo: for any change in the Apollo design system (`apollo/` folder or its stories in `apps/apollo-stories/`)
-- design-system: for global or cross-cutting changes, or changes affecting multiple design systems
-
-> **Note:** The scopes `deps`, `deps-dev`, and `release` are reserved and must NOT be used.
-
 ## Scope Selection Rules (apply in this order)
 
-- **1.** If a file in the apollo folder ends with `Common`, use both `apollo` and `look&feel` as scopes, even if the name does not contain `LF`.
-- **2.** If a file name contains `LF`, use only `look&feel` as scope, even if it is in the apollo folder (except for files ending with `Common`, which must use both `apollo` and `look&feel`).
-- **3.** If a file name contains `Apollo`, use only `apollo` as scope, even if it is in another folder (except for files ending with `Common`).
-- **4.** For all other files, use the scope corresponding to their design system folder (`slash`, `look&feel`, `apollo`) or `design-system` for global changes.
+Follow these rules in order, from top to bottom, to determine the correct scope(s) for your commit message:
 
-When generating a commit message, always analyze all staged or changed files. For each file, determine its relevant scope(s) according to the rules above. The final commit message MUST include the union of all relevant scopes, separated by a comma and sorted alphabetically. Example: `feat(look&feel,apollo): ...` if both a look&feel and an apollo file are staged.
+1. If a file in the apollo folder ends with `Common`, use both `apollo` and `look&feel` as scopes, even if the name does not contain `LF`.
+2. If a file name contains `LF`, use only the `look&feel` scope, even if the file is in the apollo folder (except for files ending with `Common`, which must use both `apollo` and `look&feel`).
+3. If a file name contains `Apollo`, use only the `apollo` scope, even if the file is in another folder (except for files ending with `Common`).
+4. For all other files:
+   - Use the `slash` scope for any change in the Slash design system (`slash/` or `apps/slash-stories/`).
+   - Use the `look&feel` scope for any change in the Look & Feel design system (`look-and-feel/` or `apps/look-and-feel-stories/`).
+   - Use the `apollo` scope for any change in the Apollo design system (`apollo/` or `apps/apollo-stories/`).
+   - Use the `design-system` scope for global, cross-cutting, or multi-design-system changes.
+5. The scopes `deps`, `deps-dev`, and `release` are reserved and MUST NOT be used.
+6. For each commit, analyze all staged or changed files. The commit message MUST include the union of all relevant scopes, separated by a comma and sorted alphabetically. Example: `feat(look&feel,apollo): ...` if both a look&feel and an apollo file are staged together.
 
 ## Guidelines
 
@@ -49,7 +46,7 @@ fix(look&feel,apollo): fix styles and icons
 chore(design-system): update dependencies
 ```
 
-### Special Cases
+### Examples for Special Cases
 
 ```text
 ComponentLF.tsx in apollo: feat(look&feel): ...

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -19,35 +19,40 @@ Use the following format for commit messages:
 
 ### Allowed Scopes
 
-- slash: commits related to the Slash design system (UI kit, components, styles, etc. in the `slash/` folder)
-- look&feel: commits related to the Look & Feel design system (UI kit, components, styles, etc. in the `look-and-feel/` folder)
-- apollo: commits related to the Apollo design system (UI kit, components, styles, etc. in the `apollo/` folder)
-- design-system: commits that affect the overall monorepo, shared tooling, documentation, or general project configuration (not specific to a single design system)
-
-If the commit affects two or more design systems, separate scopes with a comma, e.g.:
-
-```text
-fix(look&feel,apollo): fix styles and icons
-```
-
-For general project changes, use the `design-system` scope.
+- slash: for any change in the Slash design system (`slash/` folder or its stories in `apps/slash-stories/`)
+- look&feel: for any change in the Look & Feel design system (`look-and-feel/` folder or its stories in `apps/look-and-feel-stories/`)
+- apollo: for any change in the Apollo design system (`apollo/` folder or its stories in `apps/apollo-stories/`)
+- design-system: for global or cross-cutting changes, or changes affecting multiple design systems
 
 > **Note:** The scopes `deps`, `deps-dev`, and `release` are reserved and must NOT be used.
 
-### Guidelines
+## Scope Selection Rules (apply in this order)
+
+- **1.** If a file in the apollo folder ends with `Common`, use both `apollo` and `look&feel` as scopes, even if the name does not contain `LF`.
+- **2.** If a file name contains `LF`, use only `look&feel` as scope, even if it is in the apollo folder (except for files ending with `Common`, which must use both `apollo` and `look&feel`).
+- **3.** If a file name contains `Apollo`, use only `apollo` as scope, even if it is in another folder (except for files ending with `Common`).
+- **4.** For all other files, use the scope corresponding to their design system folder (`slash`, `look&feel`, `apollo`) or `design-system` for global changes.
+
+When generating a commit message, always analyze all staged or changed files. For each file, determine its relevant scope(s) according to the rules above. The final commit message MUST include the union of all relevant scopes, separated by a comma and sorted alphabetically. Example: `feat(look&feel,apollo): ...` if both a look&feel and an apollo file are staged.
+
+## Guidelines
 
 - Use imperative mood: "Add feature" not "Added feature".
 - Keep subject line under 70 characters if possible.
-- For breaking changes, add a `!` after the scope (e.g., `feat(slash)!: ...`) and include a `BREAKING CHANGE:` section in the footer describing the breaking change.
 - Do not add a body or footer unless necessary.
 
-### Valid Examples
+## Valid Examples
 
 ```text
 feat(slash): add new component
 fix(look&feel,apollo): fix styles and icons
 chore(design-system): update dependencies
-feat(slash)!: remove classModifiers
+```
 
-BREAKING CHANGE: classModifiers prop has been removed from all components.
+### Special Cases
+
+```text
+ComponentLF.tsx in apollo: feat(look&feel): ...
+ComponentCommon.tsx in apollo: feat(look&feel,apollo): ...
+ComponentApollo.tsx and ComponentLF.tsx: feat(look&feel,apollo): ...
 ```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,38 @@
 {
-  "[mdx]": {
-    "editor.wordWrap": "on"
-  },
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.fixAll.stylelint": "explicit"
-  }
+	"[mdx]": {
+		"editor.wordWrap": "on"
+	},
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": "explicit",
+		"source.fixAll.stylelint": "explicit"
+	},
+	"github.copilot.chat.commitMessageGeneration.instructions": [
+		{
+			"text": "Use the Conventional Commits format: <type>[scope]: <description>."
+		},
+		{ "text": "Allowed types: feat, fix, chore, docs, refactor, test." },
+		{
+			"text": "The scope must be one of: slash, look&feel, apollo, design-system."
+		},
+		{
+			"text": "If the commit affects two or more design systems, separate scopes with a comma, e.g., fix(look&feel,apollo): ..."
+		},
+		{ "text": "For general project changes, use the design-system scope." },
+		{
+			"text": "The scopes deps, deps-dev, and release are reserved and must NOT be used."
+		},
+		{ "text": "Use imperative mood: 'Add feature' not 'Added feature'." },
+		{ "text": "Keep subject line under 70 characters if possible." },
+		{
+			"text": "For breaking changes, add a ! after the scope (feat(slash)!: ...) and include a BREAKING CHANGE: section in the footer describing the breaking change."
+		},
+		{ "text": "Do not add a body or footer unless necessary." },
+		{ "text": "Valid examples:" },
+		{ "text": "  feat(slash): add new component" },
+		{ "text": "  fix(look&feel,apollo): fix styles and icons" },
+		{ "text": "  chore(design-system): update dependencies" },
+		{
+			"text": "  feat(slash)!: remove classModifiers with a footer BREAKING CHANGE: ..."
+		}
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,28 +11,86 @@
 			"text": "Use the Conventional Commits format: <type>[scope]: <description>."
 		},
 		{ "text": "Allowed types: feat, fix, chore, docs, refactor, test." },
+		{ "text": "Type details:" },
+		{ "text": "  feat: for new features or significant enhancements." },
+		{ "text": "  fix: for bug fixes or corrections." },
+		{
+			"text": "  chore: for maintenance, tooling, or non-functional changes (not code or docs)."
+		},
+		{
+			"text": "  docs: for documentation changes only (including Storybook MDX)."
+		},
+		{
+			"text": "  refactor: for code changes that neither fix a bug nor add a feature."
+		},
+		{ "text": "  test: for adding or updating tests only." },
 		{
 			"text": "The scope must be one of: slash, look&feel, apollo, design-system."
 		},
 		{
-			"text": "If the commit affects two or more design systems, separate scopes with a comma, e.g., fix(look&feel,apollo): ..."
+			"text": "slash: for any change in the slash design system (slash folder) or its stories (apps/slash-stories)."
+		},
+		{
+			"text": "apollo: for any change in the apollo design system (client/apollo folder) or its stories (apps/apollo-stories)."
+		},
+		{
+			"text": "look&feel: for any change in the look-and-feel design system (client/look-and-feel folder) or its stories (apps/look-and-feel-stories)."
+		},
+		{
+			"text": "design-system: for global or cross-cutting changes, or changes affecting multiple design systems."
+		},
+		{
+			"text": "If the change affects both the design system and its stories (in apps), use the same scope (e.g.: fix(slash): fix a bug in slash and apps/slash-stories)."
+		},
+		{
+			"text": "For changes affecting multiple design systems, separate scopes with a comma (e.g.: fix(look&feel,apollo): ...)."
 		},
 		{ "text": "For general project changes, use the design-system scope." },
 		{
 			"text": "The scopes deps, deps-dev, and release are reserved and must NOT be used."
 		},
 		{ "text": "Use imperative mood: 'Add feature' not 'Added feature'." },
-		{ "text": "Keep subject line under 70 characters if possible." },
-		{
-			"text": "For breaking changes, add a ! after the scope (feat(slash)!: ...) and include a BREAKING CHANGE: section in the footer describing the breaking change."
-		},
+		{ "text": "Keep the subject line under 70 characters if possible." },
 		{ "text": "Do not add a body or footer unless necessary." },
 		{ "text": "Valid examples:" },
 		{ "text": "  feat(slash): add new component" },
 		{ "text": "  fix(look&feel,apollo): fix styles and icons" },
 		{ "text": "  chore(design-system): update dependencies" },
 		{
-			"text": "  feat(slash)!: remove classModifiers with a footer BREAKING CHANGE: ..."
+			"text": "Special case: When generating a commit message, always analyze all staged or changed files. If any file is related to a design system (by folder or by file name containing identifiers like 'LF' for look&feel or 'Apollo'), you MUST include all relevant scopes in the commit message, separated by a comma. Example: refactor(look&feel,apollo): ..."
+		},
+		{
+			"text": "MANDATORY rules for scope selection (apply in this order):"
+		},
+		{
+			"text": "1. If a file in the apollo folder ends with 'Common', use both apollo and look&feel as scopes, even if the name does not contain 'LF'."
+		},
+		{
+			"text": "2. If a file name contains 'LF', use only look&feel as scope, even if it is in the apollo folder (except for files ending with 'Common', which must use both apollo and look&feel). This rule takes priority over all others except rule 1."
+		},
+		{
+			"text": "3. If a file name contains 'Apollo', use only apollo as scope, even if it is in another folder (except for files ending with 'Common')."
+		},
+		{
+			"text": "4. For all other files, use the scope corresponding to their design system folder (slash, look&feel, apollo) or design-system for global changes."
+		},
+		{
+			"text": "Examples:"
+		},
+		{
+			"text": "  ComponentLF.tsx in apollo: <type>(look&feel): ..."
+		},
+		{
+			"text": "  ComponentCommon.tsx in apollo: <type>(look&feel,apollo): ..."
+		},
+		{
+			"text": "  ComponentApollo.tsx and ComponentLF.tsx: <type>(look&feel,apollo): ..."
+		},
+		{
+			"text": "Apply these rules to every staged or changed file before generating the commit message. This rule takes precedence over all others."
+		},
+		{
+			"text": "When generating a commit message, always analyze all staged or changed files. For each file, determine its relevant scope(s) according to the rules below. The final commit message MUST include the union of all relevant scopes, separated by a comma and sorted alphabetically. Example: feat(look&feel,apollo): ... if both a look&feel and an apollo file are staged."
 		}
 	]
 }


### PR DESCRIPTION
This pull request updates the `.vscode/settings.json` file to include detailed instructions for commit message generation using GitHub Copilot. The instructions enforce the use of the Conventional Commits format, specifying rules for types, scopes, and formatting.

### Changes to commit message generation:

* Added a new `github.copilot.chat.commitMessageGeneration.instructions` configuration in `.vscode/settings.json` to guide developers on writing commit messages in the Conventional Commits format. The instructions include:
  - Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
  - Defined scopes: `slash`, `look&feel`, `apollo`, `design-system`, with rules for multiple scopes and reserved scopes like `deps`, `deps-dev`, and `release`.
  - Formatting requirements, such as using the imperative mood, keeping the subject line concise, and handling breaking changes with a `!` and a `BREAKING CHANGE` footer.
  - Examples of valid commit messages to ensure clarity and consistency.