### PR TITLE
fix(apollo, look&feel)!: card radio

### DIFF
--- a/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
+++ b/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
@@ -64,6 +64,10 @@ export const CardRadioStory: StoryObj<StoryProps> = {
       description: "Radio card options",
     },
     onChange: { action: "onChange" },
+    value: {
+      control: { type: "select" },
+      options: baseOptions.map((option) => option.value),
+    },
   },
 };
 
@@ -99,5 +103,9 @@ export const CardRadioWithLabel: StoryObj<StoryProps> = {
       description: "Radio card options",
     },
     onChange: { action: "onChange" },
+    value: {
+      control: { type: "select" },
+      options: baseOptions.map((option) => option.value),
+    },
   },
 };

--- a/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
+++ b/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
@@ -22,7 +22,6 @@ const baseOptions = [
     label: "Bruxelles",
     description: "Capitale de la Belgique",
     value: "bruxelles",
-    hasError: true,
   },
   {
     label: "Lille",

--- a/apps/look-and-feel-stories/src/CardRadio/CardRadio.stories.tsx
+++ b/apps/look-and-feel-stories/src/CardRadio/CardRadio.stories.tsx
@@ -8,7 +8,6 @@ type CardRadioOption = {
   description?: string;
   subtitle?: string;
   value: string;
-  hasError?: boolean;
 };
 
 type StoryProps = ComponentProps<typeof CardRadio> & {
@@ -35,7 +34,6 @@ const defaultOptions: CardRadioOption[] = [
     label: "Bruxelles",
     description: "Capitale de la Belgique",
     value: "bruxelles",
-    hasError: true,
   },
   {
     label: "Lille",

--- a/apps/look-and-feel-stories/src/CardRadio/CardRadio.stories.tsx
+++ b/apps/look-and-feel-stories/src/CardRadio/CardRadio.stories.tsx
@@ -71,6 +71,10 @@ export const CardRadioStory: StoryObj<StoryProps> = {
       description: "Radio card options",
     },
     onChange: { action: "onChange" },
+    value: {
+      control: { type: "select" },
+      options: defaultOptions.map((option) => option.value),
+    },
   },
 };
 
@@ -107,5 +111,9 @@ export const CardRadioWithLabel: StoryObj<StoryProps> = {
       description: "Radio card options",
     },
     onChange: { action: "onChange" },
+    value: {
+      control: { type: "select" },
+      options: defaultOptions.map((option) => option.value),
+    },
   },
 };

--- a/client/apollo/css/src/Form/Radio/CardRadio/CardRadioApollo.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadio/CardRadioApollo.scss
@@ -96,15 +96,6 @@
         }
       }
 
-      &:has([aria-invalid="true"]) {
-        --card-radio-background-color: var(--axa-red-4);
-        --card-radio-border-color: var(--red-alert-100);
-
-        & > span:first-child {
-          --radio-border-color: var(--red-alert-100);
-        }
-      }
-
       &:has(input:checked) {
         --card-radio-border-color: var(--axa-blue-100);
         --card-radio-background-color: var(--axa-blue-4);
@@ -117,6 +108,17 @@
           }
         }
       }
+    }
+  }
+
+  /* stylelint-disable-next-line no-descending-specificity */
+  &__container[aria-invalid="true"] .af-card-radio-label {
+    --card-radio-background-color: var(--axa-red-4);
+    --card-radio-border-color: var(--red-alert-100);
+
+    /* stylelint-disable-next-line no-descending-specificity */
+    & > span:first-child {
+      --radio-border-color: var(--red-alert-100);
     }
   }
 }

--- a/client/apollo/css/src/Form/Radio/CardRadio/CardRadioLF.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadio/CardRadioLF.scss
@@ -102,14 +102,6 @@
         }
       }
 
-      &:has([aria-invalid="true"]) {
-        --card-radio-border-color: var(--color-red-700);
-
-        & > span:first-child {
-          --radio-border-color: var(--color-red-700);
-        }
-      }
-
       .af-card-radio-content
         .af-card-radio-content-description
         > span:first-child {
@@ -119,14 +111,24 @@
       &:has(input:checked) {
         --card-radio-border-color: var(--color-axa);
         --card-radio-background-color: var(--color-blue-2);
+      }
+    }
+  }
 
-        &:has([aria-invalid="true"]) {
-          --card-radio-border-color: var(--color-red-700);
+  /* stylelint-disable-next-line no-descending-specificity */
+  &__container[aria-invalid="true"] .af-card-radio-label {
+    --card-radio-border-color: var(--color-red-700);
 
-          & > span:first-child {
-            --radio-border-color: var(--color-red-700);
-          }
-        }
+    /* stylelint-disable-next-line no-descending-specificity */
+    & > span:first-child {
+      --radio-border-color: var(--color-red-700);
+    }
+
+    &:has(input:checked) {
+      --card-radio-border-color: var(--color-red-700);
+
+      & > span:first-child {
+        --radio-border-color: var(--color-red-700);
       }
     }
   }

--- a/client/apollo/react/src/Form/ItemMessage/ItemMessageCommon.tsx
+++ b/client/apollo/react/src/Form/ItemMessage/ItemMessageCommon.tsx
@@ -1,5 +1,5 @@
-import errorIcon from "@material-symbols/svg-400/outlined/error-fill.svg";
 import successIcon from "@material-symbols/svg-400/outlined/check_circle-fill.svg";
+import errorIcon from "@material-symbols/svg-400/outlined/error-fill.svg";
 import { Svg } from "../../Svg/Svg";
 
 type ItemMessageProps = {
@@ -19,6 +19,7 @@ export const ItemMessage = ({
 
   return (
     <small
+      id={id}
       className={`af-item-message af-item-message--${messageType}`}
       role={messageType === "error" ? "alert" : undefined}
       aria-live="assertive"
@@ -28,9 +29,7 @@ export const ItemMessage = ({
         className="af-item-message__icon"
         aria-hidden="true"
       />
-      <span id={id} className="af-item-message__message">
-        {message}
-      </span>
+      <span className="af-item-message__message">{message}</span>
     </small>
   );
 };

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -1,13 +1,9 @@
-import React, {
-  type ComponentProps,
-  ComponentPropsWithRef,
-  type ComponentType,
-  useId,
-} from "react";
+import { type ComponentProps, type ComponentType, useId } from "react";
 import { BREAKPOINT } from "../../../utilities/constants";
 import { getComponentClassName } from "../../../utilities/getComponentClassName";
 import { useIsSmallScreen } from "../../../utilities/hook/useIsSmallScreen";
 import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
+import type { RadioCommon } from "../Radio/RadioCommon";
 import { CardRadioItem } from "./CardRadioItem";
 import type {
   IconComponent,
@@ -15,14 +11,16 @@ import type {
   TCardRadioItemOption,
 } from "./types";
 
-export type CardRadioProps = Omit<ComponentPropsWithRef<"input">, "value"> & {
+export type CardRadioProps = Omit<
+  ComponentProps<typeof RadioCommon>,
+  "size"
+> & {
   type: "vertical" | "horizontal";
   labelGroup?: string;
   descriptionGroup?: string;
   isRequired?: boolean;
   value?: number | string;
   options: TCardRadioItemOption[];
-  onChange?: React.ChangeEventHandler;
   error?: string;
 };
 
@@ -46,6 +44,7 @@ const CardRadioCommon = ({
   value,
   onChange,
   ItemMessageComponent,
+  ...inputProps
 }: CardRadioCommonProps) => {
   const componentClassName = getComponentClassName(
     "af-card-radio__container",
@@ -96,6 +95,7 @@ const CardRadioCommon = ({
                 ? value === cardRadioItemProps.value
                 : undefined
             }
+            {...inputProps}
             {...cardRadioItemProps}
           />
         ))}

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -15,12 +15,12 @@ import type {
   TCardRadioItemOption,
 } from "./types";
 
-export type CardRadioProps = ComponentPropsWithRef<"input"> & {
+export type CardRadioProps = Omit<ComponentPropsWithRef<"input">, "value"> & {
   type: "vertical" | "horizontal";
   labelGroup?: string;
   descriptionGroup?: string;
   isRequired?: boolean;
-  value?: number;
+  value?: number | string;
   options: TCardRadioItemOption[];
   onChange?: React.ChangeEventHandler;
   error?: string;
@@ -43,6 +43,7 @@ const CardRadioCommon = ({
   type = "vertical",
   error,
   name,
+  value,
   onChange,
   ItemMessageComponent,
 }: CardRadioCommonProps) => {
@@ -90,6 +91,11 @@ const CardRadioCommon = ({
             size={size}
             RadioComponent={RadioComponent}
             IconComponent={IconComponent}
+            checked={
+              value !== undefined
+                ? value === cardRadioItemProps.value
+                : undefined
+            }
             {...cardRadioItemProps}
           />
         ))}

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -84,7 +84,7 @@ const CardRadioCommon = ({
       <div className={RadioGroupClassName}>
         {options.map((cardRadioItemProps) => (
           <CardRadioItem
-            key={crypto.randomUUID()}
+            key={`${name}-${crypto.randomUUID()}`}
             name={name}
             onChange={onChange}
             size={size}

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -3,22 +3,17 @@ import React, {
   ComponentPropsWithRef,
   type ComponentType,
   useId,
-  type ReactNode,
 } from "react";
+import { BREAKPOINT } from "../../../utilities/constants";
 import { getComponentClassName } from "../../../utilities/getComponentClassName";
-import { Icon } from "../../../Icon/IconCommon";
 import { useIsSmallScreen } from "../../../utilities/hook/useIsSmallScreen";
 import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
-import { BREAKPOINT } from "../../../utilities/constants";
-import { RadioProps } from "../Radio/RadioCommon";
-
-type RadioComponent = {
-  RadioComponent: ComponentType<RadioProps>;
-};
-
-type IconComponent = {
-  IconComponent: ComponentType<ComponentProps<typeof Icon>>;
-};
+import { CardRadioItem } from "./CardRadioItem";
+import type {
+  IconComponent,
+  RadioComponent,
+  TCardRadioItemOption,
+} from "./types";
 
 export type CardRadioProps = ComponentPropsWithRef<"input"> & {
   type: "vertical" | "horizontal";
@@ -26,13 +21,7 @@ export type CardRadioProps = ComponentPropsWithRef<"input"> & {
   descriptionGroup?: string;
   isRequired?: boolean;
   value?: number;
-  options: ({
-    label: ReactNode;
-    subtitle?: ReactNode;
-    description?: ReactNode;
-    hasError?: boolean;
-    icon?: string;
-  } & Omit<React.InputHTMLAttributes<HTMLInputElement>, "disabled">)[];
+  options: TCardRadioItemOption[];
   onChange?: React.ChangeEventHandler;
   error?: string;
 };
@@ -70,10 +59,16 @@ const CardRadioCommon = ({
   const errorId = useId();
 
   const isMobile = useIsSmallScreen(BREAKPOINT.SM);
-  const size = isMobile ? "M" : "L";
+  const size: ComponentProps<typeof CardRadioItem>["size"] = isMobile
+    ? "M"
+    : "L";
 
   return (
-    <fieldset className={componentClassName}>
+    <fieldset
+      className={componentClassName}
+      aria-invalid={Boolean(error)}
+      aria-errormessage={error ? errorId : undefined}
+    >
       {labelGroup && (
         <legend className="af-card-radio__legend">
           <p>
@@ -87,40 +82,22 @@ const CardRadioCommon = ({
         </legend>
       )}
       <div className={RadioGroupClassName}>
-        {options.map(
-          (
-            { label, description, subtitle, icon, hasError, ...inputProps },
-            index,
-          ) => (
-            <label
-              key={`${name ?? inputProps.name}`}
-              aria-invalid={Boolean(error) || hasError}
-              htmlFor={`id-${name ?? inputProps.name}-${index}`}
-              className="af-card-radio-label"
-            >
-              <RadioComponent
-                id={`id-${name ?? inputProps.name}-${index}`}
-                errorId={errorId}
-                hasError={Boolean(error) || hasError}
-                {...inputProps}
-                name={name ?? inputProps.name}
-                onChange={onChange}
-              />
-              <div className="af-card-radio-content">
-                {icon && <IconComponent src={icon} size={size} />}
-                <div className="af-card-radio-content-description">
-                  <span>{label}</span>
-                  {description && <span>{description}</span>}
-                  {subtitle && <span>{subtitle}</span>}
-                </div>
-              </div>
-            </label>
-          ),
-        )}
+        {options.map((cardRadioItemProps) => (
+          <CardRadioItem
+            key={crypto.randomUUID()}
+            name={name}
+            onChange={onChange}
+            size={size}
+            RadioComponent={RadioComponent}
+            IconComponent={IconComponent}
+            {...cardRadioItemProps}
+          />
+        ))}
       </div>
       <ItemMessageComponent id={errorId} message={error} messageType="error" />
     </fieldset>
   );
 };
+
 CardRadioCommon.displayName = "CardRadioCommon";
 export { CardRadioCommon };

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioItem.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioItem.tsx
@@ -28,7 +28,7 @@ export const CardRadioItem = ({
   <label className="af-card-radio-label">
     <RadioComponent {...inputProps} />
     <div className="af-card-radio-content">
-      {icon && <IconComponent src={icon} size={size} />}
+      {icon && <IconComponent src={icon} size={size} role="presentation" />}
       <div className="af-card-radio-content-description">
         <span>{label}</span>
         {description && <span>{description}</span>}

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioItem.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioItem.tsx
@@ -1,0 +1,39 @@
+import { type ComponentProps, type ComponentType } from "react";
+import type { Icon as IconCommon } from "../../../Icon/IconCommon";
+import type { RadioCommon } from "../Radio/RadioCommon";
+
+export type TCardRadioItemProps = Omit<
+  ComponentProps<typeof RadioCommon>,
+  "size"
+> & {
+  label: string;
+  description?: string;
+  subtitle?: string;
+  icon?: ComponentProps<typeof IconCommon>["src"];
+  size: ComponentProps<typeof IconCommon>["size"];
+  RadioComponent: ComponentType<ComponentProps<typeof RadioCommon>>;
+  IconComponent: ComponentType<ComponentProps<typeof IconCommon>>;
+};
+
+export const CardRadioItem = ({
+  label,
+  description,
+  subtitle,
+  icon,
+  size,
+  RadioComponent,
+  IconComponent,
+  ...inputProps
+}: TCardRadioItemProps) => (
+  <label className="af-card-radio-label">
+    <RadioComponent {...inputProps} />
+    <div className="af-card-radio-content">
+      {icon && <IconComponent src={icon} size={size} />}
+      <div className="af-card-radio-content-description">
+        <span>{label}</span>
+        {description && <span>{description}</span>}
+        {subtitle && <span>{subtitle}</span>}
+      </div>
+    </div>
+  </label>
+);

--- a/client/apollo/react/src/Form/Radio/CardRadio/__tests__/CardRadio.test.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/__tests__/CardRadio.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
 import homeIcons from "@material-symbols/svg-400/outlined/home.svg";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { describe, expect, it } from "vitest";
 import { CardRadio } from "../CardRadioApollo";
 
 describe("Radio card Component", () => {
@@ -35,6 +35,35 @@ describe("Radio card Component", () => {
     radioInput.click();
 
     expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("should force the checked state of the radio card", () => {
+    // Arrange
+    render(
+      <CardRadio
+        type="vertical"
+        name="cities"
+        options={[
+          {
+            label: "Paris",
+            value: "paris",
+          },
+          {
+            label: "Lyon",
+            value: "lyon",
+          },
+        ]}
+        value="paris"
+      />,
+    );
+
+    // Act
+    const parisRadio = screen.getByLabelText("Paris");
+    const lyonRadio = screen.getByLabelText("Lyon");
+
+    // Then
+    expect(parisRadio).toBeChecked();
+    expect(lyonRadio).not.toBeChecked();
   });
 
   it("should violate accessibility the of radio card", async () => {

--- a/client/apollo/react/src/Form/Radio/CardRadio/types.ts
+++ b/client/apollo/react/src/Form/Radio/CardRadio/types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentType } from "react";
+import type { Icon } from "../../../indexLF";
+import type { RadioProps } from "../Radio/RadioCommon";
+import type { TCardRadioItemProps } from "./CardRadioItem";
+
+export type TCardRadioItemOption = Omit<
+  TCardRadioItemProps,
+  "RadioComponent" | "IconComponent" | "size" | "name"
+>;
+
+export type RadioComponent = {
+  RadioComponent: ComponentType<RadioProps>;
+};
+
+export type IconComponent = {
+  IconComponent: ComponentType<ComponentProps<typeof Icon>>;
+};

--- a/client/apollo/react/src/Form/Radio/Radio/RadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/Radio/RadioCommon.tsx
@@ -1,20 +1,12 @@
 import React from "react";
 
-export type RadioProps = {
-  errorId?: string;
-  hasError?: boolean;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "disabled">;
+export type RadioProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "disabled"
+>;
 
-export const RadioCommon = ({
-  errorId,
-  hasError,
-  ...inputProps
-}: RadioProps) => (
-  <span
-    className="af-radio"
-    aria-invalid={hasError}
-    aria-errormessage={errorId}
-  >
+export const RadioCommon = (inputProps: RadioProps) => (
+  <span className="af-radio">
     <input {...inputProps} type="radio" />
     <span className="af-radio__icons" />
   </span>

--- a/samples/vite/src/Client.tsx
+++ b/samples/vite/src/Client.tsx
@@ -1,9 +1,10 @@
 import {
   Button as ButtonClient,
   buttonVariants as ButtonClientVariants,
+  RadioCard,
+  Select,
   Svg,
   TextInput,
-  Select,
 } from "@axa-fr/design-system-look-and-feel-react";
 import acUnit from "@material-symbols/svg-400/outlined/ac_unit.svg";
 
@@ -11,7 +12,8 @@ import { SubmitHandler, useForm } from "react-hook-form";
 
 type Inputs = {
   exampleTextInput: string;
-  exampleSelect: string;
+  exampleSelectInput: string;
+  exampleRadioInput: string;
 };
 
 const Client = () => {
@@ -22,7 +24,8 @@ const Client = () => {
   } = useForm<Inputs>({
     defaultValues: {
       exampleTextInput: "",
-      exampleSelect: "",
+      exampleSelectInput: "",
+      exampleRadioInput: "",
     },
   });
   const onSubmit: SubmitHandler<Inputs> = (data) => console.log(data);
@@ -47,11 +50,11 @@ const Client = () => {
         <article>
           <Select
             label="Name"
-            {...register("exampleSelect", {
+            {...register("exampleSelectInput", {
               required: "This field is required",
             })}
             description="Description"
-            error={errors.exampleSelect?.message}
+            error={errors.exampleSelectInput?.message}
           >
             <option disabled value="">
               Select a country
@@ -60,6 +63,30 @@ const Client = () => {
             <option value="ES">Espagne</option>
             <option value="JP">Japon</option>
           </Select>
+        </article>
+
+        <article>
+          <RadioCard
+            type="vertical"
+            isRequired
+            options={[
+              {
+                label: "Option 1",
+                value: "option1",
+                description: "Description for option 1",
+              },
+              {
+                label: "Option 2",
+                value: "option2",
+                description: "Description for option 2",
+              },
+            ]}
+            labelGroup="Card Radio Group"
+            {...register("exampleRadioInput", {
+              required: "This field is required",
+            })}
+            error={errors.exampleRadioInput?.message}
+          />
         </article>
 
         <article>


### PR DESCRIPTION
## Description

This PR refactors the `CardRadio` component and its related stories, types, and styles. The main goals are to improve the API consistency, simplify error handling, and enhance maintainability. The changes include:

- Permit to control the value 
- Removal of the `hasError` property from CardRadio options.
- Error state is now managed globally at the group level, not per option.
- Refactoring of the CardRadio implementation to use a dedicated `CardRadioItem` component.
- Updates to types for stricter option structure.
- Adjustments to stories and tests to align with the new API.
- CSS updates to reflect the new error handling approach.

---

## Breaking Changes ⚠️

**This PR introduces the following breaking changes:**

1. **Removal of `hasError` from CardRadio options:**  
   The `hasError` property is no longer supported in CardRadio option objects. Any usage of this property will result in a type error or be ignored.

2. **Options structure update:**  
   CardRadio options must now conform to the new `TCardRadioItemOption` type. Any option not matching this structure will cause a compilation error.

3. **Removal of `errorId` and `hasError` props from `RadioCommon`:**  
   These props have been removed. Any custom usage, extension, or wrapper relying on them will break.

4. **Error handling is now only at the group level:**  
   It is no longer possible to mark an individual CardRadio option as invalid via the public API. Errors must be managed at the parent component level.