### PR TITLE
fix(apollo,look&feel): Correction d'espacement sur le composant Accordion

### DIFF
--- a/apps/apollo-stories/src/components/Accordion/Accordion.mdx
+++ b/apps/apollo-stories/src/components/Accordion/Accordion.mdx
@@ -41,6 +41,20 @@ export const AccordionComponent = () => (
 );
 ```
 
-<Canvas of={AccordionStories.AccordionStory} />
+### Accordion Playground
 
-<Controls of={AccordionStories.AccordionStory} />
+<Canvas of={AccordionStories.AccordionDefaultStory} />
+
+<Controls of={AccordionStories.AccordionDefaultStory} />
+
+### Accordion Primary
+
+<Canvas of={AccordionStories.AccordionPrimaryStory} />
+
+<Controls of={AccordionStories.AccordionPrimaryStory} />
+
+### Accordion secondary
+
+<Canvas of={AccordionStories.AccordionSecondaryStory} />
+
+<Controls of={AccordionStories.AccordionSecondaryStory} />

--- a/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
@@ -16,18 +16,14 @@ const meta: Meta<typeof Accordion> = {
 
 export default meta;
 
-const defaultArgs = {
+const commonArgs = {
   variant: "primary" as AccordionVariants,
-  icon: bank,
   title: "Titre onglet",
   subtitle: "Sous-titre onglet",
   tagLabel: "En attente",
   tagProps: {
     variant: "warning" as TagVariants,
   },
-  dateLabel: "01/01/2021",
-  dateProps: { dateTime: "2021-01-01" },
-  info1: "Lorem ipsum dolor sit amet",
   info2: "+ 686,00 €",
   children: (
     <>
@@ -67,31 +63,55 @@ const defaultArgs = {
   onClick: action("Accordion has been clicked"),
 };
 
-export const AccordionStorySecondary: StoryObj<
+export const AccordionDefaultStory: StoryObj<ComponentProps<typeof Accordion>> =
+  {
+    name: "Accordion",
+    render: (args) => <Accordion {...args} />,
+    args: {
+      ...commonArgs,
+      icon: bank,
+      dateLabel: "01/01/2021",
+      dateProps: { dateTime: "2021-01-01" },
+      info1: "Lorem ipsum dolor sit amet",
+    },
+    argTypes: {
+      dateLabel: { control: "text" },
+      variant: {
+        options: Object.values(accordionVariants),
+        control: { type: "select" },
+        value: accordionVariants.secondary,
+      },
+    },
+  };
+
+export const AccordionPrimaryStory: StoryObj<ComponentProps<typeof Accordion>> =
+  {
+    name: "Accordion Primary",
+    render: (args) => <Accordion {...args} />,
+    args: {
+      ...commonArgs,
+      icon: bank,
+      info1: "Lorem ipsum dolor sit amet",
+    },
+    argTypes: {
+      dateLabel: { control: "text" },
+      variant: { control: "text" },
+    },
+  };
+
+export const AccordionSecondaryStory: StoryObj<
   ComponentProps<typeof Accordion>
 > = {
-  name: "Accordion",
-  render: (args) => <Accordion {...args} />,
-  args: defaultArgs,
-  argTypes: {
-    dateLabel: { control: "text" },
-    variant: {
-      options: Object.values(accordionVariants),
-      control: { type: "select" },
-      value: accordionVariants.secondary,
-    },
-  },
-};
-
-export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
   name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
-  args: defaultArgs,
+  args: {
+    ...commonArgs,
+    variant: "secondary" as AccordionVariants,
+    dateLabel: "01/01/2021",
+    dateProps: { dateTime: "2021-01-01" },
+  },
   argTypes: {
     dateLabel: { control: "text" },
-    variant: {
-      options: Object.values(accordionVariants),
-      control: { type: "select" },
-    },
+    variant: { control: "text" },
   },
 };

--- a/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
@@ -85,12 +85,57 @@ export const AccordionStorySecondary: StoryObj<
 export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
   name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
-  args: defaultArgs,
+  args: {
+    variant: "secondary" as AccordionVariants,
+    icon: bank,
+    title: "Titre onglet",
+    subtitle: "Sous-titre onglet",
+    tagLabel: "En attente",
+    tagProps: {
+      variant: "warning" as TagVariants,
+    },
+    dateLabel: "01/01/2021",
+    dateProps: { dateTime: "2021-01-01" },
+    info1: "Lorem ipsum dolor sit amet",
+    info2: "+ 686,00 €",
+    children: (
+      <>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          consectetur urna a tellus semper, id elementum ligula fermentum. In
+          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
+          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
+          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
+          vulputate at elit.
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          consectetur urna a tellus semper, id elementum ligula fermentum. In
+          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
+          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
+          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
+          vulputate at elit.
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          consectetur urna a tellus semper, id elementum ligula fermentum. In
+          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
+          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
+          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
+          vulputate at elit.
+        </p>
+      </>
+    ),
+    isOpen: undefined,
+    onClick: undefined,
+  },
   argTypes: {
     dateLabel: { control: "text" },
-    variant: {
-      options: Object.values(accordionVariants),
-      control: { type: "select" },
-    },
   },
 };

--- a/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
@@ -7,6 +7,7 @@ import {
 import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 import bank from "@material-symbols/svg-700/rounded/account_balance-fill.svg";
+import { action } from "@storybook/addon-actions";
 
 const meta: Meta<typeof Accordion> = {
   component: Accordion,
@@ -63,7 +64,7 @@ const defaultArgs = {
     </>
   ),
   isOpen: undefined,
-  onClick: undefined,
+  onClick: action("Accordion has been clicked"),
 };
 
 export const AccordionStorySecondary: StoryObj<
@@ -85,57 +86,12 @@ export const AccordionStorySecondary: StoryObj<
 export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
   name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
-  args: {
-    variant: "secondary" as AccordionVariants,
-    icon: bank,
-    title: "Titre onglet",
-    subtitle: "Sous-titre onglet",
-    tagLabel: "En attente",
-    tagProps: {
-      variant: "warning" as TagVariants,
-    },
-    dateLabel: "01/01/2021",
-    dateProps: { dateTime: "2021-01-01" },
-    info1: "Lorem ipsum dolor sit amet",
-    info2: "+ 686,00 €",
-    children: (
-      <>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-          consectetur urna a tellus semper, id elementum ligula fermentum. In
-          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
-          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
-          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
-          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
-          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
-          vulputate at elit.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-          consectetur urna a tellus semper, id elementum ligula fermentum. In
-          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
-          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
-          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
-          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
-          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
-          vulputate at elit.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-          consectetur urna a tellus semper, id elementum ligula fermentum. In
-          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
-          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
-          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
-          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
-          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
-          vulputate at elit.
-        </p>
-      </>
-    ),
-    isOpen: undefined,
-    onClick: undefined,
-  },
+  args: defaultArgs,
   argTypes: {
     dateLabel: { control: "text" },
+    variant: {
+      options: Object.values(accordionVariants),
+      control: { type: "select" },
+    },
   },
 };

--- a/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/apollo-stories/src/components/Accordion/Accordion.stories.tsx
@@ -66,8 +66,24 @@ const defaultArgs = {
   onClick: undefined,
 };
 
-export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
+export const AccordionStorySecondary: StoryObj<
+  ComponentProps<typeof Accordion>
+> = {
   name: "Accordion",
+  render: (args) => <Accordion {...args} />,
+  args: defaultArgs,
+  argTypes: {
+    dateLabel: { control: "text" },
+    variant: {
+      options: Object.values(accordionVariants),
+      control: { type: "select" },
+      value: accordionVariants.secondary,
+    },
+  },
+};
+
+export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
+  name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
   args: defaultArgs,
   argTypes: {

--- a/apps/look-and-feel-stories/src/Accordion/Accordion.mdx
+++ b/apps/look-and-feel-stories/src/Accordion/Accordion.mdx
@@ -41,6 +41,20 @@ export const AccordionComponent = () => (
 );
 ```
 
-<Canvas of={AccordionStories.AccordionStory} />
+### Accordion Playground
 
-<Controls of={AccordionStories.AccordionStory} />
+<Canvas of={AccordionStories.AccordionDefaultStory} />
+
+<Controls of={AccordionStories.AccordionDefaultStory} />
+
+### Accordion Primary
+
+<Canvas of={AccordionStories.AccordionPrimaryStory} />
+
+<Controls of={AccordionStories.AccordionPrimaryStory} />
+
+### Accordion secondary
+
+<Canvas of={AccordionStories.AccordionSecondaryStory} />
+
+<Controls of={AccordionStories.AccordionSecondaryStory} />

--- a/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
+++ b/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
@@ -7,6 +7,7 @@ import {
 import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 import bank from "@material-symbols/svg-700/rounded/account_balance-fill.svg";
+import { action } from "@storybook/addon-actions";
 
 const meta: Meta<typeof Accordion> = {
   component: Accordion,
@@ -63,7 +64,7 @@ const defaultArgs = {
     </>
   ),
   isOpen: undefined,
-  onClick: undefined,
+  onClick: action("Accordion has been clicked"),
 };
 
 export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
@@ -72,11 +73,6 @@ export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
   args: defaultArgs,
   argTypes: {
     dateLabel: { control: "text" },
-    variant: {
-      options: Object.values(accordionVariants),
-      value: accordionVariants.secondary,
-      control: { type: "select" },
-    },
   },
 };
 

--- a/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
+++ b/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
@@ -3,7 +3,7 @@ import {
   accordionVariants,
   AccordionVariants,
   TagVariants,
-} from "@axa-fr/design-system-apollo-react";
+} from "@axa-fr/design-system-apollo-react/lf";
 import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 import bank from "@material-symbols/svg-700/rounded/account_balance-fill.svg";
@@ -66,9 +66,7 @@ const defaultArgs = {
   onClick: undefined,
 };
 
-export const AccordionStorySecondary: StoryObj<
-  ComponentProps<typeof Accordion>
-> = {
+export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
   name: "Accordion",
   render: (args) => <Accordion {...args} />,
   args: defaultArgs,
@@ -76,13 +74,15 @@ export const AccordionStorySecondary: StoryObj<
     dateLabel: { control: "text" },
     variant: {
       options: Object.values(accordionVariants),
-      control: { type: "select" },
       value: accordionVariants.secondary,
+      control: { type: "select" },
     },
   },
 };
 
-export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
+export const AccordionStorySecondary: StoryObj<
+  ComponentProps<typeof Accordion>
+> = {
   name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
   args: defaultArgs,
@@ -91,6 +91,7 @@ export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
     variant: {
       options: Object.values(accordionVariants),
       control: { type: "select" },
+      value: { secondary: accordionVariants.secondary },
     },
   },
 };

--- a/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
+++ b/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
@@ -16,18 +16,14 @@ const meta: Meta<typeof Accordion> = {
 
 export default meta;
 
-const defaultArgs = {
+const commonArgs = {
   variant: "primary" as AccordionVariants,
-  icon: bank,
   title: "Titre onglet",
   subtitle: "Sous-titre onglet",
   tagLabel: "En attente",
   tagProps: {
     variant: "warning" as TagVariants,
   },
-  dateLabel: "01/01/2021",
-  dateProps: { dateTime: "2021-01-01" },
-  info1: "Lorem ipsum dolor sit amet",
   info2: "+ 686,00 €",
   children: (
     <>
@@ -67,27 +63,55 @@ const defaultArgs = {
   onClick: action("Accordion has been clicked"),
 };
 
-export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
-  name: "Accordion",
-  render: (args) => <Accordion {...args} />,
-  args: defaultArgs,
-  argTypes: {
-    dateLabel: { control: "text" },
-  },
-};
+export const AccordionDefaultStory: StoryObj<ComponentProps<typeof Accordion>> =
+  {
+    name: "Accordion",
+    render: (args) => <Accordion {...args} />,
+    args: {
+      ...commonArgs,
+      icon: bank,
+      dateLabel: "01/01/2021",
+      dateProps: { dateTime: "2021-01-01" },
+      info1: "Lorem ipsum dolor sit amet",
+    },
+    argTypes: {
+      dateLabel: { control: "text" },
+      variant: {
+        options: Object.values(accordionVariants),
+        control: { type: "select" },
+        value: accordionVariants.secondary,
+      },
+    },
+  };
 
-export const AccordionStorySecondary: StoryObj<
+export const AccordionPrimaryStory: StoryObj<ComponentProps<typeof Accordion>> =
+  {
+    name: "Accordion Primary",
+    render: (args) => <Accordion {...args} />,
+    args: {
+      ...commonArgs,
+      icon: bank,
+      info1: "Lorem ipsum dolor sit amet",
+    },
+    argTypes: {
+      dateLabel: { control: "text" },
+      variant: { control: "text" },
+    },
+  };
+
+export const AccordionSecondaryStory: StoryObj<
   ComponentProps<typeof Accordion>
 > = {
   name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
-  args: defaultArgs,
+  args: {
+    ...commonArgs,
+    variant: "secondary" as AccordionVariants,
+    dateLabel: "01/01/2021",
+    dateProps: { dateTime: "2021-01-01" },
+  },
   argTypes: {
     dateLabel: { control: "text" },
-    variant: {
-      options: Object.values(accordionVariants),
-      control: { type: "select" },
-      value: { secondary: accordionVariants.secondary },
-    },
+    variant: { control: "text" },
   },
 };

--- a/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
+++ b/apps/look-and-feel-stories/src/Accordion/Accordion.stories.tsx
@@ -3,7 +3,7 @@ import {
   accordionVariants,
   AccordionVariants,
   TagVariants,
-} from "@axa-fr/design-system-apollo-react/lf";
+} from "@axa-fr/design-system-apollo-react";
 import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 import bank from "@material-symbols/svg-700/rounded/account_balance-fill.svg";
@@ -28,15 +28,62 @@ const defaultArgs = {
   dateProps: { dateTime: "2021-01-01" },
   info1: "Lorem ipsum dolor sit amet",
   info2: "+ 686,00 €",
-  children: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam semper magna et tempor blandit. 
-              Nulla vitae eros a odio pretium gravida. Sed eget tortor nec massa lobortis bibendum. Morbi eget 
-              ligula porttitor, euismod odio vestibulum, porta massa. Aenean vel venenatis tellus, sed iaculis nisl.`,
+  children: (
+    <>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+        consectetur urna a tellus semper, id elementum ligula fermentum. In
+        semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+        purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+        dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus at
+        nulla fermentum semper. In ipsum urna, tempus vel lorem vel, venenatis
+        malesuada dui. Cras massa ipsum, accumsan et scelerisque ut, vulputate
+        at elit.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+        consectetur urna a tellus semper, id elementum ligula fermentum. In
+        semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+        purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+        dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus at
+        nulla fermentum semper. In ipsum urna, tempus vel lorem vel, venenatis
+        malesuada dui. Cras massa ipsum, accumsan et scelerisque ut, vulputate
+        at elit.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+        consectetur urna a tellus semper, id elementum ligula fermentum. In
+        semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+        purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+        dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus at
+        nulla fermentum semper. In ipsum urna, tempus vel lorem vel, venenatis
+        malesuada dui. Cras massa ipsum, accumsan et scelerisque ut, vulputate
+        at elit.
+      </p>
+    </>
+  ),
   isOpen: undefined,
   onClick: undefined,
 };
 
-export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
+export const AccordionStorySecondary: StoryObj<
+  ComponentProps<typeof Accordion>
+> = {
   name: "Accordion",
+  render: (args) => <Accordion {...args} />,
+  args: defaultArgs,
+  argTypes: {
+    dateLabel: { control: "text" },
+    variant: {
+      options: Object.values(accordionVariants),
+      control: { type: "select" },
+      value: accordionVariants.secondary,
+    },
+  },
+};
+
+export const AccordionStory: StoryObj<ComponentProps<typeof Accordion>> = {
+  name: "Accordion Secondary",
   render: (args) => <Accordion {...args} />,
   args: defaultArgs,
   argTypes: {

--- a/client/apollo/css/src/Accordion/AccordionApollo.scss
+++ b/client/apollo/css/src/Accordion/AccordionApollo.scss
@@ -18,6 +18,17 @@
     --accordion-info1-font-size: calc(16 / var(--font-size-base) * 1rem);
   }
 
+  .af-accordion__date {
+    --accordion-secondary-date-font-size: calc(
+      16 / var(--font-size-base) * 1rem
+    );
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      --accordion-secondary-date-font-size: calc(
+        16 / var(--font-size-base) * 1rem
+      );
+    }
+  }
+
   &--primary {
     --accordion-title-text-color: var(--axa-blue-100);
   }
@@ -28,6 +39,9 @@
 
     @media (width > #{breakpoints.$breakpoint-md}) {
       --accordion-info1-font-size-secondary: calc(
+        16 / var(--font-size-base) * 1rem
+      );
+      --accordion-secondary-date-font-size: calc(
         16 / var(--font-size-base) * 1rem
       );
     }

--- a/client/apollo/css/src/Accordion/AccordionApollo.scss
+++ b/client/apollo/css/src/Accordion/AccordionApollo.scss
@@ -1,4 +1,5 @@
 @use "./AccordionCommon";
+@use "../common/breakpoints" as breakpoints;
 
 .af-apollo-accordion {
   --accordion-info1-text-color: var(--neutral-80);
@@ -8,12 +9,20 @@
   --accordion-font-size: calc(16 / var(--font-size-base) * 1rem);
   --accordion-subtitle-font-size: calc(14 / var(--font-size-base) * 1rem);
   --accordion-line-height: 1.25;
+  --accordion-row-gap: calc(2 / var(--font-size-base) * 1rem);
+  --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
+
+  @media (width < #{breakpoints.$breakpoint-md}) {
+    --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
+    --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
+  }
 
   &--primary {
     --accordion-title-text-color: var(--axa-blue-100);
   }
 
   &--secondary {
+    --accordion-date-text-color: var(--neutral-80);
     --accordion-title-text-color: var(--neutral-100);
   }
 }

--- a/client/apollo/css/src/Accordion/AccordionApollo.scss
+++ b/client/apollo/css/src/Accordion/AccordionApollo.scss
@@ -6,13 +6,16 @@
   --accordion-info2-text-color: var(--green-100);
   --accordion-title-text-color: var(--axa-blue-100);
   --accordion-subtitle-text-color: var(--neutral-80);
-  --accordion-font-size: calc(16 / var(--font-size-base) * 1rem);
+  --accordion-title-font-size: calc(16 / var(--font-size-base) * 1rem);
   --accordion-subtitle-font-size: calc(14 / var(--font-size-base) * 1rem);
+  --accordion-info2-font-size: calc(16 / var(--font-size-base) * 1rem);
+  --accordion-info1-font-size: calc(14 / var(--font-size-base) * 1rem);
   --accordion-line-height: 1.25;
   --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
 
   @media (width > #{breakpoints.$breakpoint-md}) {
     --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
+    --accordion-info1-font-size: calc(16 / var(--font-size-base) * 1rem);
   }
 
   &--primary {
@@ -22,5 +25,11 @@
   &--secondary {
     --accordion-date-text-color: var(--neutral-80);
     --accordion-title-text-color: var(--neutral-100);
+
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      --accordion-info1-font-size-secondary: calc(
+        16 / var(--font-size-base) * 1rem
+      );
+    }
   }
 }

--- a/client/apollo/css/src/Accordion/AccordionApollo.scss
+++ b/client/apollo/css/src/Accordion/AccordionApollo.scss
@@ -9,12 +9,10 @@
   --accordion-font-size: calc(16 / var(--font-size-base) * 1rem);
   --accordion-subtitle-font-size: calc(14 / var(--font-size-base) * 1rem);
   --accordion-line-height: 1.25;
-  --accordion-row-gap: calc(2 / var(--font-size-base) * 1rem);
-  --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
+  --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
 
-  @media (width < #{breakpoints.$breakpoint-md}) {
-    --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
-    --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
+  @media (width > #{breakpoints.$breakpoint-md}) {
+    --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
   }
 
   &--primary {

--- a/client/apollo/css/src/Accordion/AccordionCommon.scss
+++ b/client/apollo/css/src/Accordion/AccordionCommon.scss
@@ -13,7 +13,7 @@
     font-family: var(--font-family-base);
 
     @media (width > #{breakpoints.$breakpoint-md}) {
-      gap: var(--accordion-row-gap) var(--accordion-column-gap);
+      --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
     }
 
     .af-icon:first-child {
@@ -23,7 +23,7 @@
     .af-accordion {
       &__title {
         grid-area: title;
-        font-size: var(--accordion-font-size);
+        font-size: var(--accordion-title-font-size);
         font-weight: 600;
         line-height: var(--accordion-line-height);
         color: var(--accordion-title-text-color);
@@ -43,15 +43,19 @@
 
       &__date {
         grid-area: date-container;
+        font-size: var(--accordion-info1-font-size-secondary);
       }
 
       &__info1 {
         grid-area: info1;
+        font-size: var(--accordion-info1-font-size);
         color: var(--accordion-info1-text-color);
       }
 
       &__info2 {
         grid-area: info2;
+        align-items: center;
+        font-size: var(--accordion-info2-font-size);
         color: var(--accordion-info2-text-color);
       }
     }
@@ -70,6 +74,7 @@
       --summary-areas: "icon title tag-container info1 info2 arrow"
         "icon subtitle tag-container info1 info2 arrow";
       --summary-columns: min-content 1fr 1fr 1fr max-content max-content;
+      --accordion-info1-font-size: calc(16 / var(--font-size-base) * 1rem);
     }
   }
 
@@ -88,12 +93,18 @@
       &__info1 {
         display: none;
       }
+
+      &__date {
+        font-size: var(--accordion-info1-font-size-secondary);
+      }
     }
 
     @media (width > #{breakpoints.$breakpoint-md}) {
       --summary-areas: "tag-container date-container title info2 arrow"
         "tag-container date-container subtitle info2 arrow";
       --summary-columns: max-content min-content 1fr max-content max-content;
+
+      font-size: var(--accordion-info1-font-size-secondary);
     }
   }
 }

--- a/client/apollo/css/src/Accordion/AccordionCommon.scss
+++ b/client/apollo/css/src/Accordion/AccordionCommon.scss
@@ -5,6 +5,11 @@
     grid-template-areas: var(--summary-areas);
     grid-template-columns: var(--summary-columns);
     align-items: center;
+    gap: var(--accordion-row-gap) var(--accordion-column-gap);
+
+    @media (width < #{breakpoints.$breakpoint-md}) {
+      gap: var(--accordion-gap) var(--accordion-column-gap);
+    }
 
     .af-icon:first-child {
       grid-area: icon;
@@ -64,6 +69,8 @@
   }
 
   &--secondary {
+    color: var(--accordion-date-text-color);
+
     --summary-areas: "tag-container date-container title info2 arrow"
       "tag-container date-container subtitle info2 arrow";
     --summary-columns: max-content min-content 1fr max-content max-content;

--- a/client/apollo/css/src/Accordion/AccordionCommon.scss
+++ b/client/apollo/css/src/Accordion/AccordionCommon.scss
@@ -2,13 +2,18 @@
 
 .af-apollo-accordion {
   &__summary {
+    --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
+    --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
+    --accordion-row-gap: calc(2 / var(--font-size-base) * 1rem);
+
     grid-template-areas: var(--summary-areas);
     grid-template-columns: var(--summary-columns);
     align-items: center;
-    gap: var(--accordion-row-gap) var(--accordion-column-gap);
+    gap: var(--accordion-gap) var(--accordion-column-gap);
+    font-family: var(--font-family-base);
 
-    @media (width < #{breakpoints.$breakpoint-md}) {
-      gap: var(--accordion-gap) var(--accordion-column-gap);
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      gap: var(--accordion-row-gap) var(--accordion-column-gap);
     }
 
     .af-icon:first-child {
@@ -53,27 +58,27 @@
   }
 
   &--primary {
-    --summary-areas: "icon title tag-container info1 info2 arrow"
-      "icon subtitle tag-container info1 info2 arrow";
-    --summary-columns: min-content 1fr 1fr 1fr max-content max-content;
+    --summary-areas: "icon title arrow" "icon subtitle arrow"
+      "icon tag-container arrow" "icon info1 arrow" "icon info2 arrow";
+    --summary-columns: min-content 1fr min-content;
 
     .af-apollo-accordion__summary .af-accordion__date {
       display: none;
     }
 
-    @media (width < #{breakpoints.$breakpoint-md}) {
-      --summary-areas: "icon title arrow" "icon subtitle arrow"
-        "icon tag-container arrow" "icon info1 arrow" "icon info2 arrow";
-      --summary-columns: min-content 1fr min-content;
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      --summary-areas: "icon title tag-container info1 info2 arrow"
+        "icon subtitle tag-container info1 info2 arrow";
+      --summary-columns: min-content 1fr 1fr 1fr max-content max-content;
     }
   }
 
   &--secondary {
-    color: var(--accordion-date-text-color);
+    --summary-areas: "tag-container arrow" "date-container arrow" "title arrow"
+      "subtitle arrow" "info2 arrow";
+    --summary-columns: 1fr max-content;
 
-    --summary-areas: "tag-container date-container title info2 arrow"
-      "tag-container date-container subtitle info2 arrow";
-    --summary-columns: max-content min-content 1fr max-content max-content;
+    color: var(--accordion-date-text-color);
 
     .af-apollo-accordion__summary .af-accordion {
       &__icon {
@@ -85,10 +90,10 @@
       }
     }
 
-    @media (width < #{breakpoints.$breakpoint-md}) {
-      --summary-areas: "tag-container arrow" "date-container arrow"
-        "title arrow" "subtitle arrow" "info2 arrow";
-      --summary-columns: 1fr max-content;
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      --summary-areas: "tag-container date-container title info2 arrow"
+        "tag-container date-container subtitle info2 arrow";
+      --summary-columns: max-content min-content 1fr max-content max-content;
     }
   }
 }

--- a/client/apollo/css/src/Accordion/AccordionCommon.scss
+++ b/client/apollo/css/src/Accordion/AccordionCommon.scss
@@ -43,7 +43,11 @@
 
       &__date {
         grid-area: date-container;
-        font-size: var(--accordion-info1-font-size-secondary);
+        font-size: var(--accordion-secondary-date-font-size);
+
+        @media (width > #{breakpoints.$breakpoint-md}) {
+          font-size: var(--accordion-secondary-date-font-size);
+        }
       }
 
       &__info1 {
@@ -65,6 +69,7 @@
     --summary-areas: "icon title arrow" "icon subtitle arrow"
       "icon tag-container arrow" "icon info1 arrow" "icon info2 arrow";
     --summary-columns: min-content 1fr min-content;
+    --accordion-info1-font-size: calc(14 / var(--font-size-base) * 1rem);
 
     .af-apollo-accordion__summary .af-accordion__date {
       display: none;
@@ -93,18 +98,12 @@
       &__info1 {
         display: none;
       }
-
-      &__date {
-        font-size: var(--accordion-info1-font-size-secondary);
-      }
     }
 
     @media (width > #{breakpoints.$breakpoint-md}) {
       --summary-areas: "tag-container date-container title info2 arrow"
         "tag-container date-container subtitle info2 arrow";
       --summary-columns: max-content min-content 1fr max-content max-content;
-
-      font-size: var(--accordion-info1-font-size-secondary);
     }
   }
 }

--- a/client/apollo/css/src/Accordion/AccordionLF.scss
+++ b/client/apollo/css/src/Accordion/AccordionLF.scss
@@ -22,27 +22,46 @@
     --accordion-info2-font-size: calc(18 / var(--font-size-base) * 1rem);
   }
 
-  &__date {
-    grid-area: date-container;
+  .af-accordion__date {
+    --accordion-secondary-date-font-size: calc(
+      16 / var(--font-size-base) * 1rem
+    );
+    @media (width > #{breakpoints.$breakpoint-md}) {
+      --accordion-secondary-date-font-size: calc(
+        16 / var(--font-size-base) * 1rem
+      );
+    }
   }
 
   &--primary {
     --accordion-title-text-color: var(--color-gray-900);
+
+    &--info1 {
+      --accordion-info1-text-size: calc(14 / var(--font-size-base) * 1rem);
+    }
   }
 
   &--secondary {
     --accordion-title-text-color: var(--color-gray-900);
     --accordion-date-text-color: var(--color-gray-700);
+    --accordion-secondary-date-font-size: calc(
+      14 / var(--font-size-base) * 1rem
+    );
 
     .af-apollo-accordion__summary .af-accordion {
       &__date {
-        --accordion-info1-font-size-secondary: calc(
-          14 / var(--font-size-base) * 1rem
+        --accordion-secondary-date-font-size: calc(
+          16 / var(--font-size-base) * 1rem
         );
+        @media (width > #{breakpoints.$breakpoint-md}) {
+          --accordion-secondary-date-font-size: calc(
+            18 / var(--font-size-base) * 1rem
+          );
+        }
       }
 
       @media (width > #{breakpoints.$breakpoint-md}) {
-        --accordion-info1-font-size-secondary: calc(
+        --accordion-secondary-date-font-size: calc(
           18 / var(--font-size-base) * 1rem
         );
       }

--- a/client/apollo/css/src/Accordion/AccordionLF.scss
+++ b/client/apollo/css/src/Accordion/AccordionLF.scss
@@ -9,12 +9,10 @@
   --accordion-font-size: calc(16 / var(--font-size-base) * 1rem);
   --accordion-subtitle-font-size: calc(14 / var(--font-size-base) * 1rem);
   --accordion-line-height: 1.25;
-  --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
-  --accordion-row-gap: calc(2 / var(--font-size-base) * 1rem);
+  --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
 
-  @media (width < #{breakpoints.$breakpoint-md}) {
-    --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
-    --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
+  @media (width > #{breakpoints.$breakpoint-md}) {
+    --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
   }
 
   &--primary {

--- a/client/apollo/css/src/Accordion/AccordionLF.scss
+++ b/client/apollo/css/src/Accordion/AccordionLF.scss
@@ -1,4 +1,5 @@
 @use "./AccordionCommon";
+@use "../common/breakpoints" as breakpoints;
 
 .af-apollo-accordion {
   --accordion-info1-text-color: var(--color-gray-700);
@@ -8,12 +9,20 @@
   --accordion-font-size: calc(16 / var(--font-size-base) * 1rem);
   --accordion-subtitle-font-size: calc(14 / var(--font-size-base) * 1rem);
   --accordion-line-height: 1.25;
+  --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
+  --accordion-row-gap: calc(2 / var(--font-size-base) * 1rem);
+
+  @media (width < #{breakpoints.$breakpoint-md}) {
+    --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
+    --accordion-column-gap: calc(12 / var(--font-size-base) * 1rem);
+  }
 
   &--primary {
-    --accordion-title-text-color: var(--neutral-100);
+    --accordion-title-text-color: var(--color-gray-900);
   }
 
   &--secondary {
-    --accordion-title-text-color: var(--neutral-100);
+    --accordion-title-text-color: var(--color-gray-900);
+    --accordion-date-text-color: var(--color-gray-700);
   }
 }

--- a/client/apollo/css/src/Accordion/AccordionLF.scss
+++ b/client/apollo/css/src/Accordion/AccordionLF.scss
@@ -6,13 +6,24 @@
   --accordion-info2-text-color: var(--color-green-600);
   --accordion-title-text-color: var(--neutral-100);
   --accordion-subtitle-text-color: var(--neutral-80);
-  --accordion-font-size: calc(16 / var(--font-size-base) * 1rem);
+  --accordion-title-font-size: calc(16 / var(--font-size-base) * 1rem);
   --accordion-subtitle-font-size: calc(14 / var(--font-size-base) * 1rem);
+  --accordion-info2-font-size: calc(16 / var(--font-size-base) * 1rem);
+  --accordion-info1-font-size-secondary: calc(
+    14 / var(--font-size-base) * 1rem
+  );
   --accordion-line-height: 1.25;
   --accordion-gap: calc(4 / var(--font-size-base) * 1rem);
 
   @media (width > #{breakpoints.$breakpoint-md}) {
     --accordion-column-gap: calc(16 / var(--font-size-base) * 1rem);
+    --accordion-title-font-size: calc(18 / var(--font-size-base) * 1rem);
+    --accordion-subtitle-font-size: calc(16 / var(--font-size-base) * 1rem);
+    --accordion-info2-font-size: calc(18 / var(--font-size-base) * 1rem);
+  }
+
+  &__date {
+    grid-area: date-container;
   }
 
   &--primary {
@@ -22,5 +33,19 @@
   &--secondary {
     --accordion-title-text-color: var(--color-gray-900);
     --accordion-date-text-color: var(--color-gray-700);
+
+    .af-apollo-accordion__summary .af-accordion {
+      &__date {
+        --accordion-info1-font-size-secondary: calc(
+          14 / var(--font-size-base) * 1rem
+        );
+      }
+
+      @media (width > #{breakpoints.$breakpoint-md}) {
+        --accordion-info1-font-size-secondary: calc(
+          18 / var(--font-size-base) * 1rem
+        );
+      }
+    }
   }
 }

--- a/client/apollo/css/src/AccordionCore/AccordionCoreCommon.scss
+++ b/client/apollo/css/src/AccordionCore/AccordionCoreCommon.scss
@@ -10,7 +10,7 @@
     padding: var(--spacing-summary);
     align-items: center;
     column-gap: 16px;
-    font-size: var(--accordion-font-size);
+    //font-size: var(--accordion-font-size);
     font-weight: 600;
     line-height: var(--accordion-title-line-height);
     cursor: pointer;


### PR DESCRIPTION
**Accordion primary**
L’espacement entre icône et contenu doit être de 16px en Desk, 12px en mobile pour les deux thèmes
L’espacement entre « Titre onglet » et « sous-titre » = 2px pour les deux thèmes
Tous les autres espacements sont à 4px pour les deux thèmes
 
**Accordion secondary**
(Apollo) La date devrait être en neutral 80
(Look and Feel) La date devrait être en Grey 700
