### PR TITLE
|Slash] Suggestion - nouveau composant interne Fieldset

### DIFF
--- a/slash/css/src/Form/Radio/Radio.scss
+++ b/slash/css/src/Form/Radio/Radio.scss
@@ -81,7 +81,7 @@
 
   &__radio-inline {
     position: relative;
-    display: flex;
+    display: inline-flex;
     margin-right: 1rem;
     align-items: center;
 

--- a/slash/react/src/Form/Checkbox/CheckboxInput.tsx
+++ b/slash/react/src/Form/Checkbox/CheckboxInput.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, forwardRef } from "react";
 
-import { type ConsumerFieldProps, Field, useOptionsWithId } from "../core";
+import { type ConsumerFieldProps, Fieldset, useOptionsWithId } from "../core";
 import { Checkbox } from "./Checkbox";
 import { CheckboxModes } from "./CheckboxModes";
 
@@ -13,8 +13,9 @@ const CheckboxInput = forwardRef<HTMLInputElement, Props>(
   ({ label, mode = "default", options, ...otherProps }, inputRef) => {
     const newOptions = useOptionsWithId(options);
     return (
-      <Field
+      <Fieldset
         label={label}
+        classNameSuffix="checkbox"
         labelPosition={mode === CheckboxModes.classic ? "top" : "center"}
         roleContainer="group"
         {...otherProps}

--- a/slash/react/src/Form/Radio/Radio.tsx
+++ b/slash/react/src/Form/Radio/Radio.tsx
@@ -6,6 +6,7 @@ import {
 import type { Option } from "../core";
 import { RadioItem } from "./RadioItem";
 import { RadioCardGroup } from "./RadioCardGroup";
+import { useClassNameMode } from "./useClassNameMode";
 
 export enum RadioModes {
   classic = "classic",
@@ -28,23 +29,10 @@ type Props = {
     })
 );
 
-const getClassNameMode = (mode: Props["mode"]) => {
-  switch (mode) {
-    case RadioModes.classic:
-      return "af-form__radio";
-    case RadioModes.inline:
-      return "af-form__radio-inline";
-    case RadioModes.card:
-      return "af-form__radio-card";
-    default:
-      return "af-form__radio-custom";
-  }
-};
-
 const Radio = forwardRef<HTMLInputElement, Props>(
   ({ options, value = "", disabled, ...otherProps }, inputRef) => {
     const { mode, ...onlyNecessaryProps } = otherProps;
-    const classNameMode = getClassNameMode(mode ?? "default");
+    const { className: classNameMode } = useClassNameMode(mode ?? "default");
 
     if (mode === "card") {
       return (
@@ -66,9 +54,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
         className={classNameMode}
         ref={inputRef}
         {...option}
-      >
-        {children}
-      </RadioItem>
+      />
     ));
   },
 );

--- a/slash/react/src/Form/Radio/Radio.tsx
+++ b/slash/react/src/Form/Radio/Radio.tsx
@@ -19,7 +19,7 @@ type Props = {
 } & (
   | (Omit<
       ComponentPropsWithRef<typeof RadioItem>,
-      "id" | "label" | "className"
+      "id" | "label" | "className" | "children"
     > & {
       mode?: "classic" | "default" | "inline";
     })
@@ -42,7 +42,7 @@ const getClassNameMode = (mode: Props["mode"]) => {
 };
 
 const Radio = forwardRef<HTMLInputElement, Props>(
-  ({ options, value = "", children, disabled, ...otherProps }, inputRef) => {
+  ({ options, value = "", disabled, ...otherProps }, inputRef) => {
     const { mode, ...onlyNecessaryProps } = otherProps;
     const classNameMode = getClassNameMode(mode ?? "default");
 
@@ -53,9 +53,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
           options={options}
           disabled={disabled}
           value={value}
-        >
-          {children}
-        </RadioCardGroup>
+        />
       );
     }
 

--- a/slash/react/src/Form/Radio/RadioCardGroup.tsx
+++ b/slash/react/src/Form/Radio/RadioCardGroup.tsx
@@ -8,14 +8,13 @@ import { Svg } from "../../Svg";
 const DEFAULT_CLASSNAME = "af-card";
 const DEFAULT_CONTAINER_CLASSNAME = "af-form__radio-card-group";
 
-type Props = ComponentProps<"input"> & {
+type Props = Omit<ComponentProps<"input">, "children"> & {
   options: Option[];
   orientation?: "horizontal" | "vertical";
   error?: boolean;
 };
 
 export const RadioCardGroup = ({
-  children,
   options,
   className,
   value,
@@ -31,7 +30,6 @@ export const RadioCardGroup = ({
   return (
     <div
       ref={radioGroupRef}
-      role="radiogroup"
       className={classNames([
         DEFAULT_CONTAINER_CLASSNAME,
         className,
@@ -73,7 +71,6 @@ export const RadioCardGroup = ({
           );
         },
       )}
-      {children}
     </div>
   );
 };

--- a/slash/react/src/Form/Radio/RadioInput.tsx
+++ b/slash/react/src/Form/Radio/RadioInput.tsx
@@ -1,6 +1,7 @@
 import { ComponentPropsWithRef, forwardRef } from "react";
-import { type ConsumerFieldProps, Field, useOptionsWithId } from "../core";
+import { type ConsumerFieldProps, Fieldset, useOptionsWithId } from "../core";
 import { Radio, RadioModes } from "./Radio";
+import { useClassNameMode } from "./useClassNameMode";
 
 type RadioInputProps = ComponentPropsWithRef<typeof Radio> & ConsumerFieldProps;
 
@@ -8,11 +9,13 @@ const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
   ({ label, mode = "default", options, rightElement, ...props }, inputRef) => {
     const labelPosition = mode === RadioModes.classic ? "top" : "center";
     const newOptions = useOptionsWithId(options);
+    const { suffix } = useClassNameMode(mode ?? "default");
 
     return (
-      <Field
+      <Fieldset
         label={label}
         labelPosition={labelPosition}
+        classNameSuffix={suffix}
         roleContainer="radiogroup"
         {...props}
         renderInput={({

--- a/slash/react/src/Form/Radio/RadioInput.tsx
+++ b/slash/react/src/Form/Radio/RadioInput.tsx
@@ -1,11 +1,8 @@
-import { ComponentPropsWithoutRef, forwardRef } from "react";
+import { ComponentPropsWithRef, forwardRef } from "react";
 import { type ConsumerFieldProps, Field, useOptionsWithId } from "../core";
 import { Radio, RadioModes } from "./Radio";
 
-type RadioInputProps = Omit<
-  ConsumerFieldProps & ComponentPropsWithoutRef<typeof Radio>,
-  "children"
->;
+type RadioInputProps = ComponentPropsWithRef<typeof Radio> & ConsumerFieldProps;
 
 const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
   ({ label, mode = "default", options, rightElement, ...props }, inputRef) => {
@@ -16,7 +13,7 @@ const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
       <Field
         label={label}
         labelPosition={labelPosition}
-        roleContainer={mode !== "card" ? "radiogroup" : undefined}
+        roleContainer="radiogroup"
         {...props}
         renderInput={({
           classModifier,

--- a/slash/react/src/Form/Radio/__tests__/Radio.test.tsx
+++ b/slash/react/src/Form/Radio/__tests__/Radio.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import villaIcon from "@material-symbols/svg-400/outlined/villa.svg";
 import { axe } from "jest-axe";
 import { Radio } from "../Radio";
@@ -24,17 +24,9 @@ const options: Option[] = [
 
 describe("Radio mode card", () => {
   it("should render 3 radio cards", () => {
-    render(
-      <Radio mode="card" options={options}>
-        Test
-      </Radio>,
-    );
+    render(<Radio mode="card" options={options} name="myRadio" />);
 
-    const radioGroup = screen.getByRole("radiogroup");
-    expect(radioGroup).toBeInTheDocument();
-    expect(radioGroup).toHaveClass("af-form__radio-card-group");
-
-    const radioCards = within(radioGroup).getAllByRole("radio");
+    const radioCards = screen.getAllByRole("radio");
     expect(radioCards).toHaveLength(3);
   });
 
@@ -53,9 +45,9 @@ describe("Radio mode card", () => {
     render(<Radio mode="card" orientation="horizontal" options={options} />);
 
     // Assert
-    expect(screen.getByRole("radiogroup")).toHaveClass(
-      "af-form__radio-card-group--horizontal",
-    );
+    expect(
+      document.querySelector(".af-form__radio-card-group--horizontal"),
+    ).toBeInTheDocument();
   });
 
   it("should have custom class", () => {
@@ -63,7 +55,7 @@ describe("Radio mode card", () => {
     render(<Radio mode="card" options={options} className="custom-class" />);
 
     // Assert
-    expect(screen.getByRole("radiogroup")).toHaveClass("custom-class");
+    expect(document.querySelector(".custom-class")).toBeInTheDocument();
   });
 
   it("shouldn't have an accessibility violation", async () => {

--- a/slash/react/src/Form/Radio/__tests__/RadioInput.test.tsx
+++ b/slash/react/src/Form/Radio/__tests__/RadioInput.test.tsx
@@ -12,7 +12,6 @@ describe("RadioInput", () => {
     // Act
     render(
       <RadioInput
-        name="languages"
         mode="card"
         label="Languages"
         options={languageOptions}

--- a/slash/react/src/Form/Radio/__tests__/RadioInput.test.tsx
+++ b/slash/react/src/Form/Radio/__tests__/RadioInput.test.tsx
@@ -21,7 +21,7 @@ describe("RadioInput", () => {
     );
 
     // Assert
-    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup")).toHaveAccessibleName(/Languages/i);
     expect(screen.getByText("Test")).toBeInTheDocument();
   });
 });

--- a/slash/react/src/Form/Radio/useClassNameMode.ts
+++ b/slash/react/src/Form/Radio/useClassNameMode.ts
@@ -1,0 +1,12 @@
+import { RadioModes } from "./Radio";
+
+export const useClassNameMode = (mode: keyof typeof RadioModes) => {
+  switch (mode) {
+    case RadioModes.classic:
+      return { className: "af-form__radio", suffix: "radio" };
+    case RadioModes.inline:
+      return { className: "af-form__radio-inline", suffix: "radio-inline" };
+    default:
+      return { className: "af-form__radio-custom", suffix: "radio-custom" };
+  }
+};

--- a/slash/react/src/Form/core/Field.tsx
+++ b/slash/react/src/Form/core/Field.tsx
@@ -1,16 +1,10 @@
 import classNames from "classnames";
-import { type ReactNode, useId } from "react";
-import {
-  FieldError,
-  FormClassManager,
-  HelpMessage,
-  MessageTypes,
-  useInputClassModifier,
-} from ".";
-import { getComponentClassName } from "../../utilities";
+import { type ReactNode } from "react";
+import { FieldError, HelpMessage, MessageTypes } from ".";
 import { useAriaInvalid } from "./useAriaInvalid";
+import { useFieldClass, useFieldId } from "./useField";
 
-type InputProps = {
+export type InputProps = {
   /**
    * The label of the input element.
    */
@@ -32,7 +26,6 @@ type InputProps = {
   isVisible?: boolean;
   roleContainer?: string;
   ariaLabelContainer?: string;
-  isLabelContainerLinkedToInput?: boolean;
   forceDisplayMessage?: boolean;
   message?: string;
   messageType?: MessageTypes;
@@ -109,69 +102,62 @@ export const Field = ({
   isVisible = true,
   roleContainer,
   ariaLabelContainer,
-  isLabelContainerLinkedToInput = true,
   labelPosition = "center",
   classNameSuffix = "text",
   renderInput,
   appendChildren,
   ...otherProps
 }: InputProps) => {
-  const inputUseId = useId();
-  const inputId = id ?? inputUseId;
-  const actualRequired = required || classModifier.includes("required");
+  const { errorId, inputId, labelId } = useFieldId({
+    id,
+    forceDisplayMessage,
+    helpMessage,
+  });
   const isInvalid = useAriaInvalid(message, forceDisplayMessage, messageType);
-  const errorId =
-    forceDisplayMessage || helpMessage ? `${inputId}-description` : undefined;
+  const actualRequired = required || classModifier.includes("required");
 
-  const { inputClassModifier, inputFieldClassModifier } = useInputClassModifier(
-    classModifier,
+  const {
+    groupClassName,
+    inputClassModifier,
+    fieldContainerClassName,
+    modifiers,
+  } = useFieldClass({
     disabled,
-    false,
     actualRequired,
-  );
-
-  const labelId = useId();
+    forceDisplayMessage,
+    message,
+    messageType,
+    classNameSuffix,
+  });
 
   if (!isVisible) {
     return null;
   }
 
-  const isGroup = roleContainer === "radiogroup" || roleContainer === "group";
-  const LabelElement = isGroup ? "div" : "label";
-
-  const modifiers = forceDisplayMessage
-    ? `${inputFieldClassModifier} ${FormClassManager.getModifier(messageType)}`
-    : inputFieldClassModifier;
-  const fieldContainerClassName = getComponentClassName(
-    `af-form__${classNameSuffix}`,
-    modifiers,
-  );
-  const groupClassName = getComponentClassName(
-    className,
-    classModifier,
-    "af-form__group",
-  );
-
   return (
     <div
-      className={classNames("row", groupClassName, {
-        "af-form__group--required": actualRequired,
-        "af-form__group--label-top": labelPosition === "top",
-      })}
+      className={classNames(
+        "row",
+        groupClassName,
+        {
+          "af-form__group--required": actualRequired,
+          "af-form__group--label-top": labelPosition === "top",
+        },
+        className,
+      )}
       role={roleContainer}
       aria-label={ariaLabelContainer}
-      aria-labelledby={isGroup ? labelId : undefined}
     >
       <div className={classNameContainerLabel}>
-        <LabelElement
+        <label
           className={classNames("af-form__group-label", {
             "af-form__group-label--required": actualRequired,
           })}
-          htmlFor={isLabelContainerLinkedToInput ? inputId : undefined}
+          htmlFor={inputId}
           id={labelId}
         >
           {label}
-        </LabelElement>
+        </label>
       </div>
 
       <div className={classNameContainerInput}>

--- a/slash/react/src/Form/core/Fielset.tsx
+++ b/slash/react/src/Form/core/Fielset.tsx
@@ -1,0 +1,95 @@
+import classNames from "classnames";
+import type { InputProps } from "./Field";
+import { useAriaInvalid } from "./useAriaInvalid";
+import { useFieldClass, useFieldId } from "./useField";
+import { FieldError } from "./FieldError";
+import { HelpMessage } from "./HelpMessage";
+
+export const Fieldset = ({
+  id,
+  label,
+  roleContainer,
+  required,
+  classNameContainerInput = "col-md-10",
+  classNameContainerLabel = "col-md-2",
+  classModifier = "",
+  message,
+  forceDisplayMessage,
+  messageType,
+  helpMessage,
+  isVisible = true,
+  disabled = false,
+  classNameSuffix = "text",
+  labelPosition = "center",
+  renderInput,
+  className,
+  ...otherProps
+}: InputProps) => {
+  const { errorId, inputId } = useFieldId({
+    id,
+    forceDisplayMessage,
+    helpMessage,
+  });
+  const isInvalid = useAriaInvalid(message, forceDisplayMessage, messageType);
+  const actualRequired = required || classModifier.includes("required");
+
+  const { groupClassName, inputClassModifier, modifiers } = useFieldClass({
+    disabled,
+    actualRequired,
+    forceDisplayMessage,
+    message,
+    messageType,
+    classNameSuffix,
+  });
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <fieldset
+      role={roleContainer}
+      aria-required={required}
+      aria-invalid={isInvalid}
+      className={classNames(
+        "row",
+        groupClassName,
+        {
+          "af-form__group--required": actualRequired,
+          "af-form__group--label-top": labelPosition === "top",
+        },
+        className,
+      )}
+    >
+      <div className={classNameContainerLabel}>
+        <legend
+          className={classNames("af-form__group-label", {
+            "af-form__group-label--required": actualRequired,
+          })}
+        >
+          {label}
+        </legend>
+      </div>
+
+      <div className={classNameContainerInput}>
+        {renderInput({
+          id: inputId,
+          classModifier: `${inputClassModifier} ${modifiers}`,
+          errorId,
+          ariaInvalid: isInvalid,
+          disabled,
+          ...otherProps,
+        })}
+        {forceDisplayMessage ? (
+          <FieldError
+            message={message}
+            messageType={messageType}
+            errorId={errorId}
+          />
+        ) : (
+          <HelpMessage message={helpMessage} id={errorId} />
+        )}
+      </div>
+    </fieldset>
+  );
+};

--- a/slash/react/src/Form/core/index.ts
+++ b/slash/react/src/Form/core/index.ts
@@ -4,6 +4,7 @@ export { LegacyField } from "./Deprecated/Field";
 export { FieldForm } from "./Deprecated/FieldForm";
 export { FieldInput } from "./Deprecated/FieldInput";
 export { Field } from "./Field";
+export { Fieldset } from "./Fielset";
 export type { ConsumerFieldProps } from "./Field";
 export { FieldError } from "./FieldError";
 export { FormClassManager } from "./FormClassManager";

--- a/slash/react/src/Form/core/useField.ts
+++ b/slash/react/src/Form/core/useField.ts
@@ -1,0 +1,72 @@
+import { ReactNode, useId } from "react";
+import { MessageTypes } from "./MessageTypes";
+import { FormClassManager } from "./FormClassManager";
+import { getComponentClassName } from "../../utilities";
+import { useInputClassModifier } from "./useInputClassModifier";
+
+type FieldIdProps = {
+  id?: string;
+  forceDisplayMessage?: boolean;
+  helpMessage?: ReactNode;
+};
+
+type Props = {
+  actualRequired: boolean;
+  required?: boolean;
+  disabled: boolean;
+  classModifier?: string;
+  message?: string;
+  forceDisplayMessage?: boolean;
+  messageType?: MessageTypes;
+  classNameSuffix?: string;
+};
+
+export const useFieldId = ({
+  id,
+  forceDisplayMessage,
+  helpMessage,
+}: FieldIdProps) => {
+  const inputUseId = useId();
+  const inputId = id ?? inputUseId;
+  const labelId = useId();
+  const errorId =
+    forceDisplayMessage || helpMessage ? `${inputId}-description` : undefined;
+
+  return {
+    inputId,
+    labelId,
+    errorId,
+  };
+};
+
+export const useFieldClass = ({
+  disabled,
+  classModifier = "",
+  forceDisplayMessage,
+  messageType,
+  classNameSuffix = "text",
+  actualRequired,
+}: Props) => {
+  const { inputClassModifier, inputFieldClassModifier } = useInputClassModifier(
+    classModifier,
+    disabled,
+    false,
+    actualRequired,
+  );
+
+  const modifiers = forceDisplayMessage
+    ? `${inputFieldClassModifier} ${FormClassManager.getModifier(messageType)}`
+    : inputFieldClassModifier;
+  const fieldContainerClassName = getComponentClassName(
+    `af-form__${classNameSuffix}`,
+    modifiers,
+  );
+  const groupClassName = getComponentClassName("af-form__group", classModifier);
+
+  return {
+    inputClassModifier,
+    modifiers,
+    fieldContainerClassName,
+    groupClassName,
+  };
+};


### PR DESCRIPTION
Il existe le composant `Field` qui permet d'avoir tous les inputs standardisés et mutualisés en terme de gestion d'erreur, des messages ,className, etc ...
Par contre ce composant `Field` est adapté uniquement pour les "single" input, un input number ou text ou textarea.
Si on veut faire des groupements ma suggestion est le composant `Fieldset` qui permet une meilleur gestion des "multi" inputs notamment en terme d'accessibilité.

le commun entre `Field` et `Fieldset` a été sorti dans des hooks.