### PR TITLE
Simplify Radio component implementation

### DIFF
--- a/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
@@ -1,75 +1,33 @@
 import { Radio } from "@axa-fr/design-system-apollo-react";
-import { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps, useEffect, useRef } from "react";
-
-const argsDefault = {
-  name: "option1",
-  value: "option1",
-};
-
-const argTypesDefault = {
-  name: {
-    control: { type: "text" },
-  },
-  value: {
-    control: { type: "text" },
-  },
-  checked: {
-    control: { type: "boolean" },
-  },
-  onChange: { action: "onChange" },
-  "aria-invalid": { type: "boolean" },
-} as const;
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
 
 const meta: Meta = {
   title: "Components/Form/Radio/Radio",
   component: Radio,
-  argTypes: argTypesDefault,
-  args: argsDefault,
+  argTypes: {
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    isInvalid: { type: "boolean" },
+  },
+  args: {
+    name: "option1",
+    value: "option1",
+  },
 };
 
 export default meta;
 
-const renderFocus = ({ ...args }) => {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    ref?.current?.focus?.();
-  }, []);
-
-  return <Radio {...args} ref={ref} />;
-};
-
 export const RadioStory: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio",
-};
-
-export const RadioStoryFocus: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio focus",
-  render: renderFocus,
-};
-
-export const RadioStoryChecked: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio Checked",
-  args: {
-    ...argsDefault,
-    checked: true,
-  },
-};
-
-export const RadioStoryError: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio Error",
-  args: {
-    ...argsDefault,
-    "aria-invalid": true,
-  },
-};
-
-export const RadioStoryErrorFocus: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio Error focus",
-  render: renderFocus,
-  args: {
-    ...argsDefault,
-    "aria-invalid": true,
-  },
+  name: "Playground",
+  render: ({ isInvalid, ...args }) => (
+    <Radio {...args} isInvalid={isInvalid ? true : undefined} />
+  ),
 };

--- a/apps/look-and-feel-stories/src/Radio/Radio.mdx
+++ b/apps/look-and-feel-stories/src/Radio/Radio.mdx
@@ -12,7 +12,7 @@ import * as RadioStories from "./Radio.stories";
 To use the `Radio`component import it like this:
 
 ```tsx
-import { Radio } from "@axa-fr/design-system-look-and-feel-react";
+import { Radio } from "@axa-fr/design-system-apollo-react/lf";
 
 const MyComponent = () => <Radio name="name" value="value" />;
 ```

--- a/apps/look-and-feel-stories/src/Radio/Radio.stories.tsx
+++ b/apps/look-and-feel-stories/src/Radio/Radio.stories.tsx
@@ -1,75 +1,33 @@
 import { Radio } from "@axa-fr/design-system-apollo-react/lf";
-import { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps, useEffect, useRef } from "react";
-
-const argsDefault = {
-  name: "option1",
-  value: "option1",
-};
-
-const argTypesDefault = {
-  name: {
-    control: { type: "text" },
-  },
-  value: {
-    control: { type: "text" },
-  },
-  checked: {
-    control: { type: "boolean" },
-  },
-  onChange: { action: "onChange" },
-  "aria-invalid": { type: "boolean" },
-} as const;
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
 
 const meta: Meta = {
   title: "Components/Form/Radio/Radio",
   component: Radio,
-  argTypes: argTypesDefault,
-  args: argsDefault,
+  argTypes: {
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    isInvalid: { type: "boolean" },
+  },
+  args: {
+    name: "option1",
+    value: "option1",
+  },
 };
 
 export default meta;
 
-const renderFocus = ({ ...args }) => {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    ref?.current?.focus?.();
-  }, []);
-
-  return <Radio {...args} ref={ref} />;
-};
-
 export const RadioStory: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio",
-};
-
-export const RadioStoryFocus: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio focus",
-  render: renderFocus,
-};
-
-export const RadioStoryChecked: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio Checked",
-  args: {
-    ...argsDefault,
-    checked: true,
-  },
-};
-
-export const RadioStoryError: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio Error",
-  args: {
-    ...argsDefault,
-    "aria-invalid": true,
-  },
-};
-
-export const RadioStoryErrorFocus: StoryObj<ComponentProps<typeof Radio>> = {
-  name: "Radio Error focus",
-  render: renderFocus,
-  args: {
-    ...argsDefault,
-    "aria-invalid": true,
-  },
+  name: "Playground",
+  render: ({ isInvalid, ...args }) => (
+    <Radio {...args} isInvalid={isInvalid ? true : undefined} />
+  ),
 };

--- a/client/apollo/css/src/Form/Radio/Radio/RadioApollo.scss
+++ b/client/apollo/css/src/Form/Radio/Radio/RadioApollo.scss
@@ -2,28 +2,27 @@
 
 .af-radio {
   --radio-border-color: var(--axa-blue-65);
-  --radio-outline-color: var(--radio-border-color);
   --radio-background-color: var(--white);
-
-  &__icons {
-    --radio-width: calc(12 / var(--font-size-base) * 1rem);
-    --radio-icon-background-color: var(--axa-blue-100);
-  }
 
   &:hover,
   &:focus-within,
-  &:has(:checked) {
+  &:checked {
     --radio-border-color: var(--axa-blue-100);
-    --radio-outline-width: 1px;
+    --radio-border-width: 2px;
   }
 
-  &:not(:has(:checked)):has([aria-invalid="true"]) {
+  &:checked {
+    --radio-ckecked-color: var(--axa-blue-100);
+  }
+
+  &--invalid:not(:checked) {
     --radio-border-color: var(--red-alert-100);
-    --radio-outline-width: 1px;
+    --radio-border-width: 2px;
 
     &:hover,
     &:focus-within {
-      --radio-outline-width: 2px;
+      --radio-border-color: var(--red-alert-100);
+      --radio-border-width: 3px;
     }
   }
 }

--- a/client/apollo/css/src/Form/Radio/Radio/RadioCommon.scss
+++ b/client/apollo/css/src/Form/Radio/Radio/RadioCommon.scss
@@ -1,38 +1,28 @@
 .af-radio {
   --radio-border-width: 1px;
+  --radio-ckecked-color: transparent;
+  --radio-ckecked-width: calc(12 / var(--font-size-base) * 1rem);
+  --radio-background-color: var(--white);
 
   display: flex;
   width: calc(24 / var(--font-size-base) * 1rem);
-  aspect-ratio: 1;
-  border: var(--radio-border-width) solid var(--radio-border-color);
+  height: calc(24 / var(--font-size-base) * 1rem);
+  margin: 0;
+  padding: 0;
   border-radius: 50%;
   align-items: center;
   justify-content: center;
-  gap: calc(12 / var(--font-size-base) * 1rem);
   background-color: var(--radio-background-color);
-  outline: var(--radio-outline-width) solid var(--radio-outline-color);
-  outline-offset: calc(
-    -1 * calc(var(--radio-border-width) + var(--radio-outline-width))
-  );
+  outline: var(--radio-border-width) solid var(--radio-border-color);
+  outline-offset: calc(-1 * var(--radio-border-width));
+  cursor: pointer;
+  appearance: unset;
 
-  &__icons {
-    display: none;
-    width: var(--radio-width);
-    aspect-ratio: 1;
+  &::after {
+    width: var(--radio-ckecked-width);
+    height: var(--radio-ckecked-width);
     border-radius: 50%;
-    background-color: var(--radio-icon-background-color);
-  }
-
-  input[type="radio"] {
-    position: absolute;
-    width: calc(24 / var(--font-size-base) * 1rem);
-    height: calc(24 / var(--font-size-base) * 1rem);
-    margin: 0;
-    opacity: 0;
-    cursor: pointer;
-
-    &:checked ~ .af-radio__icons {
-      display: block;
-    }
+    background-color: var(--radio-ckecked-color);
+    content: "";
   }
 }

--- a/client/apollo/css/src/Form/Radio/Radio/RadioLF.scss
+++ b/client/apollo/css/src/Form/Radio/Radio/RadioLF.scss
@@ -2,31 +2,26 @@
 
 .af-radio {
   --radio-border-color: var(--color-gray-700);
-  --radio-outline-color: var(--radio-border-color);
-  --radio-outline-width: 1px;
-  --radio-background-color: var(--color-white);
-
-  &__icons {
-    --radio-width: calc(10 / var(--font-size-base) * 1rem);
-    --radio-icon-background-color: var(--color-axa);
-  }
+  --radio-border-width: 2px;
+  --radio-ckecked-width: calc(10 / var(--font-size-base) * 1rem);
 
   &:hover,
   &:focus-within,
-  &:has(:checked) {
+  &:checked {
     --radio-border-color: var(--color-axa);
   }
 
-  &:hover,
-  &:focus-within {
-    --radio-outline-width: 2px;
+  &:checked {
+    --radio-ckecked-color: var(--color-axa);
   }
 
-  &:has(:checked) {
-    --radio-outline-width: 1px;
-  }
-
-  &:not(:has(:checked)):has([aria-invalid="true"]) {
+  &--invalid:not(:checked) {
     --radio-border-color: var(--color-red-700);
+
+    &:hover,
+    &:focus-within {
+      --radio-border-color: var(--color-red-700);
+      --radio-border-width: 3px;
+    }
   }
 }

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -3,7 +3,7 @@ import { BREAKPOINT } from "../../../utilities/constants";
 import { getComponentClassName } from "../../../utilities/getComponentClassName";
 import { useIsSmallScreen } from "../../../utilities/hook/useIsSmallScreen";
 import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
-import type { RadioCommon } from "../Radio/RadioCommon";
+import type { Radio } from "../Radio/RadioCommon";
 import { CardRadioItem } from "./CardRadioItem";
 import type {
   IconComponent,
@@ -11,10 +11,7 @@ import type {
   TCardRadioItemOption,
 } from "./types";
 
-export type CardRadioProps = Omit<
-  ComponentProps<typeof RadioCommon>,
-  "size"
-> & {
+export type CardRadioProps = Omit<ComponentProps<typeof Radio>, "size"> & {
   type: "vertical" | "horizontal";
   labelGroup?: string;
   descriptionGroup?: string;
@@ -91,6 +88,7 @@ const CardRadioCommon = ({
             size={size}
             RadioComponent={RadioComponent}
             IconComponent={IconComponent}
+            isInvalid={Boolean(error)}
             checked={
               value !== undefined
                 ? value === cardRadioItemProps.value

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioItem.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioItem.tsx
@@ -1,17 +1,14 @@
 import { type ComponentProps, type ComponentType } from "react";
 import type { Icon as IconCommon } from "../../../Icon/IconCommon";
-import type { RadioCommon } from "../Radio/RadioCommon";
+import type { Radio } from "../Radio/RadioCommon";
 
-export type TCardRadioItemProps = Omit<
-  ComponentProps<typeof RadioCommon>,
-  "size"
-> & {
+export type TCardRadioItemProps = Omit<ComponentProps<typeof Radio>, "size"> & {
   label: string;
   description?: string;
   subtitle?: string;
   icon?: ComponentProps<typeof IconCommon>["src"];
   size: ComponentProps<typeof IconCommon>["size"];
-  RadioComponent: ComponentType<ComponentProps<typeof RadioCommon>>;
+  RadioComponent: ComponentType<ComponentProps<typeof Radio>>;
   IconComponent: ComponentType<ComponentProps<typeof IconCommon>>;
 };
 

--- a/client/apollo/react/src/Form/Radio/Radio/RadioApollo.tsx
+++ b/client/apollo/react/src/Form/Radio/Radio/RadioApollo.tsx
@@ -1,9 +1,3 @@
-import { forwardRef } from "react";
 import "@axa-fr/design-system-apollo-css/dist/Form/Radio/Radio/RadioApollo.scss";
-import { RadioCommon, type RadioProps } from "./RadioCommon";
 
-export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => (
-  <RadioCommon {...props} ref={ref} />
-));
-
-Radio.displayName = "Radio";
+export { Radio } from "./RadioCommon";

--- a/client/apollo/react/src/Form/Radio/Radio/RadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/Radio/RadioCommon.tsx
@@ -1,17 +1,20 @@
-import React, { forwardRef } from "react";
+import { forwardRef, type ComponentProps } from "react";
 
-export type RadioProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "disabled"
->;
+export type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
+  isInvalid?: boolean;
+};
 
-export const RadioCommon = forwardRef<HTMLInputElement, RadioProps>(
-  (inputProps, ref) => (
-    <span className="af-radio">
-      <input {...inputProps} type="radio" ref={ref} />
-      <span className="af-radio__icons" />
-    </span>
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  ({ className, isInvalid, ...props }, ref) => (
+    <input
+      {...props}
+      className={["af-radio", isInvalid && "af-radio--invalid", className]
+        .filter(Boolean)
+        .join(" ")}
+      type="radio"
+      ref={ref}
+    />
   ),
 );
 
-RadioCommon.displayName = "RadioCommon";
+Radio.displayName = "Radio";

--- a/client/apollo/react/src/Form/Radio/Radio/RadioLF.tsx
+++ b/client/apollo/react/src/Form/Radio/Radio/RadioLF.tsx
@@ -1,9 +1,3 @@
-import { forwardRef } from "react";
 import "@axa-fr/design-system-apollo-css/dist/Form/Radio/Radio/RadioLF.scss";
-import { RadioCommon, type RadioProps } from "./RadioCommon";
 
-export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => (
-  <RadioCommon {...props} ref={ref} />
-));
-
-Radio.displayName = "Radio";
+export { Radio } from "./RadioCommon";

--- a/client/apollo/react/src/Form/Radio/Radio/__tests__/Radio.test.tsx
+++ b/client/apollo/react/src/Form/Radio/Radio/__tests__/Radio.test.tsx
@@ -1,29 +1,45 @@
 import { render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
 import { Radio } from "../RadioApollo";
 
 describe("Radio Component", () => {
-  it("renders correctly with default props", () => {
+  it("should render correctly with default props", () => {
     render(<Radio />);
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).toBeInTheDocument();
+    expect(radioInput).toHaveClass("af-radio");
   });
 
-  it("renders as checked when the checked prop is true", () => {
-    render(<Radio checked />);
+  it("should render as checked when the checked prop is true", () => {
+    render(<Radio checked onChange={vi.fn()} />);
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).toBeChecked();
   });
 
-  it("calls the onChange handler when clicked", () => {
+  it("should call the onChange handler when clicked", async () => {
+    const user = userEvent.setup();
     const handleChange = vi.fn();
     render(<Radio onChange={handleChange} />);
 
     const radioInput = screen.getByRole("radio");
-    radioInput.click();
+    await user.click(radioInput);
 
     expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass additional props to the input element", () => {
+    render(<Radio aria-label="custom" />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toHaveAttribute("aria-label", "custom");
+  });
+
+  it("should apply custom class names", () => {
+    render(<Radio className="custom-class" />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toHaveClass("af-radio custom-class");
   });
 });

--- a/client/look-and-feel/react/src/index.ts
+++ b/client/look-and-feel/react/src/index.ts
@@ -28,7 +28,10 @@ export { FileUpload } from "./Form/FileUpload";
 export { InputError } from "./Form/InputError";
 export { ItemMessage } from "./Form/ItemMessage/ItemMessage";
 export { ItemLabel } from "./Form/ItemLabel/ItemLabel";
-export { Radio, RadioCard } from "./Form/Radio";
+export {
+  /** @deprecated Use `Radio` from apollo/lf package instead. */ Radio,
+  /** @deprecated Use `RadioCard` from apollo/lf package instead. */ RadioCard,
+} from "./Form/Radio";
 export { ItemFile, itemFileVariants } from "./Form/ItemFile/ItemFile";
 export {
   Dropdown,


### PR DESCRIPTION
**Description:**

This PR simplifies the `Radio` component implementation across the Apollo and Look-and-Feel packages.  
Key changes include:

- Refactored the `Radio` component to use a single input element with the `af-radio` class, removing unnecessary wrapper spans and icon elements.
- Updated SCSS styles to match the new structure and ensure correct visual states (checked, error, etc.).
- Adjusted Storybook stories and tests to align with the new implementation.
- Updated type imports and usages to reflect the new component structure.
- Marked the Look-and-Feel `Radio` and `RadioCard` exports as deprecated, recommending usage from the Apollo/lf package instead.
- Improved test coverage for the new component API.

This refactor reduces complexity, improves maintainability, and ensures consistent behavior and styling for the `Radio` component.  
No breaking changes are expected for consumers using the public API.
