### PR TITLE
Feat: parameterize message type of the stepper component

### DIFF
--- a/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
@@ -30,4 +30,7 @@ export const Playground: Story = {
     message: "Titre message",
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
+  argTypes: {
+    messageType: { control: 'select', options: ['error', 'success'] },
+  }
 };

--- a/apps/look-and-feel-stories/src/Stepper/Stepper.stories.tsx
+++ b/apps/look-and-feel-stories/src/Stepper/Stepper.stories.tsx
@@ -30,4 +30,7 @@ export const Playground: Story = {
     message: "Titre message",
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
+  argTypes: {
+    messageType: { control: 'select', options: ['error', 'success'] },
+  }
 };

--- a/client/apollo/react/src/Stepper/StepperCommon.tsx
+++ b/client/apollo/react/src/Stepper/StepperCommon.tsx
@@ -5,7 +5,10 @@ import {
   useId,
 } from "react";
 import { ProgressBarGroupProps } from "../ProgressBarGroup/ProgressBarGroupCommon";
-import { ItemMessage } from "../Form/ItemMessage/ItemMessageCommon";
+import {
+  ItemMessage,
+  ItemMessageProps,
+} from "../Form/ItemMessage/ItemMessageCommon";
 
 export type StepperProps = {
   currentStepProgress?: number;
@@ -15,6 +18,7 @@ export type StepperProps = {
   nbSteps?: 3 | 4 | 5 | 6 | 7 | 8;
   helper?: string;
   message?: string;
+  messageType?: ItemMessageProps["messageType"];
   titleLevel?: 1 | 2 | 3;
   ProgressBarGroupComponent: ComponentType<
     Omit<ProgressBarGroupProps, "ProgressBarComponent">
@@ -31,6 +35,7 @@ export const Stepper = ({
   ProgressBarGroupComponent,
   helper,
   message,
+  messageType = "success",
   titleLevel = 2,
   ...props
 }: StepperProps) => {
@@ -57,7 +62,7 @@ export const Stepper = ({
         currentStepProgress={currentStepProgress}
       />
       {Boolean(helper) && <span className="af-stepper__helper">{helper}</span>}
-      <ItemMessage message={message} messageType="success" />
+      <ItemMessage message={message} messageType={messageType} />
     </div>
   );
 };

--- a/client/apollo/react/src/Stepper/__tests__/StepperCommon.test.tsx
+++ b/client/apollo/react/src/Stepper/__tests__/StepperCommon.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Stepper } from "../StepperCommon";
 import { ProgressBarGroup } from "../../ProgressBarGroup/ProgressBarGroupApollo";
+import { ItemMessageProps } from "../../Form/ItemMessage/ItemMessageCommon";
 
 describe("Stepper Component", () => {
   it("renders the title and subtitle when visible", () => {
@@ -67,19 +68,30 @@ describe("Stepper Component", () => {
     expect(helper).toBeInTheDocument();
   });
 
-  it("renders the message when provided", () => {
-    render(
-      <Stepper
-        currentStep={1}
-        message="This is a success message"
-        nbSteps={4}
-        ProgressBarGroupComponent={ProgressBarGroup}
-      />,
-    );
+  it.each([
+    ["success", "This is a success message", null],
+    ["error", "This is an error message", "alert"],
+  ])(
+    "renders a %s message when message provided with %s message type",
+    (messageType, messageText, expectedRole) => {
+      render(
+        <Stepper
+          currentStep={1}
+          message={messageText}
+          nbSteps={4}
+          ProgressBarGroupComponent={ProgressBarGroup}
+          messageType={messageType as ItemMessageProps["messageType"]}
+        />,
+      );
 
-    const message = screen.getByText("This is a success message");
-    expect(message).toBeInTheDocument();
-  });
+      const message = screen.getByText(messageText);
+      expect(message.parentElement?.classList).toContain(
+        `af-item-message--${messageType}`,
+      );
+      expect(message.parentElement?.role).toBe(expectedRole);
+      expect(message).toBeInTheDocument();
+    },
+  );
 
   it("applies additional className to the ProgressBarGroupComponent", () => {
     render(


### PR DESCRIPTION
**Apollo :**

<img width="1217" height="267" alt="image" src="https://github.com/user-attachments/assets/e7e0a6a2-91b8-49c9-98c6-65b5bf42c407" />

<img width="1231" height="238" alt="image" src="https://github.com/user-attachments/assets/38d360b1-8235-40f5-8b8c-f451f094f8f3" />


**Look & feel :**

<img width="1175" height="203" alt="image" src="https://github.com/user-attachments/assets/3bce1a84-ca9e-43d1-a394-f7c9fb5a82e3" />

<img width="1184" height="218" alt="image" src="https://github.com/user-attachments/assets/ba3d417f-6199-48e2-a375-2131d89795ed" />
