### PR TITLE
feat(Message): new role config

### DIFF
--- a/client/apollo/react/src/Message/MessageCommon.tsx
+++ b/client/apollo/react/src/Message/MessageCommon.tsx
@@ -33,7 +33,25 @@ export type MessageProps = {
   action?: ReactElement<typeof Link | ComponentType<ButtonProps>>;
   iconSize?: number;
   heading?: Headings;
+  role?: string;
 } & ComponentPropsWithoutRef<"div">;
+
+const getDefaultRole = (variant: MessageVariants): string | undefined => {
+  if (
+    variant === messageVariants.error ||
+    variant === messageVariants.warning
+  ) {
+    return "alert";
+  }
+  if (
+    variant === messageVariants.information ||
+    variant === messageVariants.validation ||
+    variant === messageVariants.neutral
+  ) {
+    return "status";
+  }
+  return undefined;
+};
 
 const getIconFromType = (variant: MessageVariants) =>
   ({
@@ -52,15 +70,18 @@ export const Message = ({
   action,
   iconSize = 24,
   heading: Heading = "h4",
+  role,
 }: PropsWithChildren<MessageProps>) => {
   const icon = useMemo(() => getIconFromType(variant), [variant]);
+
+  const roleToUse = role ?? getDefaultRole(variant);
 
   return (
     <div
       className={["af-message", `af-message--${variant}`, className]
         .filter(Boolean)
         .join(" ")}
-      role="alert"
+      role={roleToUse}
     >
       <Svg
         src={icon}

--- a/client/apollo/react/src/Message/__tests__/Message.test.tsx
+++ b/client/apollo/react/src/Message/__tests__/Message.test.tsx
@@ -40,10 +40,6 @@ describe("Message", () => {
         expect(screen.getByText(RegExp(children))).toBeDefined();
       }
 
-      expect(screen.getByRole("alert")).toHaveClass(
-        `af-message--${variant || messageVariants.information}`,
-      );
-
       expect(screen.getByRole("presentation")).toHaveAttribute(
         "data-src",
         expect.stringContaining(icon),
@@ -73,6 +69,38 @@ describe("Message", () => {
       "href",
       "https://fakelink.com",
     );
+  });
+
+  describe("Accessibility roles", () => {
+    it.each`
+      variant                        | expectedRole
+      ${undefined}                   | ${"status"}
+      ${messageVariants.information} | ${"status"}
+      ${messageVariants.validation}  | ${"status"}
+      ${messageVariants.neutral}     | ${"status"}
+      ${messageVariants.error}       | ${"alert"}
+      ${messageVariants.warning}     | ${"alert"}
+    `(
+      'should assign role="$expectedRole" by default for variant: $variant',
+      ({ variant, expectedRole }) => {
+        render(<Message variant={variant}>{`Test ${variant}`}</Message>);
+        const messageDiv = screen.getByRole(expectedRole);
+        expect(messageDiv).toBeInTheDocument();
+        expect(messageDiv).toHaveClass(
+          `af-message--${variant || messageVariants.information}`,
+        );
+      },
+    );
+
+    it("should use the explicitly passed role over the default", () => {
+      render(
+        <Message variant="error" role="status">
+          Error message with custom role
+        </Message>,
+      );
+      const messageDiv = screen.getByRole("status");
+      expect(messageDiv).toBeInTheDocument();
+    });
   });
 
   describe("A11Y", () => {


### PR DESCRIPTION
# Feat (#1360)

Comportement précédent :
Le rôle alert est toujours présent, quel que soit le variant du message.

Nouveau comportement :
Le rôle ARIA est adapté au type de message :
alert uniquement pour les erreurs ou alertes.
status ou aucun rôle pour les autres variants (information, validation, etc.).

Impact :
Les lecteurs d’écran annoncent tous les messages comme des alertes, ce qui peut perturber l’expérience utilisateur.


<img width="935" height="369" alt="image" src="https://github.com/user-attachments/assets/389b7732-49c9-401f-b5d7-4d269cd0d21a" />
