### PR TITLE
[Slash] Field - Ajout de la classe af-form_group meme lors d'une surcharge de className

### DIFF
--- a/slash/react/src/Form/core/Field.tsx
+++ b/slash/react/src/Form/core/Field.tsx
@@ -32,7 +32,6 @@ type InputProps = {
   isVisible?: boolean;
   roleContainer?: string;
   ariaLabelContainer?: string;
-  isLabelContainerLinkedToInput?: boolean;
   forceDisplayMessage?: boolean;
   message?: string;
   messageType?: MessageTypes;
@@ -109,7 +108,6 @@ export const Field = ({
   isVisible = true,
   roleContainer,
   ariaLabelContainer,
-  isLabelContainerLinkedToInput = true,
   labelPosition = "center",
   classNameSuffix = "text",
   renderInput,
@@ -146,15 +144,11 @@ export const Field = ({
     `af-form__${classNameSuffix}`,
     modifiers,
   );
-  const groupClassName = getComponentClassName(
-    className,
-    classModifier,
-    "af-form__group",
-  );
+  const groupClassName = getComponentClassName("af-form__group", classModifier);
 
   return (
     <div
-      className={classNames("row", groupClassName, {
+      className={classNames(className, "row", groupClassName, {
         "af-form__group--required": actualRequired,
         "af-form__group--label-top": labelPosition === "top",
       })}
@@ -167,7 +161,7 @@ export const Field = ({
           className={classNames("af-form__group-label", {
             "af-form__group-label--required": actualRequired,
           })}
-          htmlFor={isLabelContainerLinkedToInput ? inputId : undefined}
+          htmlFor={!isGroup ? inputId : undefined}
           id={labelId}
         >
           {label}


### PR DESCRIPTION
Si on surcharge notre Input (par ex: RadioInput) avec une className alors la class `af-form_group` était supprimée.
La PR permet de garder les 2 classes `af-form_group` et la surcharge de className par le consommateur