### PR TITLE
fix(apollo,look&feel): modifier le hover du variant small pour le ClickItem

### DIFF
--- a/client/apollo/css/src/List/ClickItem/ClickItemCommon.scss
+++ b/client/apollo/css/src/List/ClickItem/ClickItemCommon.scss
@@ -1,6 +1,7 @@
 .af-apollo-click-item {
   display: flex;
   width: 100%;
+  padding: 0;
   border: none;
   flex-direction: row;
   align-items: center;
@@ -58,17 +59,20 @@
 
   &--small {
     .af-apollo-click-item {
-      &__title {
-        span:hover {
-          border-bottom: 1px var(--click-item-title-border-color) solid;
-        }
-      }
-
       &__subtitle,
       &__secondary,
       &__tertiary,
       &__tag-container {
         display: none;
+      }
+    }
+
+    &:hover,
+    &:focus {
+      .af-apollo-click-item__title {
+        text-decoration: underline solid var(--click-item-title-border-color)
+          1px;
+        text-underline-offset: 25%;
       }
     }
   }

--- a/client/apollo/react/src/List/ClickItem/components/ClickItemContentCommon.tsx
+++ b/client/apollo/react/src/List/ClickItem/components/ClickItemContentCommon.tsx
@@ -25,9 +25,7 @@ export const ClickItemContentCommon = ({
 }: ClickItemContentCommonProps) => {
   return (
     <>
-      <p className="af-apollo-click-item__title">
-        <span>{title}</span>
-      </p>
+      <p className="af-apollo-click-item__title">{title}</p>
       {subtitle && <p className="af-apollo-click-item__subtitle">{subtitle}</p>}
       {textSecondary && (
         <p className="af-apollo-click-item__secondary">{textSecondary}</p>


### PR DESCRIPTION
Le lien devrait se souligner lors du passage de la souris sur le click item et pas seulement sur le mot
