### PR TITLE
feat(look&feel): removes uppercase transformation from footer

### DIFF
--- a/client/look-and-feel/css/src/Layout/Footer/Footer.scss
+++ b/client/look-and-feel/css/src/Layout/Footer/Footer.scss
@@ -5,7 +5,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  text-transform: uppercase;
   color: var(--color-white);
   background-color: var(--color-ocean-blue);
 


### PR DESCRIPTION
Removes the `text-transform: uppercase` style from the footer. This allows the footer text to be displayed in its original casing, improving readability and design flexibility.