### PR TITLE
Refactor Checkbox and CheckboxText components for simplification and improved accessibility

### DIFF
--- a/apps/apollo-stories/src/components/Checkbox/Checkbox.mdx
+++ b/apps/apollo-stories/src/components/Checkbox/Checkbox.mdx
@@ -1,27 +1,23 @@
 import { Canvas, Controls, Meta } from "@storybook/blocks";
 import * as CheckboxStories from "./Checkbox.stories";
 
-<Meta of={CheckboxStories} />
+<Meta of={CheckboxStories} name="Checkbox" />
 
 # Checkbox components
 
-## Checkbox
-
-### How to use
+## How to use
 
 To use the `Checkbox`component import it like this:
 
 ```tsx
 import { Checkbox } from "@axa-fr/design-system-apollo-react";
 
-const MyComponent = () => (
-  <Checkbox
-    name="name"
-    value="value"
-    label="J'accepte de fournir à AXA mes coordonnées ainsi que les données  relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra  me contacter pour m'accompagner."
-  />
-);
+const MyComponent = () => <Checkbox name="jedi" value="yoda" />;
 ```
 
-<Canvas of={CheckboxStories.CheckboxStory} />
+## Playground
+
+The Checkbox component inherits all native `<input type="checkbox"/>` element props.
+
+<Canvas of={CheckboxStories.CheckboxStory} sourceState="shown" />
 <Controls of={CheckboxStories.CheckboxStory} />

--- a/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,76 +1,40 @@
 import { Checkbox } from "@axa-fr/design-system-apollo-react";
-import { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps, useEffect, useRef } from "react";
-
-const argsDefault = {
-  name: "option1",
-  value: "option1",
-};
-
-const argTypesDefault = {
-  name: {
-    control: { type: "text" },
-  },
-  value: {
-    control: { type: "text" },
-  },
-  checked: {
-    control: { type: "boolean" },
-  },
-  onChange: { action: "onChange" },
-} as const;
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
 
 const meta: Meta = {
   title: "Components/Form/Checkbox/Checkbox",
   component: Checkbox,
-  argTypes: argTypesDefault,
-  args: argsDefault,
+  argTypes: {
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    "aria-invalid": { type: "boolean" },
+    errorId: {
+      table: {
+        disable: true,
+      },
+    },
+    hasError: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    name: "option1",
+    value: "option1",
+  },
 };
 
 export default meta;
 
-const renderFocus = ({ ...args }) => {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    ref?.current?.focus?.();
-  }, []);
-
-  return <Checkbox {...args} ref={ref} />;
-};
-
 export const CheckboxStory: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox",
-};
-
-export const CheckboxStoryFocus: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox focus",
-  render: renderFocus,
-};
-
-export const CheckboxStoryChecked: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox Checked",
-  args: {
-    ...argsDefault,
-    checked: true,
-  },
-};
-
-export const CheckboxStoryError: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox Error",
-  args: {
-    ...argsDefault,
-    hasError: true,
-  },
-};
-
-export const CheckboxStoryErrorFocus: StoryObj<
-  ComponentProps<typeof Checkbox>
-> = {
-  name: "Checkbox Error focus",
-  render: renderFocus,
-  args: {
-    ...argsDefault,
-    hasError: true,
-  },
+  name: "Playground",
 };

--- a/apps/apollo-stories/src/components/CheckboxText/CheckboxText.mdx
+++ b/apps/apollo-stories/src/components/CheckboxText/CheckboxText.mdx
@@ -1,13 +1,11 @@
 import { Canvas, Controls, Meta } from "@storybook/blocks";
 import * as CheckboxTextStories from "./CheckboxText.stories";
 
-<Meta of={CheckboxTextStories} />
+<Meta of={CheckboxTextStories} name="CheckboxText" />
 
 # CheckboxText components
 
-## CheckboxText
-
-### How to use
+## How to use
 
 To use the `CheckboxText`component import it like this:
 
@@ -23,8 +21,7 @@ const MyComponent = () => (
 );
 ```
 
-<Canvas of={CheckboxTextStories.CheckboxTextStory} />
-<Controls of={CheckboxTextStories.CheckboxTextStory} />
+## Playground
 
-<Canvas of={CheckboxTextStories.CheckboxTextWithErrorStory} />
-<Controls of={CheckboxTextStories.CheckboxTextWithErrorStory} />
+<Canvas of={CheckboxTextStories.CheckboxTextStory} sourceState="shown" />
+<Controls of={CheckboxTextStories.CheckboxTextStory} />

--- a/apps/apollo-stories/src/components/CheckboxText/CheckboxText.stories.tsx
+++ b/apps/apollo-stories/src/components/CheckboxText/CheckboxText.stories.tsx
@@ -1,91 +1,48 @@
 import { CheckboxText } from "@axa-fr/design-system-apollo-react";
-import { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps, useEffect, useRef } from "react";
-
-const argTypesDefault = {
-  label: {
-    control: { type: "text" },
-  },
-  name: {
-    control: { type: "text" },
-  },
-  value: {
-    control: { type: "text" },
-  },
-  errorMessage: {
-    control: { type: "text" },
-  },
-  checked: {
-    control: { type: "boolean" },
-  },
-  onChange: { action: "onChange" },
-} as const;
-
-const argsDefault = {
-  label:
-    "J'accepte de fournir à AXA mes coordonnées ainsi que les données  relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra  me contacter pour m'accompagner.",
-  name: "option1",
-  value: "option1",
-};
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
 
 const meta: Meta = {
   title: "Components/Form/Checkbox/CheckboxText",
   component: CheckboxText,
-  argTypes: argTypesDefault,
-  args: argsDefault,
+  argTypes: {
+    label: {
+      control: { type: "text" },
+    },
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    errorMessage: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    errorId: {
+      table: {
+        disable: true,
+      },
+    },
+    hasError: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    label:
+      "J'accepte de fournir à AXA mes coordonnées ainsi que les données relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra  me contacter pour m'accompagner.",
+    name: "option1",
+    value: "option1",
+  },
 };
 
 export default meta;
 
-const renderFocus = ({ ...args }: ComponentProps<typeof CheckboxText>) => {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    ref?.current?.focus?.();
-  }, []);
-
-  return <CheckboxText {...args} ref={ref} />;
-};
-
 export const CheckboxTextStory: StoryObj<ComponentProps<typeof CheckboxText>> =
   {
-    name: "CheckboxText",
+    name: "Playground",
   };
-
-export const CheckboxTextChecked: StoryObj<
-  ComponentProps<typeof CheckboxText>
-> = {
-  name: "CheckboxTextChecked",
-  args: {
-    ...argsDefault,
-    checked: true,
-  },
-};
-
-export const CheckboxTextFocus: StoryObj<ComponentProps<typeof CheckboxText>> =
-  {
-    name: "CheckboxTextFocus",
-    render: renderFocus,
-  };
-
-export const CheckboxTextWithErrorStory: StoryObj<
-  ComponentProps<typeof CheckboxText>
-> = {
-  name: "CheckboxText With Error",
-  args: {
-    ...argsDefault,
-    errorMessage: "There is an error",
-  },
-};
-
-export const CheckboxTextWithErrorFocusStory: StoryObj<
-  ComponentProps<typeof CheckboxText>
-> = {
-  name: "CheckboxText With Error focus",
-
-  render: renderFocus,
-  args: {
-    ...argsDefault,
-    errorMessage: "There is an error",
-  },
-};

--- a/apps/look-and-feel-stories/src/CheckBoxText/CheckboxText.mdx
+++ b/apps/look-and-feel-stories/src/CheckBoxText/CheckboxText.mdx
@@ -1,19 +1,15 @@
 import { Canvas, Controls, Meta } from "@storybook/blocks";
 import * as CheckboxTextStories from "./CheckboxText.stories";
 
-<Meta of={CheckboxTextStories} />
+<Meta of={CheckboxTextStories} name="CheckboxText" />
 
 # CheckboxText components
 
-## Checkbox
-
-### How to use
+## How to use
 
 To use the `CheckboxText`component import it like this:
 
 ```tsx
-import { CheckboxText } from "@axa-fr/design-system-look-and-feel-react";
-# ou
 import { CheckboxText } from "@axa-fr/design-system-apollo-react/lf";
 
 const MyComponent = () => (
@@ -25,5 +21,7 @@ const MyComponent = () => (
 );
 ```
 
-<Canvas of={CheckboxTextStories.CheckboxTextStory} />
+## Playground
+
+<Canvas of={CheckboxTextStories.CheckboxTextStory} sourceState="shown" />
 <Controls of={CheckboxTextStories.CheckboxTextStory} />

--- a/apps/look-and-feel-stories/src/CheckBoxText/CheckboxText.stories.tsx
+++ b/apps/look-and-feel-stories/src/CheckBoxText/CheckboxText.stories.tsx
@@ -1,91 +1,48 @@
 import { CheckboxText } from "@axa-fr/design-system-apollo-react/lf";
-import { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps, useEffect, useRef } from "react";
-
-const argTypesDefault = {
-  label: {
-    control: { type: "text" },
-  },
-  name: {
-    control: { type: "text" },
-  },
-  value: {
-    control: { type: "text" },
-  },
-  errorMessage: {
-    control: { type: "text" },
-  },
-  checked: {
-    control: { type: "boolean" },
-  },
-  onChange: { action: "onChange" },
-} as const;
-
-const argsDefault = {
-  label:
-    "J'accepte de fournir à AXA mes coordonnées ainsi que les données  relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra  me contacter pour m'accompagner.",
-  name: "option1",
-  value: "option1",
-};
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
 
 const meta: Meta = {
   title: "Components/Form/Checkbox/CheckboxText",
   component: CheckboxText,
-  argTypes: argTypesDefault,
-  args: argsDefault,
+  argTypes: {
+    label: {
+      control: { type: "text" },
+    },
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    errorMessage: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    errorId: {
+      table: {
+        disable: true,
+      },
+    },
+    hasError: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    label:
+      "J'accepte de fournir à AXA mes coordonnées ainsi que les données relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra  me contacter pour m'accompagner.",
+    name: "option1",
+    value: "option1",
+  },
 };
 
 export default meta;
 
-const renderFocus = ({ ...args }: ComponentProps<typeof CheckboxText>) => {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    ref?.current?.focus?.();
-  }, []);
-
-  return <CheckboxText {...args} ref={ref} />;
-};
-
 export const CheckboxTextStory: StoryObj<ComponentProps<typeof CheckboxText>> =
   {
-    name: "CheckboxText",
+    name: "Playground",
   };
-
-export const CheckboxTextChecked: StoryObj<
-  ComponentProps<typeof CheckboxText>
-> = {
-  name: "CheckboxTextChecked",
-  args: {
-    ...argsDefault,
-    checked: true,
-  },
-};
-
-export const CheckboxTextFocus: StoryObj<ComponentProps<typeof CheckboxText>> =
-  {
-    name: "CheckboxTextFocus",
-    render: renderFocus,
-  };
-
-export const CheckboxTextWithErrorStory: StoryObj<
-  ComponentProps<typeof CheckboxText>
-> = {
-  name: "CheckboxText With Error",
-  args: {
-    ...argsDefault,
-    errorMessage: "There is an error",
-  },
-};
-
-export const CheckboxTextWithErrorFocusStory: StoryObj<
-  ComponentProps<typeof CheckboxText>
-> = {
-  name: "CheckboxText With Error focus",
-
-  render: renderFocus,
-  args: {
-    ...argsDefault,
-    errorMessage: "There is an error",
-  },
-};

--- a/apps/look-and-feel-stories/src/Checkbox/Checkbox.mdx
+++ b/apps/look-and-feel-stories/src/Checkbox/Checkbox.mdx
@@ -1,29 +1,23 @@
 import { Canvas, Controls, Meta } from "@storybook/blocks";
 import * as CheckboxStories from "./Checkbox.stories";
 
-<Meta of={CheckboxStories} />
+<Meta of={CheckboxStories} name="Checkbox" />
 
 # Checkbox components
 
-## Checkbox
-
-### How to use
+## How to use
 
 To use the `Checkbox`component import it like this:
 
 ```tsx
-import { Checkbox } from "@axa-fr/design-system-look-and-feel-react";
-# ou
 import { Checkbox } from "@axa-fr/design-system-apollo-react/lf";
 
-const MyComponent = () => (
-  <Checkbox
-    name="name"
-    value="value"
-    label="J'accepte de fournir à AXA mes coordonnées ainsi que les données  relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra  me contacter pour m'accompagner."
-  />
-);
+const MyComponent = () => <Checkbox name="name" value="value" />;
 ```
 
-<Canvas of={CheckboxStories.CheckboxStory} />
+## Playground
+
+The Checkbox component inherits all native `<input type="checkbox"/>` element props.
+
+<Canvas of={CheckboxStories.CheckboxStory} sourceState="shown" />
 <Controls of={CheckboxStories.CheckboxStory} />

--- a/apps/look-and-feel-stories/src/Checkbox/Checkbox.stories.tsx
+++ b/apps/look-and-feel-stories/src/Checkbox/Checkbox.stories.tsx
@@ -1,75 +1,40 @@
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { Checkbox } from "@axa-fr/design-system-look-and-feel-react";
-import { ComponentProps, useEffect, useRef } from "react";
-
-const argsDefault = {
-  name: "option1",
-  value: "option1",
-};
-
-const argTypesDefault = {
-  name: {
-    control: { type: "text" },
-  },
-  value: {
-    control: { type: "text" },
-  },
-  checked: {
-    control: { type: "boolean" },
-  },
-  onChange: { action: "onChange" },
-} as const;
+import type { ComponentProps } from "react";
 
 const meta: Meta = {
   title: "Components/Form/Checkbox/Checkbox",
   component: Checkbox,
-  argTypes: argTypesDefault,
+  argTypes: {
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    "aria-invalid": { type: "boolean" },
+    errorId: {
+      table: {
+        disable: true,
+      },
+    },
+    hasError: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    name: "option1",
+    value: "option1",
+  },
 };
 
 export default meta;
 
-const renderFocus = ({ ...args }) => {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    ref?.current?.focus?.();
-  }, []);
-
-  return <Checkbox {...args} ref={ref} />;
-};
-
 export const CheckboxStory: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox",
-};
-
-export const CheckboxStoryFocus: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox focus",
-  render: renderFocus,
-};
-
-export const CheckboxStoryChecked: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox Checked",
-  args: {
-    ...argsDefault,
-    checked: true,
-  },
-};
-
-export const CheckboxStoryError: StoryObj<ComponentProps<typeof Checkbox>> = {
-  name: "Checkbox Error",
-  args: {
-    ...argsDefault,
-    hasError: true,
-  },
-};
-
-export const CheckboxStoryErrorFocus: StoryObj<
-  ComponentProps<typeof Checkbox>
-> = {
-  name: "Checkbox Error focus",
-  render: renderFocus,
-  args: {
-    ...argsDefault,
-    hasError: true,
-  },
+  name: "Playground",
 };

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxApollo.scss
@@ -1,30 +1,29 @@
 @use "CheckboxCommon";
 
 .af-checkbox {
+  --checkbox-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' viewBox='0 -960 960 960'%3E%3Cpath d='m400-402 250-250q9-9 21-9t21 9q9 9 9 21t-9 21L421-339q-9 9-21 9t-21-9L268-450q-9-9-9-21t9-21q9-9 21-9t21 9l90 90Z'/%3E%3C/svg%3E");
   --checkbox-border-radius: calc(6 / var(--font-size-base) * 1rem);
-  --checkbox-border-color: var(--axa-blue-65);
-  --checkbox-outline-color: var(--checkbox-border-color);
-  --checkbox-check-fill: var(--white);
   --checkbox-background-color: var(--white);
+  --checkbox-border-color: var(--axa-blue-65);
 
   &:hover,
   &:focus-within,
-  &:has(:checked) {
+  &:checked {
     --checkbox-border-color: var(--axa-blue-100);
-    --checkbox-outline-width: 1px;
+    --checkbox-border-width: 2px;
   }
 
-  &:has(:checked) {
+  &:checked {
     --checkbox-background-color: var(--axa-blue-100);
   }
 
-  &:not(:has(:checked)):has([aria-invalid="true"]) {
+  &[aria-invalid="true"]:not(:checked) {
     --checkbox-border-color: var(--red-alert-100);
-    --checkbox-outline-width: 1px;
+    --checkbox-border-width: 2px;
 
     &:hover,
     &:focus-within {
-      --checkbox-outline-width: 2px;
+      --checkbox-border-width: 3px;
     }
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
@@ -3,6 +3,7 @@
 
   width: calc(24 / var(--font-size-base) * 1rem);
   height: calc(24 / var(--font-size-base) * 1rem);
+  margin: 0;
   border-radius: var(--checkbox-border-radius);
   align-items: center;
   background-color: var(--checkbox-background-color);

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
@@ -1,38 +1,17 @@
 .af-checkbox {
   --checkbox-border-width: 1px;
 
-  position: relative;
-  display: flex;
   width: calc(24 / var(--font-size-base) * 1rem);
   height: calc(24 / var(--font-size-base) * 1rem);
-  border: var(--checkbox-border-width) solid var(--checkbox-border-color);
   border-radius: var(--checkbox-border-radius);
   align-items: center;
   background-color: var(--checkbox-background-color);
-  outline: var(--checkbox-outline-width) solid var(--checkbox-outline-color);
-  outline-offset: calc(
-    -1 * calc(var(--checkbox-border-width) + var(--checkbox-outline-width))
-  );
+  outline: var(--checkbox-border-width) solid var(--checkbox-border-color);
+  outline-offset: calc(-1 * var(--checkbox-border-width));
+  cursor: pointer;
+  appearance: unset;
 
-  svg {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    display: none;
-    transform: translate(-50%, -50%);
-    fill: var(--checkbox-check-fill);
-  }
-
-  input[type="checkbox"] {
-    position: absolute;
-    width: calc(24 / var(--font-size-base) * 1rem);
-    height: calc(24 / var(--font-size-base) * 1rem);
-    margin: 0;
-    opacity: 0;
-    cursor: pointer;
-  }
-
-  svg:has(+ input[type="checkbox"]:checked) {
-    display: block;
+  &:checked {
+    background-image: var(--checkbox-background-image);
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxLF.scss
@@ -1,25 +1,29 @@
 @use "CheckboxCommon";
 
 .af-checkbox {
+  --checkbox-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' viewBox='0 -960 960 960'%3E%3Cpath d='m378-332 363-363q9.27-9 21.64-9 12.36 0 21.36 9.05 9 9.06 9 21.5 0 12.45-9 21.45L399-267q-9 9-21 9t-21-9L175-449q-9-9.07-8.5-21.53.5-12.47 9.55-21.47 9.06-9 21.5-9 12.45 0 21.45 9l159 160Z'/%3E%3C/svg%3E");
   --checkbox-border-radius: calc(4 / var(--font-size-base) * 1rem);
-  --checkbox-border-color: var(--color-gray-500);
-  --checkbox-outline-color: var(--checkbox-border-color);
-  --checkbox-check-fill: var(--color-white);
   --checkbox-background-color: var(--color-white);
-  --checkbox-outline-width: 1px;
+  --checkbox-border-color: var(--color-gray-500);
 
   &:hover,
   &:focus-within,
-  &:has(:checked) {
+  &:checked {
     --checkbox-border-color: var(--color-axa);
-    --checkbox-outline-width: 2px;
+    --checkbox-border-width: 3px;
   }
 
-  &:has(:checked) {
+  &:checked {
     --checkbox-background-color: var(--color-axa);
   }
 
-  &:not(:has(:checked)):has([aria-invalid="true"]) {
+  &[aria-invalid="true"]:not(:checked) {
     --checkbox-border-color: var(--color-red-700);
+    --checkbox-border-width: 2px;
+
+    &:hover,
+    &:focus-within {
+      --checkbox-border-width: 3px;
+    }
   }
 }

--- a/client/apollo/css/src/Form/Checkbox/CheckboxText/CheckboxTextApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxText/CheckboxTextApollo.scss
@@ -1,7 +1,5 @@
 @use "CheckboxTextCommon";
 
 .af-checkbox-text {
-  & label {
-    --checkbox-text-label-color: var(--black);
-  }
+  --checkbox-text-label-color: var(--black);
 }

--- a/client/apollo/css/src/Form/Checkbox/CheckboxText/CheckboxTextCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxText/CheckboxTextCommon.scss
@@ -1,31 +1,32 @@
-@use "../../../common/breakpoints" as breakpoints;
+@use "../../../common/breakpoints";
 
 .af-checkbox-text {
   display: grid;
-  grid-template-areas:
-    "icon label"
-    "icon message";
-  grid-template-columns: min-content 1fr;
-  column-gap: calc(8 / var(--font-size-base) * 1rem);
+  grid-template-areas: "icon label";
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: calc(8 / var(--font-size-base) * 1rem);
 
   &:has(> .af-item-message) {
-    row-gap: calc(8 / var(--font-size-base) * 1rem);
+    grid-template-areas:
+      "icon label"
+      "icon message";
   }
 
   label {
-    display: flex;
-    margin: 0;
+    display: contents;
+    cursor: pointer;
+  }
+
+  &__label-content {
     grid-area: label;
-    align-items: flex-start;
-    gap: calc(8 / var(--font-size-base) * 1rem);
-    font-size: calc(18 / var(--font-size-base) * 1rem);
+    font-size: calc(16 / var(--font-size-base) * 1rem);
     font-weight: 400;
     line-height: 1.25;
     color: var(--checkbox-text-label-color);
-    cursor: pointer;
 
-    @media (width < #{breakpoints.$breakpoint-sm}) {
-      font-size: calc(16 / var(--font-size-base) * 1rem);
+    @media (width > #{breakpoints.$breakpoint-sm}) {
+      font-size: calc(18 / var(--font-size-base) * 1rem);
     }
   }
 

--- a/client/apollo/css/src/Form/Checkbox/CheckboxText/CheckboxTextLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/CheckboxText/CheckboxTextLF.scss
@@ -1,7 +1,5 @@
 @use "CheckboxTextCommon";
 
 .af-checkbox-text {
-  & label {
-    --checkbox-text-label-color: var(--color-black);
-  }
+  --checkbox-text-label-color: var(--color-black);
 }

--- a/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxApollo.tsx
+++ b/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxApollo.tsx
@@ -1,12 +1,3 @@
-import { forwardRef } from "react";
 import "@axa-fr/design-system-apollo-css/dist/Form/Checkbox/Checkbox/CheckboxApollo.scss";
-import checkBoxIcon from "@material-symbols/svg-400/rounded/check_small.svg";
-import { CheckboxCommon, type CheckboxProps } from "./CheckboxCommon";
 
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  (props, ref) => (
-    <CheckboxCommon {...props} ref={ref} checkBoxIcon={checkBoxIcon} />
-  ),
-);
-
-Checkbox.displayName = "Checkbox";
+export { Checkbox } from "./CheckboxCommon";

--- a/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -1,31 +1,23 @@
-import { forwardRef, type InputHTMLAttributes } from "react";
-import { Svg } from "../../../Svg/Svg";
+import { type ComponentProps, forwardRef } from "react";
 
 export type CheckboxProps = {
+  /** @deprecated Use `aria-errormessage` instead */
   errorId?: string;
+  /** @deprecated Use `aria-invalid` instead */
   hasError?: boolean;
-  className?: string;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, "disabled">;
+} & Omit<ComponentProps<"input">, "disabled" | "type">;
 
-type CheckboxCommonProps = CheckboxProps & {
-  checkBoxIcon: string;
-};
-
-const CheckboxCommon = forwardRef<HTMLInputElement, CheckboxCommonProps>(
-  ({ errorId, checkBoxIcon, hasError, ...inputProps }, ref) => (
-    <span className="af-checkbox">
-      <Svg src={checkBoxIcon} aria-hidden />
-      <input
-        {...inputProps}
-        ref={ref}
-        type="checkbox"
-        aria-errormessage={errorId}
-        aria-invalid={hasError}
-        disabled={false}
-      />
-    </span>
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ errorId, hasError, className, ...inputProps }, ref) => (
+    <input
+      aria-errormessage={errorId}
+      aria-invalid={hasError}
+      {...inputProps}
+      className={["af-checkbox", className].filter(Boolean).join(" ")}
+      ref={ref}
+      type="checkbox"
+    />
   ),
 );
 
-CheckboxCommon.displayName = "CheckboxCommon";
-export { CheckboxCommon };
+Checkbox.displayName = "Checkbox";

--- a/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxLF.tsx
+++ b/client/apollo/react/src/Form/Checkbox/Checkbox/CheckboxLF.tsx
@@ -1,12 +1,3 @@
-import { forwardRef } from "react";
 import "@axa-fr/design-system-apollo-css/dist/Form/Checkbox/Checkbox/CheckboxLF.scss";
-import checkBoxIcon from "@material-symbols/svg-400/rounded/check.svg";
-import { CheckboxCommon, type CheckboxProps } from "./CheckboxCommon";
 
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  (props, ref) => (
-    <CheckboxCommon {...props} ref={ref} checkBoxIcon={checkBoxIcon} />
-  ),
-);
-
-Checkbox.displayName = "Checkbox";
+export { Checkbox } from "./CheckboxCommon";

--- a/client/apollo/react/src/Form/Checkbox/Checkbox/__tests__/Checkbox.test.tsx
+++ b/client/apollo/react/src/Form/Checkbox/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,37 +1,46 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Checkbox } from "../CheckboxApollo";
+import { Checkbox } from "../CheckboxCommon";
 
 describe("CheckboxCommon Component", () => {
   it("should render the CheckboxCommon component with label", () => {
-    // Act
     render(<Checkbox />);
     const checkbox = screen.getByRole("checkbox");
 
-    // Then
     expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveClass("af-checkbox");
   });
 
-  it("should checked the checkbox", async () => {
-    // Act
-    render(<Checkbox />);
+  it("should render as checked when the checked prop is true", () => {
+    render(<Checkbox checked onChange={vi.fn()} />);
     const checkbox = screen.getByRole("checkbox");
 
-    // Then
-    expect(checkbox).not.toBeChecked();
-    await userEvent.click(checkbox);
     expect(checkbox).toBeChecked();
-    await userEvent.click(checkbox);
-    expect(checkbox).not.toBeChecked();
   });
 
-  it("should set aria-invalid to true when isError is true", () => {
-    // Act
-    render(<Checkbox hasError />);
+  it("should call the onChange handler when clicked", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Checkbox onChange={handleChange} />);
 
-    // Then
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+    await user.click(checkbox);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass additional props to the input element", () => {
+    render(<Checkbox aria-label="custom" />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveAttribute("aria-label", "custom");
+  });
+
+  it("should apply custom class names", () => {
+    render(<Checkbox className="custom-class" />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveClass("af-checkbox custom-class");
   });
 });

--- a/client/apollo/react/src/Form/Checkbox/CheckboxText/CheckboxTextCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CheckboxText/CheckboxTextCommon.tsx
@@ -1,26 +1,18 @@
-import React, {
-  type ReactNode,
-  useId,
-  type ComponentProps,
-  type ComponentType,
-  forwardRef,
-} from "react";
-import { ItemMessage } from "../../ItemMessage/ItemMessageCommon";
-import { Checkbox } from "../Checkbox/CheckboxCommon";
+import { type ReactNode, useId, type ComponentType, forwardRef } from "react";
+import type { ItemMessageProps } from "../../ItemMessage/ItemMessageCommon";
+import type { CheckboxProps } from "../Checkbox/CheckboxCommon";
 
 export type CheckboxTextProps = {
   label: string | ReactNode;
   errorMessage?: string;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "disabled">;
+} & Omit<CheckboxProps, "aria-errormessage" | "aria-invalid">;
 
 export type CheckboxTextCommonProps = CheckboxTextProps & {
-  CheckboxComponent: ComponentType<
-    Omit<ComponentProps<typeof Checkbox>, "checkBoxIcon">
-  >;
-  ItemMessageComponent: ComponentType<ComponentProps<typeof ItemMessage>>;
+  CheckboxComponent: ComponentType<Omit<CheckboxProps, "checkBoxIcon">>;
+  ItemMessageComponent: ComponentType<ItemMessageProps>;
 };
 
-const CheckboxTextCommon = forwardRef<
+export const CheckboxTextCommon = forwardRef<
   HTMLInputElement,
   CheckboxTextCommonProps
 >(
@@ -28,35 +20,33 @@ const CheckboxTextCommon = forwardRef<
     {
       label,
       errorMessage,
+      id,
       CheckboxComponent,
       ItemMessageComponent,
       ...inputProps
     },
     ref,
   ) => {
-    const errorId = useId();
-    let inputId = useId();
-    inputId = inputProps.id || inputId;
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const errorId = `${inputId}-error`;
 
     return (
       <div className="af-checkbox-text">
-        <CheckboxComponent
-          id={inputId}
-          errorId={errorId}
-          hasError={Boolean(errorMessage)}
-          {...inputProps}
-          ref={ref}
-        />
-
-        <label key={inputProps.name} htmlFor={inputId}>
-          <span>{label}</span>
+        <label htmlFor={inputId}>
+          <CheckboxComponent
+            id={inputId}
+            {...inputProps}
+            aria-errormessage={errorMessage ? errorId : undefined}
+            aria-invalid={errorMessage ? true : undefined}
+            ref={ref}
+          />
+          <span className="af-checkbox-text__label-content">{label}</span>
         </label>
-
-        <ItemMessageComponent message={errorMessage} />
+        <ItemMessageComponent message={errorMessage} id={errorId} />
       </div>
     );
   },
 );
 
 CheckboxTextCommon.displayName = "CheckboxTextCommon";
-export { CheckboxTextCommon };

--- a/client/apollo/react/src/Form/Checkbox/CheckboxText/CheckboxTextCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CheckboxText/CheckboxTextCommon.tsx
@@ -6,7 +6,7 @@ import React, {
   forwardRef,
 } from "react";
 import { ItemMessage } from "../../ItemMessage/ItemMessageCommon";
-import { CheckboxCommon } from "../Checkbox/CheckboxCommon";
+import { Checkbox } from "../Checkbox/CheckboxCommon";
 
 export type CheckboxTextProps = {
   label: string | ReactNode;
@@ -15,7 +15,7 @@ export type CheckboxTextProps = {
 
 export type CheckboxTextCommonProps = CheckboxTextProps & {
   CheckboxComponent: ComponentType<
-    Omit<ComponentProps<typeof CheckboxCommon>, "checkBoxIcon">
+    Omit<ComponentProps<typeof Checkbox>, "checkBoxIcon">
   >;
   ItemMessageComponent: ComponentType<ComponentProps<typeof ItemMessage>>;
 };

--- a/client/apollo/react/src/Form/Checkbox/CheckboxText/__tests__/CheckboxText.test.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CheckboxText/__tests__/CheckboxText.test.tsx
@@ -1,57 +1,73 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { axe } from "jest-axe";
-import { CheckboxText } from "../CheckboxTextApollo";
+import { ItemMessage } from "../../../ItemMessage/ItemMessageCommon";
+import { Checkbox } from "../../Checkbox/CheckboxCommon";
+import {
+  CheckboxTextCommon,
+  type CheckboxTextProps,
+} from "../CheckboxTextCommon";
 
 describe("CheckboxText Component", () => {
-  const props = {
-    label: "label axa fr",
-    inputProps: {
-      name: "checkboxTextTest",
-      value: "value",
-      inputId: "checkboxText-1",
-      errorMessage: "",
-    },
-  };
-  it("should render the CheckboxText component with label", () => {
-    // Act
-    render(<CheckboxText {...props} />);
+  const CheckboxText = (props: CheckboxTextProps) => (
+    <CheckboxTextCommon
+      {...props}
+      ItemMessageComponent={ItemMessage}
+      CheckboxComponent={Checkbox}
+    />
+  );
 
-    // Then
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(screen.getByText("label axa fr")).toBeInTheDocument();
+  it("should render the label correctly", () => {
+    render(<CheckboxText label="I accept the terms" name="test" value="1" />);
+
+    expect(
+      screen.getByRole("checkbox", { name: "I accept the terms" }),
+    ).toBeInTheDocument();
   });
 
-  it("should render error when error is provided", () => {
-    // Act
-    render(<CheckboxText {...props} errorMessage="error field" />);
+  it("should handle checked state", () => {
+    render(
+      <CheckboxText
+        label="Option"
+        name="option"
+        value="1"
+        checked
+        onChange={vi.fn()}
+      />,
+    );
 
-    // Then
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(screen.getByText("label axa fr")).toBeInTheDocument();
-    expect(screen.getByText("error field")).toBeInTheDocument();
-  });
-
-  it("should check and uncheck CheckboxText", async () => {
-    // Act
-    render(<CheckboxText {...props} />);
-    const checkboxLabel = screen.getByText("label axa fr");
-    const checkbox = screen.getByRole("checkbox");
-
-    // Then
-    expect(checkbox).not.toBeChecked();
-    await userEvent.click(checkboxLabel);
+    const checkbox = screen.getByRole("checkbox", { name: "Option" });
     expect(checkbox).toBeChecked();
-    await userEvent.click(checkboxLabel);
-    expect(checkbox).not.toBeChecked();
   });
 
-  it("should violate accessibility the of CheckboxText", async () => {
-    // Act
-    const { container } = render(<CheckboxText {...props} />);
+  it("should display the error message if provided", () => {
+    render(
+      <CheckboxText
+        label="Option"
+        name="option"
+        value="1"
+        errorMessage="Required error"
+      />,
+    );
 
-    // Then
-    expect(await axe(container)).toHaveNoViolations();
+    const checkbox = screen.getByRole("checkbox", { name: "Option" });
+    expect(checkbox).toHaveAccessibleErrorMessage("Required error");
+    expect(checkbox).toBeInvalid();
+  });
+
+  it("should call onChange when clicked", async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CheckboxText
+        label="Option"
+        name="option"
+        value="1"
+        onChange={handleChange}
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox", { name: "Option" });
+    await user.click(checkbox);
+    expect(handleChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/apollo/react/src/Form/ItemMessage/ItemMessageCommon.tsx
+++ b/client/apollo/react/src/Form/ItemMessage/ItemMessageCommon.tsx
@@ -3,7 +3,7 @@ import errorIcon from "@material-symbols/svg-400/outlined/error-fill.svg";
 import type { ReactNode } from "react";
 import { Svg } from "../../Svg/Svg";
 
-type ItemMessageProps = {
+export type ItemMessageProps = {
   message?: ReactNode;
   id?: string;
   messageType?: "error" | "success";


### PR DESCRIPTION
**Description:**  
This PR refactors the `Checkbox` and `CheckboxText` components in both Apollo and Look & Feel packages. The main changes are:

- Simplified the Checkbox implementation by removing unnecessary wrappers and SVG icons, relying on CSS for the checkmark and states.
- Updated the Checkbox to inherit all native `<input type="checkbox" />` props, improving flexibility and accessibility.
- Refactored CheckboxText to use a more semantic structure, associating the label and input correctly and improving error message handling.
- Updated Storybook stories and documentation to reflect the new usage and props.
- Improved SCSS for both Checkbox and CheckboxText to support the new structure and states, including error and focus.
- Deprecated `hasError` and `errorId` props in favor of native `aria-invalid` and `aria-errormessage` attributes.

These changes make the components easier to use, more accessible, and more consistent with native HTML behaviors. No breaking changes are expected for standard usage, but custom integrations should verify compatibility with the new props and structure.

Closes #759 
Closes #822 
Closes #867 