### PR TITLE
fix(apollo): correct arrow direction for accordion component

### DIFF
--- a/client/apollo/react/src/AccordionCore/AccordionCoreCommon.tsx
+++ b/client/apollo/react/src/AccordionCore/AccordionCoreCommon.tsx
@@ -5,7 +5,7 @@ import {
   type ReactNode,
   useCallback,
 } from "react";
-import keyboardUp from "@material-symbols/svg-400/rounded/keyboard_arrow_up-fill.svg";
+import keyboardDown from "@material-symbols/svg-400/rounded/keyboard_arrow_down-fill.svg";
 import { Icon } from "../Icon/IconCommon";
 
 export type AccordionCoreProps = {
@@ -57,7 +57,7 @@ export const AccordionCoreCommon = ({
       >
         {summary}
         <div className={["af-accordion__arrow", "af-click-icon"].join(" ")}>
-          <IconComponent src={keyboardUp} role="presentation" />
+          <IconComponent src={keyboardDown} role="presentation" />
         </div>
       </summary>
       {children}


### PR DESCRIPTION
Fixed arrow  direction: UP when accordion is opened, DOWN when accordion is closed

<img width="1506" height="109" alt="image" src="https://github.com/user-attachments/assets/55948aef-ec35-4dc6-8fab-dcae88fb98d2" />
<img width="1513" height="204" alt="image" src="https://github.com/user-attachments/assets/092958b6-a803-4d11-84e9-90ac8ca1becd" />
