### PR TITLE
fix(slash): alignement for Card compoent content with no icon

### DIFF
--- a/slash/css/src/Card/Card.css
+++ b/slash/css/src/Card/Card.css
@@ -15,6 +15,7 @@
   border-radius: var(--card-border-radius);
   flex-flow: column nowrap;
   align-items: center;
+  justify-content: center;
   line-height: 1.25rem;
   text-align: center;
   color: var(--card-text-color);
@@ -64,10 +65,10 @@
   min-height: 6rem;
   padding-right: 0;
   flex-direction: row;
+  justify-content: flex-start;
 
   &:not(:has(svg)) {
     min-width: 11.25rem;
-    justify-content: flex-start;
   }
 
   svg {


### PR DESCRIPTION
Avant : 
<img width="259" height="133" alt="image" src="https://github.com/user-attachments/assets/11396a49-9164-4a09-95de-e1d29bd61068" />

Après : 
<img width="243" height="134" alt="image" src="https://github.com/user-attachments/assets/dc4f9f92-423b-489f-a568-253d57c24600" />
