### PR TITLE
refactor(apollo,look&feel): simplify TextArea component, update and simplify style and update stories

### DIFF
--- a/apps/apollo-stories/src/components/TextArea/TextArea.mdx
+++ b/apps/apollo-stories/src/components/TextArea/TextArea.mdx
@@ -3,27 +3,17 @@ import * as TextAreaStories from "./TextArea.stories";
 
 <Meta of={TextAreaStories} name="TextArea" />
 
-# TextArea
+# TextArea component
 
-To use the TextArea import it like that:
+## How to use
 
 ```tsx
 import { TextArea } from "@axa-fr/design-system-apollo-react";
 
-const MyComponent = () => (
-  <TextArea
-    ItemLabelComponent={}
-    ItemMessageComponent={}
-    label={}
-    sideButtonLabel={}
-  />
-);
+const MyComponent = () => <TextArea />;
 ```
-
-## Default
-
-<Canvas of={TextAreaStories.TextAreaStory} />
 
 ## Playground
 
+<Canvas of={TextAreaStories.TextAreaStory} sourceState="shown" />
 <Controls of={TextAreaStories.TextAreaStory} />

--- a/apps/apollo-stories/src/components/TextArea/TextArea.mdx
+++ b/apps/apollo-stories/src/components/TextArea/TextArea.mdx
@@ -3,7 +3,7 @@ import * as TextAreaStories from "./TextArea.stories";
 
 <Meta of={TextAreaStories} name="TextArea" />
 
-# TextArea component
+# TextArea
 
 ## How to use
 

--- a/apps/apollo-stories/src/components/TextArea/TextArea.stories.tsx
+++ b/apps/apollo-stories/src/components/TextArea/TextArea.stories.tsx
@@ -1,83 +1,27 @@
 import { TextArea } from "@axa-fr/design-system-apollo-react";
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
 
 const meta: Meta<typeof TextArea> = {
   component: TextArea,
   title: "Components/Form/Input/TextArea",
+  argTypes: {
+    label: { control: { type: "text" } },
+    value: { control: { type: "text" } },
+    disabled: { control: { type: "boolean" } },
+    required: { control: { type: "boolean" } },
+    placeholder: { control: { type: "text" } },
+    helper: { control: { type: "text" } },
+    error: { control: { type: "text" } },
+  },
   args: {
-    value: "",
     label: "Label",
     placeholder: "Placeholder",
-    helper: "1800 caractères maximum.",
     name: "name",
-    id: "nameid",
-    disabled: false,
-    required: false,
-    className: "",
-    buttonLabel: "",
-  },
-  argTypes: {
-    onChange: { action: "onChange" },
   },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof TextArea>;
-
-const render = ({
-  onChange,
-  ...args
-}: React.ComponentProps<typeof TextArea>) => (
-  <TextArea onChange={onChange} {...args} />
-);
-
-export const TextAreaStory: Story = {
+export const TextAreaStory: StoryObj<typeof TextArea> = {
   name: "TextArea",
-  render,
-};
-export const TextAreaWithLabelStory: Story = {
-  name: "TextArea with label",
-  render,
-  args: {
-    label: "Label",
-    description: "Description",
-    buttonLabel: "En savoir plus",
-  },
-};
-
-export const TextAreaWithDescriptionStory: Story = {
-  name: "TextArea with description",
-  render,
-  args: {
-    description: "Description",
-  },
-};
-
-export const TextAreaWithButton: Story = {
-  name: "TextArea with button",
-  render,
-  args: {
-    buttonLabel: "En savoir plus",
-  },
-};
-
-export const TextAreaOnErrorStory: Story = {
-  name: "TextArea on error",
-  render,
-  args: {
-    classModifier: "error",
-    description: "Description",
-    error: "Error Message",
-  },
-};
-
-export const TextAreaDisabled: Story = {
-  name: "TextArea disabled",
-  render,
-  args: {
-    buttonLabel: "En savoir plus",
-    disabled: true,
-  },
 };

--- a/apps/apollo-stories/src/components/TextArea/TextArea.stories.tsx
+++ b/apps/apollo-stories/src/components/TextArea/TextArea.stories.tsx
@@ -23,5 +23,5 @@ const meta: Meta<typeof TextArea> = {
 export default meta;
 
 export const TextAreaStory: StoryObj<typeof TextArea> = {
-  name: "TextArea",
+  name: "Playground",
 };

--- a/apps/look-and-feel-stories/src/Textarea/TextArea.mdx
+++ b/apps/look-and-feel-stories/src/Textarea/TextArea.mdx
@@ -3,20 +3,17 @@ import * as TextAreaStories from "./TextArea.stories";
 
 <Meta of={TextAreaStories} name="TextArea" />
 
-# TextArea
+# TextArea component
 
-To use the TextArea import it like that:
+## How to use
 
 ```tsx
-import { TextArea } from "@axa-fr/design-system-look-and-feel-react";
+import { TextArea } from "@axa-fr/design-system-apollo-react/lf";
 
 const MyComponent = () => <TextArea />;
 ```
 
-## Default
-
-<Canvas of={TextAreaStories.TextAreaStory} />
-
 ## Playground
 
+<Canvas of={TextAreaStories.TextAreaStory} sourceState="shown" />
 <Controls of={TextAreaStories.TextAreaStory} />

--- a/apps/look-and-feel-stories/src/Textarea/TextArea.mdx
+++ b/apps/look-and-feel-stories/src/Textarea/TextArea.mdx
@@ -3,7 +3,7 @@ import * as TextAreaStories from "./TextArea.stories";
 
 <Meta of={TextAreaStories} name="TextArea" />
 
-# TextArea component
+# TextArea
 
 ## How to use
 

--- a/apps/look-and-feel-stories/src/Textarea/TextArea.stories.tsx
+++ b/apps/look-and-feel-stories/src/Textarea/TextArea.stories.tsx
@@ -23,5 +23,5 @@ const meta: Meta<typeof TextArea> = {
 export default meta;
 
 export const TextAreaStory: StoryObj<typeof TextArea> = {
-  name: "TextArea",
+  name: "Playground",
 };

--- a/apps/look-and-feel-stories/src/Textarea/TextArea.stories.tsx
+++ b/apps/look-and-feel-stories/src/Textarea/TextArea.stories.tsx
@@ -1,83 +1,27 @@
-import { TextArea } from "@axa-fr/design-system-look-and-feel-react";
+import { TextArea } from "@axa-fr/design-system-apollo-react/lf";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof TextArea> = {
   component: TextArea,
   title: "Components/Form/Input/TextArea",
+  argTypes: {
+    label: { control: { type: "text" } },
+    value: { control: { type: "text" } },
+    disabled: { control: { type: "boolean" } },
+    required: { control: { type: "boolean" } },
+    placeholder: { control: { type: "text" } },
+    helper: { control: { type: "text" } },
+    error: { control: { type: "text" } },
+  },
   args: {
-    value: "Lorem ipsum",
     label: "Label",
     placeholder: "Placeholder",
-    helper: "Informations complémentaires",
     name: "name",
-    id: "nameid",
-    disabled: false,
-    required: false,
-    className: "",
-    buttonLabel: "",
-  },
-  argTypes: {
-    onChange: { action: "onChange" },
   },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof TextArea>;
-
-const render = ({
-  onChange,
-  ...args
-}: React.ComponentProps<typeof TextArea>) => (
-  <TextArea onChange={onChange} {...args} />
-);
-
-export const TextAreaStory: Story = {
+export const TextAreaStory: StoryObj<typeof TextArea> = {
   name: "TextArea",
-  render,
-};
-
-export const TextAreaWithDescriptionStory: Story = {
-  name: "TextArea with description",
-  render,
-  args: {
-    description: "Description",
-  },
-};
-
-export const TextAreaOnErrorStory: Story = {
-  name: "TextArea on error",
-  render,
-  args: {
-    classModifier: "error",
-    description: "Description",
-    error: "Error Message",
-  },
-};
-
-export const TextAreaWithButton: Story = {
-  name: "TextArea with button",
-  render,
-  args: {
-    buttonLabel: "En savoir plus",
-    disabled: false,
-  },
-};
-
-export const TextAreaDisabled: Story = {
-  args: {
-    value: "Placeholder",
-    label: "Label",
-    placeholder: "Placeholder",
-    helper: "Informations complémentaires",
-    name: "name",
-    id: "nameid",
-    disabled: true,
-    required: false,
-    className: "",
-    buttonLabel: "En savoir plus",
-  },
-
-  name: "TextArea disabled",
-  render,
 };

--- a/client/apollo/css/src/Form/TextArea/TextAreaApollo.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaApollo.scss
@@ -1,4 +1,4 @@
-@use "../../common/breakpoints" as breakpoints;
+@use "../../common/breakpoints";
 @use "TextAreaCommon";
 
 .af-form__input-textarea {

--- a/client/apollo/css/src/Form/TextArea/TextAreaApollo.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaApollo.scss
@@ -1,78 +1,44 @@
 @use "../../common/breakpoints" as breakpoints;
 @use "TextAreaCommon";
 
-.af-form__input-container {
-  .af-item-label .af-item-label__label {
-    --input-text-area-font-size: calc(18 / var(--font-size-base) * 1rem);
-  }
-  @media (width < #{breakpoints.$breakpoint-sm}) {
-    .af-item-label .af-item-label__label {
-      --input-text-area-font-size: calc(16 / var(--font-size-base) * 1rem);
-    }
-
-    :focus,
-    :hover,
-    :placeholder-shown,
-    &:not(:disabled, &--error),
-    &--error {
-      --input-text-area-font-size: calc(16 / var(--font-size-base) * 1rem);
-    }
-  }
-}
-
 .af-form__input-textarea {
-  --input-text-area-box-shadow: var(--axa-blue-100);
-  --input-text-area-border-radius: var(--radius-8);
-  --input-text-area-border-color: var(--axa-blue-65);
-  --input-text-area-background: var(--white);
-  --input-text-area-color: var(--neutral-80);
+  --input-textarea-border-radius: var(--radius-8);
+  --input-textarea-box-shadow-color: var(--axa-blue-65);
+  --input-textarea-placeholder-color: var(--neutral-80);
+  --input-textarea-background-color: var(--white);
+  --input-textarea-color: var(--axa-blue-100);
+  --input-textarea-box-shadow-size: 1px;
 
-  &--error {
-    --input-text-area-border-color: var(--axa-red-100);
+  &:hover,
+  &:focus,
+  &:not(:placeholder-shown) {
+    --input-textarea-box-shadow-color: var(--axa-blue-100);
+    --input-textarea-box-shadow-size: 2px;
   }
 
-  &--error:hover,
-  &--error:focus {
-    --input-text-area-box-shadow-color: var(--axa-red-100);
-  }
+  &[aria-invalid="true"] {
+    --input-textarea-box-shadow-color: var(--red-alert-100);
+    --input-textarea-box-shadow-size: 2px;
 
-  &:not(:placeholder-shown, :focus, :active) {
-    --input-text-area-font-color: var(--axa-blue-100);
-  }
-
-  :not(:placeholder-shown),
-  :focus {
-    --input-text-area-font-size: calc(18 / var(--font-size-base) * 1rem);
-    --input-text-area-font-weight: 400;
+    &:hover,
+    &:focus {
+      --input-textarea-box-shadow-size: 3px;
+    }
   }
 
   &:disabled {
-    --input-text-area-border-color: var(--neutral-14);
-    --input-text-area-background: var(--neutral-5);
-  }
+    --input-textarea-background-color: var(--neutral-5);
+    --input-textarea-box-shadow-color: var(--neutral-50);
+    --input-textarea-placeholder-color: var(--neutral-50);
+    --input-textarea-color: var(--neutral-80);
+    --input-textarea-box-shadow-size: 1px;
 
-  &:disabled:not(:placeholder-shown) {
-    --input-text-area-border-color: var(--neutral-14);
-  }
-
-  &:not(.af-form__input-textarea--error):focus,
-  &:not(.af-form__input-textarea--error, :disabled):hover {
-    --input-text-area-border-size: 2px;
-    --input-text-area-border-color: var(--axa-blue-100);
-  }
-
-  &:not(:disabled, &--error) {
-    &:not(:placeholder-shown) {
-      --input-text-area-font-color: var(--axa-blue-100);
-      --input-text-area-font-weight: 600;
+    &:hover {
+      --input-textarea-box-shadow-size: 1px;
     }
   }
 
-  @media (width < #{breakpoints.$breakpoint-sm}) {
-    --input-text-area-font-size: calc(16 / var(--font-size-base) * 1rem);
-
-    &:not(.af-form__input-textarea--error):focus {
-      --input-text-area-font-size: calc(16 / var(--font-size-base) * 1rem);
-    }
+  &:not(:placeholder-shown):hover {
+    --input-textarea-box-shadow-size: 3px;
   }
 }

--- a/client/apollo/css/src/Form/TextArea/TextAreaCommon.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaCommon.scss
@@ -1,10 +1,6 @@
 @use "../../common/breakpoints";
 
 .af-form__input-textarea {
-  @media (width > #{breakpoints.$breakpoint-md}) {
-    font-size: calc(18 / var(--font-size-base) * 1rem);
-  }
-
   width: 100%;
   min-height: calc(56 / var(--font-size-base) * 1rem);
   padding: calc(16 / var(--font-size-base) * 1rem);
@@ -19,6 +15,10 @@
   box-shadow: 0 0 0 var(--input-textarea-box-shadow-size)
     var(--input-textarea-box-shadow-color);
   outline: none;
+
+  @media (width > #{breakpoints.$breakpoint-md}) {
+    font-size: calc(18 / var(--font-size-base) * 1rem);
+  }
 
   &::placeholder {
     font-weight: 400;

--- a/client/apollo/css/src/Form/TextArea/TextAreaCommon.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaCommon.scss
@@ -1,4 +1,4 @@
-@use "../../common/breakpoints" as breakpoints;
+@use "../../common/breakpoints";
 
 .af-form__input-textarea {
   @media (width > #{breakpoints.$breakpoint-md}) {

--- a/client/apollo/css/src/Form/TextArea/TextAreaCommon.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaCommon.scss
@@ -1,89 +1,27 @@
 @use "../../common/breakpoints" as breakpoints;
 
-.af-form__input-container {
-  .af-item-label .af-item-label__label {
-    font-size: var(--input-text-area-font-size);
+.af-form__input-textarea {
+  @media (width > #{breakpoints.$breakpoint-md}) {
+    font-size: calc(18 / var(--font-size-base) * 1rem);
   }
 
-  .af-form__input-textarea {
-    width: 100%;
-    min-height: calc(56 / var(--font-size-base) * 1rem);
-    padding: calc(16 / var(--font-size-base) * 1rem);
-    border: 1px solid var(--input-text-area-border-color);
-    border-radius: var(--input-text-area-border-radius);
-    font: var(--font-family-base);
-    font-size: var(--input-text-area-font-size);
-    line-height: calc(20 / var(--font-size-base) * 1rem);
-    color: var(--input-text-area-color);
-    background-color: var(--input-text-area-background);
-    box-shadow: 0 0 0 1px var(--input-text-area-background);
-    resize: vertical;
+  width: 100%;
+  min-height: calc(56 / var(--font-size-base) * 1rem);
+  padding: calc(16 / var(--font-size-base) * 1rem);
+  border: none;
+  border-radius: var(--input-textarea-border-radius);
+  font: var(--font-family-base);
+  font-size: var(--input-textarea-font-size);
+  font-weight: 600;
+  line-height: 125%;
+  color: var(--input-textarea-color);
+  background-color: var(--input-textarea-background-color);
+  box-shadow: 0 0 0 var(--input-textarea-box-shadow-size)
+    var(--input-textarea-box-shadow-color);
+  outline: none;
 
-    @media (width < #{breakpoints.$breakpoint-sm}) {
-      line-height: 125%;
-      box-shadow: none;
-
-      --input-text-area-font-size: calc(16 / var(--font-size-base) * 1rem);
-
-      &:focus {
-        font-size: var(--input-text-area-font-size);
-      }
-    }
-
-    &--error,
-    :not(:placeholder-shown),
-    :focus,
-    :hover {
-      font-weight: var(--input-text-area-font-weight);
-      color: var(--input-text-area-font-color);
-      box-shadow: 1px solid var(--input-text-area-box-shadow-color);
-      outline: none;
-    }
-
-    &:enabled,
-    &:focus,
-    &:active {
-      box-shadow: 0 0 0 1px var(--white);
-      outline: none;
-    }
-
-    &--error:hover,
-    &--error:focus {
-      box-shadow: 0 0 0 1px var(--input-text-area-box-shadow-color);
-    }
-
-    &:disabled {
-      border: 1px solid var(--input-text-area-border-color);
-      background: var(--input-text-area-background);
-    }
-
-    &:not(
-        :placeholder-shown,
-        :focus,
-        :disabled,
-        .af-form__input-textarea--error
-      ) {
-      box-shadow: 0 0 0 1px var(--input-text-area-box-shadow);
-    }
-
-    &:disabled:not(:placeholder-shown) {
-      border: 1px solid var(--input-text-area-border-color);
-    }
-
-    &:not(.af-form__input-textarea--error):focus,
-    &:not(.af-form__input-textarea--error, :disabled):hover {
-      border: var(--input-text-area-border-size) solid
-        var(--input-text-area-border-color);
-      box-shadow: 0 0 0 1px var(--input-text-area-border-color);
-    }
-
-    &:not(:disabled, &--error) {
-      &:focus,
-      &:hover,
-      &:not(:placeholder-shown, :focus) {
-        font-weight: var(--input-text-area-font-weight);
-        color: var(--input-text-area-font-color);
-      }
-    }
+  &::placeholder {
+    font-weight: 400;
+    color: var(--input-textarea-placeholder-color);
   }
 }

--- a/client/apollo/css/src/Form/TextArea/TextAreaLF.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaLF.scss
@@ -1,4 +1,4 @@
-@use "../../common/breakpoints" as breakpoints;
+@use "../../common/breakpoints";
 @use "TextAreaCommon";
 
 .af-form__input-textarea {

--- a/client/apollo/css/src/Form/TextArea/TextAreaLF.scss
+++ b/client/apollo/css/src/Form/TextArea/TextAreaLF.scss
@@ -1,54 +1,43 @@
 @use "../../common/breakpoints" as breakpoints;
 @use "TextAreaCommon";
 
-.af-form__input-container {
-  .af-item-label .af-item-label__label {
-    --input-text-area-font-size: calc(18 / var(--font-size-base) * 1rem);
-  }
-
-  @media (width < #{breakpoints.$breakpoint-sm}) {
-    .af-item-label .af-item-label__label {
-      --input-text-area-font-size: calc(16 / var(--font-size-base) * 1rem);
-    }
-  }
-}
-
 .af-form__input-textarea {
-  --input-text-area-border-radius: var(--default-border-radius);
-  --input-text-area-border-color: var(--color-gray-700);
-  --input-text-area-background: var(--color-white);
-  --input-text-area-color: var(--color-gray);
+  --input-textarea-border-radius: var(--default-border-radius);
+  --input-textarea-box-shadow-color: var(--color-gray-700);
+  --input-textarea-placeholder-color: var(--color-gray-700);
+  --input-textarea-background-color: var(--color-white);
+  --input-textarea-color: var(--color-gray-900);
+  --input-textarea-box-shadow-size: 1px;
 
-  &--error {
-    --input-text-area-border-color: var(--color-red-700);
+  &:hover,
+  &:focus {
+    --input-textarea-box-shadow-size: 2px;
   }
 
-  &--error:hover,
-  &--error:focus {
-    --input-text-area-box-shadow-color: var(--color-red-700);
+  &:hover,
+  &:focus,
+  &:not(:placeholder-shown) {
+    --input-textarea-box-shadow-color: var(--color-axa);
+  }
+
+  &[aria-invalid="true"] {
+    --input-textarea-box-shadow-color: var(--color-red-700);
+    --input-textarea-box-shadow-size: 2px;
+
+    &:hover,
+    &:focus {
+      --input-textarea-box-shadow-size: 3px;
+    }
   }
 
   &:disabled {
-    --input-text-area-border-color: var(--color-gray-400);
-    --input-text-area-background: var(--color-gray-200);
-  }
+    --input-textarea-background-color: var(--color-gray-200);
+    --input-textarea-box-shadow-color: var(--color-gray-400);
+    --input-textarea-placeholder-color: var(--color-gray-500);
+    --input-textarea-color: var(--color-gray-700);
 
-  &:not(.af-form__input-textarea--error, :disabled):hover,
-  &:not(.af-form__input-textarea--error):focus {
-    --input-text-area-border-size: 2px;
-    --input-text-area-border-color: var(--color-axa);
-  }
-
-  &:not(:disabled, &--error) {
-    &:not(:placeholder-shown) {
-      --input-text-area-font-weight: 600;
-      --input-text-area-border-color: var(--color-axa);
-    }
-  }
-
-  &:not(:placeholder-shown) {
-    &:focus {
-      --input-text-area-box-shadow: none;
+    &:hover {
+      --input-textarea-box-shadow-size: 1px;
     }
   }
 }

--- a/client/apollo/react/src/Form/TextArea/TextAreaCommon.tsx
+++ b/client/apollo/react/src/Form/TextArea/TextAreaCommon.tsx
@@ -6,7 +6,6 @@ import {
   MouseEventHandler,
   useId,
 } from "react";
-import { getComponentClassName } from "../../utilities/getComponentClassName";
 import { ItemLabel } from "../ItemLabel/ItemLabelCommon";
 import { ItemMessage } from "../ItemMessage/ItemMessageCommon";
 
@@ -19,6 +18,7 @@ type Props = ComponentPropsWithRef<"textarea"> &
     | "sideButtonLabel"
     | "onSideButtonClick"
   > & {
+    /** @deprecated Use `className` instead */
     classModifier?: string;
     helper?: string;
     error?: string;
@@ -29,9 +29,10 @@ type Props = ComponentPropsWithRef<"textarea"> &
     onButtonClick?: MouseEventHandler<HTMLButtonElement>;
   } & Partial<ComponentPropsWithRef<typeof ItemMessage>>;
 
-const TextArea = forwardRef<HTMLTextAreaElement, Props>(
+export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
   (
     {
+      id,
       className,
       classModifier = "",
       label,
@@ -45,23 +46,18 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
       ItemLabelComponent,
       ItemMessageComponent,
       onSideButtonClick,
-      ...otherProps
+      placeholder = " ",
+      ...inputProps
     },
     inputRef,
   ) => {
-    const componentClassName = getComponentClassName(
-      "af-form__input-textarea",
-      className,
-      classModifier,
-    );
-
-    let inputId = useId();
-    inputId = otherProps.id || inputId;
-    const idHelp = useId();
-    const idError = useId();
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const helperId = `${inputId}--helper`;
+    const errorId = `${inputId}--error`;
 
     return (
-      <div className="af-form__input-container">
+      <div className={`af-form__input-container ${className}`}>
         <ItemLabelComponent
           label={label}
           description={description}
@@ -74,23 +70,24 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
         />
         <textarea
           id={inputId}
-          className={componentClassName}
+          className="af-form__input-textarea"
           ref={inputRef}
-          aria-errormessage={error ? idError : undefined}
-          aria-describedby={helper ? idHelp : undefined}
-          aria-invalid={Boolean(error)}
-          {...otherProps}
+          aria-errormessage={error ? errorId : undefined}
+          aria-describedby={helper ? helperId : undefined}
+          required={required}
+          aria-invalid={Boolean(error) || classModifier.includes("error")}
+          placeholder={placeholder}
+          {...inputProps}
         />
         {helper ? (
-          <span id={idHelp} className="af-form__input-helper">
+          <span id={helperId} className="af-form__input-helper">
             {helper}
           </span>
         ) : null}
-        <ItemMessageComponent id={idError} message={error} />
+        <ItemMessageComponent id={errorId} message={error} />
       </div>
     );
   },
 );
-TextArea.displayName = "TextArea";
 
-export { TextArea };
+TextArea.displayName = "TextArea";

--- a/client/apollo/react/src/Form/TextArea/TextAreaCommon.tsx
+++ b/client/apollo/react/src/Form/TextArea/TextAreaCommon.tsx
@@ -53,11 +53,15 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
   ) => {
     const generatedId = useId();
     const inputId = id ?? generatedId;
-    const helperId = `${inputId}--helper`;
-    const errorId = `${inputId}--error`;
+    const helperId = `${inputId}-helper`;
+    const errorId = `${inputId}-error`;
 
     return (
-      <div className={`af-form__input-container ${className}`}>
+      <div
+        className={["af-form__input-container", className]
+          .filter(Boolean)
+          .join(" ")}
+      >
         <ItemLabelComponent
           label={label}
           description={description}
@@ -75,7 +79,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
           aria-errormessage={error ? errorId : undefined}
           aria-describedby={helper ? helperId : undefined}
           required={required}
-          aria-invalid={Boolean(error) || classModifier.includes("error")}
+          aria-invalid={
+            Boolean(error) || classModifier.includes("error") ? true : undefined
+          }
           placeholder={placeholder}
           {...inputProps}
         />


### PR DESCRIPTION
# Description

- Deprecate classModifier
- Fix error style
- Refactor Apollo, LF and common style files to make it simpler
- Refactor stories to have one playground with all props to test component and style

# Breaking change

- Move className from textarea input to input container