### PR TITLE
fix(look&feel, apollo): allow to use react hook form register on card checkbox

### DIFF
--- a/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
@@ -1,9 +1,4 @@
-import React, {
-  ComponentPropsWithRef,
-  useId,
-  type ComponentProps,
-  type ComponentType,
-} from "react";
+import React, { useId, type ComponentProps, type ComponentType } from "react";
 import { BREAKPOINT } from "../../../utilities/constants";
 import { getComponentClassName } from "../../../utilities/getComponentClassName";
 import { useIsSmallScreen } from "../../../utilities/hook/useIsSmallScreen";
@@ -11,7 +6,10 @@ import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
 import { CardCheckboxItem, type TCardCheckboxItem } from "./CardCheckboxItem";
 import type { CheckboxComponent, IconComponent } from "./types";
 
-export type CardCheckboxProps = ComponentPropsWithRef<"input"> & {
+export type CardCheckboxProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "disabled" | "size"
+> & {
   type: "vertical" | "horizontal";
   labelGroup?: string;
   descriptionGroup?: string;
@@ -39,6 +37,7 @@ export const CardCheckboxCommon = ({
   type = "vertical",
   error,
   ItemMessageComponent,
+  ...inputProps
 }: CardCheckboxCommonProps) => {
   const componentClassName = getComponentClassName(
     "af-card-checkbox__container",
@@ -69,7 +68,7 @@ export const CardCheckboxCommon = ({
       )}
       <div className="af-card-checkbox__choices">
         <ul className={checkboxGroupClassName}>
-          {options.map(({ hasError, ...inputProps }) => (
+          {options.map(({ hasError, ...optionProps }) => (
             <li key={crypto.randomUUID()}>
               <CardCheckboxItem
                 size={size}
@@ -79,6 +78,7 @@ export const CardCheckboxCommon = ({
                 IconComponent={IconComponent}
                 hasError={Boolean(error) || hasError}
                 {...inputProps}
+                {...optionProps}
               />
             </li>
           ))}

--- a/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
@@ -6,10 +6,7 @@ import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
 import { CardCheckboxItem, type TCardCheckboxItem } from "./CardCheckboxItem";
 import type { CheckboxComponent, IconComponent } from "./types";
 
-export type CardCheckboxProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "disabled" | "size"
-> & {
+export type CardCheckboxProps = Partial<TCardCheckboxItem> & {
   type: "vertical" | "horizontal";
   labelGroup?: string;
   descriptionGroup?: string;
@@ -71,13 +68,13 @@ export const CardCheckboxCommon = ({
           {options.map(({ hasError, ...optionProps }) => (
             <li key={crypto.randomUUID()}>
               <CardCheckboxItem
+                {...inputProps}
                 size={size}
                 errorId={errorId}
                 onChange={onChange}
                 CheckboxComponent={CheckboxComponent}
                 IconComponent={IconComponent}
                 hasError={Boolean(error) || hasError}
-                {...inputProps}
                 {...optionProps}
               />
             </li>

--- a/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
@@ -1,4 +1,9 @@
-import React, { useId, type ComponentProps, type ComponentType } from "react";
+import {
+  useId,
+  type ChangeEventHandler,
+  type ComponentProps,
+  type ComponentType,
+} from "react";
 import { BREAKPOINT } from "../../../utilities/constants";
 import { getComponentClassName } from "../../../utilities/getComponentClassName";
 import { useIsSmallScreen } from "../../../utilities/hook/useIsSmallScreen";
@@ -12,7 +17,7 @@ export type CardCheckboxProps = Partial<TCardCheckboxItem> & {
   descriptionGroup?: string;
   isRequired?: boolean;
   options: TCardCheckboxItem[];
-  onChange?: React.ChangeEventHandler;
+  onChange?: ChangeEventHandler;
   error?: string;
 };
 

--- a/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -1,11 +1,11 @@
-import React, { forwardRef } from "react";
+import { forwardRef, type InputHTMLAttributes } from "react";
 import { Svg } from "../../../Svg/Svg";
 
 export type CheckboxProps = {
   errorId?: string;
   hasError?: boolean;
   className?: string;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "disabled">;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, "disabled">;
 
 type CheckboxCommonProps = CheckboxProps & {
   checkBoxIcon: string;

--- a/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -1,13 +1,13 @@
 import React, { forwardRef } from "react";
 import { Svg } from "../../../Svg/Svg";
 
-export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement> & {
+export type CheckboxProps = {
   errorId?: string;
   hasError?: boolean;
   className?: string;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, "disabled">;
 
-export type CheckboxCommonProps = CheckboxProps & {
+type CheckboxCommonProps = CheckboxProps & {
   checkBoxIcon: string;
 };
 

--- a/samples/vite/src/Client.tsx
+++ b/samples/vite/src/Client.tsx
@@ -1,6 +1,7 @@
 import {
   Button as ButtonClient,
   buttonVariants as ButtonClientVariants,
+  CardCheckbox,
   RadioCard,
   Select,
   Svg,
@@ -14,6 +15,7 @@ type Inputs = {
   exampleTextInput: string;
   exampleSelectInput: string;
   exampleRadioInput: string;
+  exampleCheckboxInput: string[];
 };
 
 const Client = () => {
@@ -26,9 +28,11 @@ const Client = () => {
       exampleTextInput: "",
       exampleSelectInput: "",
       exampleRadioInput: "",
+      exampleCheckboxInput: [],
     },
   });
   const onSubmit: SubmitHandler<Inputs> = (data) => console.log(data);
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <section className="design-section">
@@ -67,8 +71,10 @@ const Client = () => {
 
         <article>
           <RadioCard
+            labelGroup="Card Radio Group"
             type="vertical"
             isRequired
+            error={errors.exampleRadioInput?.message}
             options={[
               {
                 label: "Option 1",
@@ -81,11 +87,33 @@ const Client = () => {
                 description: "Description for option 2",
               },
             ]}
-            labelGroup="Card Radio Group"
             {...register("exampleRadioInput", {
               required: "This field is required",
             })}
-            error={errors.exampleRadioInput?.message}
+          />
+        </article>
+
+        <article>
+          <CardCheckbox
+            labelGroup="Card Checkbox Group"
+            type="vertical"
+            isRequired
+            error={errors.exampleCheckboxInput?.message}
+            options={[
+              {
+                label: "Checkbox 1",
+                value: "checkbox1",
+                description: "Description for checkbox 1",
+              },
+              {
+                label: "Checkbox 2",
+                value: "checkbox2",
+                description: "Description for checkbox 2",
+              },
+            ]}
+            {...register("exampleCheckboxInput", {
+              required: "This field is required",
+            })}
           />
         </article>
 


### PR DESCRIPTION
This pull request update the type of `...inputProps` in the CardCheckboxCommon component.
Now, it will be possible to use React Hook Form `register()` function directly into the component like this : 

```tsx
<CardCheckbox
  labelGroup="Card Checkbox Group"
  type="vertical"
  isRequired
  error={errors.exampleCheckboxInput?.message}
  options={[
    {
      label: "Checkbox 1",
      value: "checkbox1",
      description: "Description for checkbox 1",
    },
    {
      label: "Checkbox 2",
      value: "checkbox2",
      description: "Description for checkbox 2",
    },
  ]}
  {...register("exampleCheckboxInput", {
    required: "This field is required",
  })}
/>
```