### PR TITLE
fix(CardRadio): fix typo and improve horizontal alignment

### DIFF
--- a/apps/look-and-feel-stories/src/CardRadio/CardRadio.mdx
+++ b/apps/look-and-feel-stories/src/CardRadio/CardRadio.mdx
@@ -10,7 +10,7 @@ import * as CardRadioStories from "./CardRadio.stories";
 To use the `CardRadio`component import it like this:
 
 ```tsx
-import { CardRadio } from "@axa-fr/design-system-apollo-react";
+import { CardRadio } from "@axa-fr/design-system-apollo-react/lf";
 
 const MyComponent = () => (
   <CardRadio

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
@@ -68,6 +68,10 @@
   &--horizontal {
     flex-direction: row;
 
+    & .af-card-radio-option__content {
+      align-items: flex-start;
+    }
+
     & .af-radio {
       order: -1;
     }

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -109,6 +109,7 @@ export const CardRadioCommon = ({
                 ? value === cardRadioItemProps.value
                 : undefined
             }
+            required={required}
             {...inputProps}
             {...cardRadioItemProps}
             type={type}


### PR DESCRIPTION
****Description:**  
This PR fixes a typo in the import path for the `CardRadio` component in the documentation, ensuring the correct usage from the `@axa-fr/design-system-apollo-react/lf` package.

Additionally, it improves the horizontal alignment of the `CardRadioOption` content by updating the SCSS to align items to the left when in horizontal mode. The `required` attribute is now correctly passed to the input element in the `CardRadioCommon` component, ensuring proper form validation.

**Changes:**  
- Fixed import path typo in `CardRadio.mdx` documentation.
- Improved horizontal alignment in `CardRadioOptionCommon.scss`.
- Passed the `required` prop to the input in `CardRadioCommon.tsx`.

**Impact:**  
- Documentation is now accurate for consumers.
- Visual alignment of horizontal `CardRadio` options is improved.
- Form validation for required fields is now handled correctly.

No breaking changes are introduced.