### PR TITLE
feat(slash): modifiy margin of modal to center it vertically

### DIFF
--- a/slash/css/src/Modal/Modal.scss
+++ b/slash/css/src/Modal/Modal.scss
@@ -78,7 +78,7 @@
 @include common.media-breakpoint-up(sm) {
   .af-modal {
     max-width: calc(500rem / 16);
-    margin: calc(30rem / 16) auto;
+    margin: auto;
 
     &--sm {
       max-width: calc(300rem / 16);
@@ -90,7 +90,7 @@
   .af-modal {
     &--lg {
       max-width: calc(800rem / 16);
-      margin: calc(30rem / 16) auto;
+      margin: auto;
     }
   }
 }

--- a/slash/react/src/Form/MultiSelect/FormatOptionLabel.tsx
+++ b/slash/react/src/Form/MultiSelect/FormatOptionLabel.tsx
@@ -20,9 +20,9 @@ const formatOptionLabel = (
     <div className="react-select__multi-option-label">
       <div className="checkbox-indicator">
         <span
-          className={classNames("indicator", isChecked && "checkbox-checked")}
+          className={classNames("indicator", { "checkbox-checked": isChecked })}
         >
-          {isChecked && <Svg src={checkIcon} />}
+          {isChecked ? <Svg src={checkIcon} /> : null}
         </span>
       </div>
       {data.label}


### PR DESCRIPTION
closes #740 

**feat: Vertically center the modal**

Modifying modal css => margin to auto

**Before :** 

<img width="829" height="691" alt="image" src="https://github.com/user-attachments/assets/cf76041c-5fc0-4e9a-ac02-64b37a17e447" />


**After :** 

<img width="883" height="575" alt="image" src="https://github.com/user-attachments/assets/e9bcde4d-5d02-40c2-af89-d14d2f614cd0" />


**fix: correcting eslint error**

Changed <Svg/> render method and the conditionnal classname

<img width="1024" height="67" alt="image" src="https://github.com/user-attachments/assets/23f3ca8f-d44a-42c4-9395-998cfba1ba9e" />
