### PR TITLE
fix(apollo,look&feel): using same card radio item keys between rerenders

### DIFF
--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -56,7 +56,8 @@ const CardRadioCommon = ({
     type,
   );
 
-  const errorId = useId();
+  const cardRadioId = useId();
+  const errorId = `${cardRadioId}-error`;
 
   const isMobile = useIsSmallScreen(BREAKPOINT.SM);
   const size: ComponentProps<typeof CardRadioItem>["size"] = isMobile
@@ -84,7 +85,7 @@ const CardRadioCommon = ({
       <div className={RadioGroupClassName}>
         {options.map((cardRadioItemProps) => (
           <CardRadioItem
-            key={`${name}-${crypto.randomUUID()}`}
+            key={`${name ?? cardRadioId}-${cardRadioItemProps.label}`}
             name={name}
             onChange={onChange}
             size={size}

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -57,7 +57,7 @@ const CardRadioCommon = ({
   );
 
   const cardRadioId = useId();
-  const errorId = `${cardRadioId}-error`;
+  const errorId = `${cardRadioId}:error`;
 
   const isMobile = useIsSmallScreen(BREAKPOINT.SM);
   const size: ComponentProps<typeof CardRadioItem>["size"] = isMobile


### PR DESCRIPTION
This PR fixed the keyboard navigation issues caused by RadioCardItem keys being randomly generated every re-render