### PR TITLE
feat(Footer): change hover link color

### DIFF
--- a/client/look-and-feel/css/src/Layout/Footer/Footer.scss
+++ b/client/look-and-feel/css/src/Layout/Footer/Footer.scss
@@ -50,7 +50,7 @@
     color: var(--color-white);
 
     &:hover {
-      color: var(--color-blue-1);
+      color: black;
     }
   }
 


### PR DESCRIPTION
## Fixes (#1218)

The links in the footer have too low contrast on hover, 3.28 instead of 4.5
After using the contrast finder tool to identify a similar color with a sufficient ratio
No color were found, so black color with a ratio of 4.58 was chosen

<img width="311" height="47" alt="image" src="https://github.com/user-attachments/assets/8db48eeb-0bcd-45af-9d03-743a93d8020f" />
