### PR TITLE
fix(slash): divider color on horizontal mode

### DIFF
--- a/slash/css/src/Divider/Divider.css
+++ b/slash/css/src/Divider/Divider.css
@@ -1,15 +1,14 @@
 .af-divider {
-  display: block;
   margin: 0;
-  border-color: var(--gray40);
+  border: 0;
 }
 
 .af-divider--vertical {
   height: inherit;
-  border-left: none;
+  border-left: 1px solid var(--gray40);
 }
 
 .af-divider--horizontal {
   width: 100%;
-  border-bottom: none;
+  border-top: 1px solid var(--gray40);
 }


### PR DESCRIPTION
Fix la couleur sur le mode horizontal.

Avant : 
<img width="445" height="118" alt="image" src="https://github.com/user-attachments/assets/efc8a8bf-7b33-4659-baf8-103079c760d5" />

Après : 
<img width="437" height="115" alt="image" src="https://github.com/user-attachments/assets/5a4551cc-38dd-4346-a3d2-6767e475fded" />
