### PR TITLE
feat(ProgressBarCommon): Add percentage display and step number visibility  (#1226)

### DIFF
--- a/client/apollo/css/src/ProgressBar/ProgressBarCommon.scss
+++ b/client/apollo/css/src/ProgressBar/ProgressBarCommon.scss
@@ -13,4 +13,17 @@
       0.75s ease-out,
       background-color 0.75s;
   }
+
+  &__text {
+    margin-top: 4px;
+    color: black;
+  }
+
+  &__step-indicator {
+    position: absolute;
+    display: flex;
+    margin-top: 4px;
+    flex-direction: column;
+    color: black;
+  }
 }

--- a/client/apollo/react/src/ProgressBar/ProgressBarCommon.tsx
+++ b/client/apollo/react/src/ProgressBar/ProgressBarCommon.tsx
@@ -3,13 +3,19 @@ const MAX_STEPPER_PROGRESS = 100;
 export type ProgressBarProps = {
   value: number;
   active?: boolean;
+  stepNumber?: number;
+  totalSteps?: number;
 };
 
 export const ProgressBar = ({
   value = MAX_STEPPER_PROGRESS,
   active = true,
+  stepNumber,
+  totalSteps,
 }: ProgressBarProps) => {
   const clampedValue = Math.max(0, Math.min(value, MAX_STEPPER_PROGRESS));
+  const showStepNumber =
+    totalSteps && totalSteps > 1 && stepNumber !== undefined;
   return (
     <div
       role="progressbar"
@@ -25,6 +31,14 @@ export const ProgressBar = ({
         className="af-progressbar__progress"
         style={{ width: `${clampedValue}%` }}
       />
+      <div />
+
+      <div className="af-progressbar__step-indicator">
+        {showStepNumber && (
+          <span className="af-step-label">{`Étape ${stepNumber} sur ${totalSteps}`}</span>
+        )}
+        <span className="af-progressbar__text">{`Progression ${clampedValue}%`}</span>
+      </div>
     </div>
   );
 };

--- a/client/apollo/react/src/ProgressBar/__tests__/ProgressBarCommon.test.tsx
+++ b/client/apollo/react/src/ProgressBar/__tests__/ProgressBarCommon.test.tsx
@@ -42,4 +42,17 @@ describe("ProgressBar Component", () => {
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).not.toHaveAttribute("aria-hidden", "true");
   });
+
+  describe("ProgressBar - percentage display", () => {
+    it("displays the percentage in all cases", () => {
+      render(<ProgressBar value={45} stepNumber={2} totalSteps={3} />);
+      expect(screen.getByText("Progression 45%")).toBeInTheDocument();
+
+      render(<ProgressBar value={100} stepNumber={1} totalSteps={3} />);
+      expect(screen.getByText("Progression 100%")).toBeInTheDocument();
+
+      render(<ProgressBar value={0} stepNumber={3} totalSteps={3} />);
+      expect(screen.getByText("Progression 0%")).toBeInTheDocument();
+    });
+  });
 });

--- a/client/apollo/react/src/ProgressBarGroup/ProgressBarGroupCommon.tsx
+++ b/client/apollo/react/src/ProgressBarGroup/ProgressBarGroupCommon.tsx
@@ -8,7 +8,7 @@ const MAX_STEPPER_PROGRESS = 100;
 export type ProgressBarGroupProps = {
   currentStepProgress?: number;
   currentStep: number;
-  nbSteps?: 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  nbSteps?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
   label?: string;
   className?: string;
   ProgressBarComponent: ComponentType<ComponentProps<typeof ProgressBar>>;
@@ -46,6 +46,8 @@ export const ProgressBarGroup = ({
           key={`${stepperId}-${index}`}
           value={getCurrentProgress(index)}
           active={index === currentStep}
+          stepNumber={index + 1}
+          totalSteps={nbSteps}
         />
       ))}
     </div>

--- a/client/apollo/react/src/ProgressBarGroup/__tests__/ProgressBarGroupCommon.test.tsx
+++ b/client/apollo/react/src/ProgressBarGroup/__tests__/ProgressBarGroupCommon.test.tsx
@@ -83,4 +83,30 @@ describe("ProgressBarGroup Component", () => {
     const group = screen.getByRole("group");
     expect(group).toHaveClass("custom-class");
   });
+
+  describe("ProgressBarGroup - step number display", () => {
+    it("displays the step number when totalSteps > 1", () => {
+      render(
+        <ProgressBarGroup
+          currentStep={2}
+          nbSteps={3}
+          ProgressBarComponent={ProgressBar}
+        />,
+      );
+      expect(screen.getByText("Étape 1 sur 3")).toBeInTheDocument();
+      expect(screen.getByText("Étape 2 sur 3")).toBeInTheDocument();
+      expect(screen.getByText("Étape 3 sur 3")).toBeInTheDocument();
+    });
+
+    it("does not display step numbers when totalSteps = 1", () => {
+      render(
+        <ProgressBarGroup
+          currentStep={1}
+          nbSteps={1}
+          ProgressBarComponent={ProgressBar}
+        />,
+      );
+      expect(screen.queryByText(/^Étape/)).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Updated ProgressBarCommon.tsx and ProgressBarGroupCommon.tsx to show the step number only when there are multiple steps

Render the percentage progress

<img width="842" height="38" alt="image" src="https://github.com/user-attachments/assets/337a0dc8-e583-422a-862c-44be9500ba9c" />

<img width="856" height="67" alt="image" src="https://github.com/user-attachments/assets/f69ec6ee-96c0-41f5-95f4-fc8db62be496" />

