### PR TITLE
fix(apollo, look&feel): Espacement et couleur du dropdown

### DIFF
--- a/client/apollo/css/src/Form/Dropdown/DropdownApollo.scss
+++ b/client/apollo/css/src/Form/Dropdown/DropdownApollo.scss
@@ -30,6 +30,9 @@
   &:disabled {
     --dropdown-bg-color-disabled: var(--neutral-5);
     --dropdown-border-color: var(--neutral-50);
+    --dropdown-background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 -960 960 960'><path fill='%23999999' d='M480-344 240-584l43-43 197 197 197-197 43 43-240 240Z'/></svg>")
+      no-repeat right 1rem center / 1.5rem 1.5rem;
+    --dropdown-color: var(--neutral-50);
   }
 
   &:not(:disabled):hover,

--- a/client/apollo/css/src/Form/Dropdown/DropdownCommon.scss
+++ b/client/apollo/css/src/Form/Dropdown/DropdownCommon.scss
@@ -34,9 +34,10 @@
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 2px var(--dropdown-box-shadow) inset;
-    outline: 2px;
-    outline-offset: 2px;
+    font-weight: 600;
+    box-shadow: 0 0 0 1px var(--dropdown-box-shadow) inset;
+    outline: 1px;
+    outline-offset: 1px;
   }
 
   &:disabled {

--- a/client/apollo/css/src/Form/Dropdown/DropdownCommon.scss
+++ b/client/apollo/css/src/Form/Dropdown/DropdownCommon.scss
@@ -60,3 +60,21 @@
     box-shadow: 0 0 0 1px var(--dropdown-box-shadow) inset;
   }
 }
+
+.af-form__dropdown-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  row-gap: calc(8 / var(--font-size-base) * 1rem);
+}
+
+.af-form__dropdown-container--input-helper {
+  font-size: calc(14 / var(--font-size-base) * 1rem);
+  font-weight: 400;
+  line-height: 1.25em;
+  color: var(--input-helper-color);
+
+  @media (width > #{breakpoints.$breakpoint-md}) {
+    font-size: calc(16 / var(--font-size-base) * 1rem);
+  }
+}

--- a/client/apollo/css/src/Form/Dropdown/DropdownLF.scss
+++ b/client/apollo/css/src/Form/Dropdown/DropdownLF.scss
@@ -22,11 +22,14 @@
 
   &:focus-visible {
     --dropdown-border-color: var(--color-axa);
+    --dropdown-box-shadow: var(--color-axa);
   }
 
   &:disabled {
     --dropdown-bg-color-disabled: var(--color-gray-200);
     --dropdown-border-color: var(--color-gray-400);
+    --dropdown-background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'><polygon points='12,18 36,18 24,34' fill='%23999999'/></svg>")
+      no-repeat right 1rem center / 1.5rem 1.5rem;
   }
 
   &:not(:disabled):hover,

--- a/client/apollo/react/src/Form/Dropdown/DropdownCommon.tsx
+++ b/client/apollo/react/src/Form/Dropdown/DropdownCommon.tsx
@@ -57,7 +57,7 @@ const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>(
     );
 
     return (
-      <div>
+      <div className="af-form__input-container">
         <ItemLabelComponent
           label={label}
           description={description}

--- a/client/apollo/react/src/Form/Dropdown/DropdownCommon.tsx
+++ b/client/apollo/react/src/Form/Dropdown/DropdownCommon.tsx
@@ -57,7 +57,7 @@ const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>(
     );
 
     return (
-      <div className="af-form__input-container">
+      <div className="af-form__dropdown-container">
         <ItemLabelComponent
           label={label}
           description={description}


### PR DESCRIPTION
- Il doit y avoir un espacement de 8px entre le helper (Information complémentaire) et le message de résilience (rouge)
- Il y a un problème d'épaisseur du stroke sur Apollo et L&F sur le champs au clic du Hover. (sauf l'état par default sur L&F qui fonctionne bien)
- Couleurs du paceholder et de la fleche en "disabled", qui ne doit pas être bleu mais gris (comme sur nos maquette figma) sur Apollo, sur L&F uniquement le chevron (fleche) qui est bleu au lieu de gris.
- Etat Field d'Apollo, le texte placeholder passe semibold et non en regular.

closes #1331 