### PR TITLE
fix(apollo): textarea remove css double border

### DIFF
--- a/client/apollo/css/src/Form/TextArea/TextAreaApollo.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaApollo.scss
@@ -11,10 +11,6 @@
     --input-text-area-border-color: var(--axa-red-100);
   }
 
-  &:not(:placeholder-shown, :focus, :active) {
-    --input-text-area-box-shadow: var(--axa-blue-100);
-  }
-
   &--error:hover,
   &--error:focus {
     --input-text-area-border-color: var(--axa-red-100);


### PR DESCRIPTION
Fix double border in textarea error state
<img width="457" height="186" alt="image" src="https://github.com/user-attachments/assets/4a4afab6-a8fb-4f09-8d51-98f2284003f4" />
