### PR TITLE
Fix(apollo,look&feel): Content Item duo retours pair test

### DIFF
--- a/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
+++ b/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
@@ -42,7 +42,7 @@
       row-gap: 0;
     }
 
-    row-gap: calc(12 / var(--font-size-base) * 1rem);
+    row-gap: calc(8 / var(--font-size-base) * 1rem);
 
     .af-content-item-duo {
       &__icon {
@@ -74,7 +74,7 @@
       "icon label button"
       ". value value";
     grid-template-columns: auto 1fr auto;
-    gap: calc(6 / var(--font-size-base) * 1rem)
+    gap: calc(8 / var(--font-size-base) * 1rem)
       calc(12 / var(--font-size-base) * 1rem);
 
     .af-content-item-duo {

--- a/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
+++ b/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
@@ -7,7 +7,7 @@
     "icon label value"
     "icon label button";
   grid-template-columns: auto 1fr 1fr;
-  row-gap: calc(16 / var(--font-size-base) * 1rem);
+  row-gap: calc(8 / var(--font-size-base) * 1rem);
 
   &__label,
   &__value {

--- a/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
+++ b/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
@@ -42,8 +42,6 @@
       row-gap: 0;
     }
 
-    row-gap: calc(8 / var(--font-size-base) * 1rem);
-
     .af-content-item-duo {
       &__icon {
         margin-top: calc(4 / var(--font-size-base) * 1rem);
@@ -106,8 +104,6 @@
 @media (width <= #{breakpoints.$breakpoint-sm}) {
   .af-content-item-duo {
     &--large {
-      row-gap: calc(8 / var(--font-size-base) * 1rem);
-
       .af-content-item-duo {
         &__label,
         &__value {

--- a/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
+++ b/client/apollo/css/src/List/ContentItemDuo/ContentItemDuoCommon.scss
@@ -7,7 +7,7 @@
     "icon label value"
     "icon label button";
   grid-template-columns: auto 1fr 1fr;
-  row-gap: calc(8 / var(--font-size-base) * 1rem);
+  row-gap: calc(16 / var(--font-size-base) * 1rem);
 
   &__label,
   &__value {
@@ -51,7 +51,7 @@
 
       &__label,
       &__value {
-        font-size: calc(16 / var(--font-size-base) * 1rem);
+        font-size: calc(18 / var(--font-size-base) * 1rem);
         line-height: 125%;
       }
 


### PR DESCRIPTION
Le variant large devrait avoir les fonts à 18px au lieux de 16px sur desktop
le ROW GAP passe à 8px entre la ligne du haut et du bas.