### PR TITLE
feat(Footer): add aria-expended and aria-controls on mobile button menu links (#1219)

### DIFF
--- a/client/look-and-feel/react/src/Layout/Footer/Footer.tsx
+++ b/client/look-and-feel/react/src/Layout/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import "@axa-fr/design-system-look-and-feel-css/dist/Layout/Footer/Footer.scss";
 import expandMore from "@material-symbols/svg-400/outlined/keyboard_arrow_down.svg";
 import classNames from "classnames";
-import { FC, useCallback, useState } from "react";
+import { FC, useCallback, useId, useState } from "react";
 import { MenuIcons, SocialMedia } from "./MenuIcons";
 import { Link, MenuLink } from "./MenuLink";
 import { Svg } from "../../Svg";
@@ -25,6 +25,7 @@ export const Footer: FC<Props> = ({
   const handleClick = useCallback(() => {
     setIsAboutOpen((isOpen) => !isOpen);
   }, []);
+  const navLinkControlId = useId();
   return (
     <footer role="contentinfo" id={id} className="af-footer">
       <div className="af-footer__footerTop">
@@ -37,6 +38,8 @@ export const Footer: FC<Props> = ({
             type="button"
             onClick={handleClick}
             className="af-footer__menuAboutTrigger"
+            aria-expanded={isAboutOpen}
+            aria-controls={navLinkControlId}
           >
             <span className="af-footer__menuAboutTriggerText">
               {expandLinkText}
@@ -50,7 +53,11 @@ export const Footer: FC<Props> = ({
               )}
             />
           </button>
-          <MenuLink links={links} isAboutOpen={isAboutOpen} />
+          <MenuLink
+            links={links}
+            isAboutOpen={isAboutOpen}
+            idMenuLink={navLinkControlId}
+          />
         </nav>
         <MenuIcons socialMedias={socialMedias} />
       </div>

--- a/client/look-and-feel/react/src/Layout/Footer/MenuLink.tsx
+++ b/client/look-and-feel/react/src/Layout/Footer/MenuLink.tsx
@@ -10,9 +10,14 @@ export type Link = {
 type MenuLinkProps = {
   links: Link[];
   isAboutOpen?: boolean;
+  idMenuLink?: string;
 };
 
-export const MenuLink = ({ links, isAboutOpen = false }: MenuLinkProps) => {
+export const MenuLink = ({
+  links,
+  isAboutOpen = false,
+  idMenuLink,
+}: MenuLinkProps) => {
   const isSmallScreen = useIsSmallScreen(BREAKPOINT.MD);
 
   if (links.length === 0) {
@@ -24,6 +29,7 @@ export const MenuLink = ({ links, isAboutOpen = false }: MenuLinkProps) => {
         "af-footer__menuLinks",
         isAboutOpen && "af-footer__menuLinks--display",
       )}
+      id={idMenuLink}
     >
       {links.map((menuItem) => (
         <li key={menuItem.text}>


### PR DESCRIPTION
Used aria-expanded to reflect the current state of the menu (open or closed)
Implemented aria-controls on the button to reference the menu <ul>, with a dynamically generated unique ID using useId()

<img width="712" height="179" alt="image" src="https://github.com/user-attachments/assets/45832a46-cab1-4cfd-9c46-0989d6ae17c4" />
