### PR TITLE
fix(apollo, look&feel): add input id to InputTextAtom from InputText

### DIFF
--- a/client/apollo/react/src/Form/InputText/InputTextCommon.tsx
+++ b/client/apollo/react/src/Form/InputText/InputTextCommon.tsx
@@ -76,6 +76,7 @@ const InputText = forwardRef<HTMLInputElement, InputTextProps>(
         />
 
         <InputTextAtomComponent
+          id={inputId}
           ref={inputRef}
           unit={unit}
           className={componentClassName}


### PR DESCRIPTION
This pull request add the generated id from InputText to InputTextAtom to correctly link the label with this input.