### PR TITLE
various fixes for 2.0.0

### DIFF
--- a/apps/slash-stories/src/Message.stories.tsx
+++ b/apps/slash-stories/src/Message.stories.tsx
@@ -99,15 +99,15 @@ export const Default: Story = {
   },
 };
 
-export const DangerAlert: Story = {
+export const WarningMessage: Story = {
   args: {
-    variant: "danger",
+    variant: "warning",
     title: "Attention: des informations sont manquantes",
     closeButtonAriaLabel: "close",
   },
 };
 
-export const InfoAlert: Story = {
+export const InfoMessage: Story = {
   args: {
     variant: "info",
     title: "Attention: des informations sont manquantes",
@@ -115,7 +115,7 @@ export const InfoAlert: Story = {
   },
 };
 
-export const SuccessAlert: Story = {
+export const SuccessMessage: Story = {
   args: {
     variant: "success",
     title: "Succès: votre demande a bien été enregistrée.",
@@ -123,7 +123,7 @@ export const SuccessAlert: Story = {
   },
 };
 
-export const ErrorAlert: Story = {
+export const ErrorMessage: Story = {
   args: {
     variant: "error",
     title: "Erreur dans les champs suivants :",

--- a/apps/slash-stories/src/Modal.stories.tsx
+++ b/apps/slash-stories/src/Modal.stories.tsx
@@ -106,7 +106,7 @@ export const DefaultModalStory: TDefaultModalStory = {
           <ModalFooter>
             {args.size !== "sm" && (
               <Button
-                classModifier="reverse"
+                variant="secondary"
                 type="button"
                 onClick={() => {
                   args.onCancel();
@@ -117,7 +117,7 @@ export const DefaultModalStory: TDefaultModalStory = {
               </Button>
             )}
             <Button
-              classModifier="success"
+              variant="validated"
               type="button"
               onClick={() => {
                 args.onSubmit();

--- a/apps/slash-stories/src/Tag.mdx
+++ b/apps/slash-stories/src/Tag.mdx
@@ -1,4 +1,4 @@
-import { Controls, Canvas, Meta } from "@storybook/blocks";
+import { Canvas, Controls, Meta } from "@storybook/blocks";
 import * as TagStories from "./Tag.stories.tsx";
 
 <Meta of={TagStories} />
@@ -7,7 +7,7 @@ import * as TagStories from "./Tag.stories.tsx";
 
 ### Info
 
-The Tag component is used to display a tag with a text or an icon. The component Badge was deprecated in favor of Tag.
+The `Tag` component is used to display a tag with a text or an icon. The component `Badge` was deprecated in favor of `Tag`.
 
 You can use `af-badge` but it will be replaced by `af-tag` which takes precedence. `af-badge` is deprecated and will be removed in the next major version.
 
@@ -27,13 +27,27 @@ export const SimpleTag = () => <Tag classModifier="success">Lorem ipsum</Tag>;
 
 ```tsx title="test.js"
 export const WithIconTag = () => (
-  <Tag classModifier="error">
-    <i className="glyphicon glyphicon-bell" />
+  <Tag variant="error">
+    <Svg src={iconBell} />3 errors
   </Tag>
 );
 ```
 
 ## Tag with modifiers
+
+The `Tag` component exists in the following variants:
+
+- `default`
+- `success`
+- `warning`
+- `info`
+- `error`
+- `black`
+- `purple`
+- `gray`
+- `white`
+
+The white variant is designed to be used on dark backgrounds.
 
 <Canvas of={TagStories.MultiExamples} />
 

--- a/apps/slash-stories/src/Tag.stories.tsx
+++ b/apps/slash-stories/src/Tag.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, StoryObj } from "@storybook/react";
 import { Tag } from "@axa-fr/design-system-slash-react";
+import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Tag> = {
   title: "Components/Tag",
@@ -18,7 +18,7 @@ export const Default: StoryObj<typeof Tag> = {
     disabled: false,
   },
   argTypes: {
-    classModifier: {
+    variant: {
       options: [
         "success",
         "information",
@@ -42,11 +42,11 @@ export const TagIconStory: StoryObj<typeof Tag> = {
         <i className="glyphicon glyphicon-bell" /> success
       </>
     ),
-    classModifier: "success",
+    variant: "success",
     disabled: false,
   },
   argTypes: {
-    classModifier: {
+    variant: {
       options: [
         "success",
         "information",
@@ -87,25 +87,25 @@ export const MultiExamples: StoryObj<typeof Tag> = {
           }}
         >
           <Tag disabled={args.disabled}>Tag Default</Tag>
-          <Tag disabled={args.disabled} classModifier="success">
+          <Tag disabled={args.disabled} variant="success">
             Tag Success
           </Tag>
-          <Tag disabled={args.disabled} classModifier="warning">
+          <Tag disabled={args.disabled} variant="warning">
             Tag Warning
           </Tag>
-          <Tag disabled={args.disabled} classModifier="information">
+          <Tag disabled={args.disabled} variant="information">
             Tag Info
           </Tag>
-          <Tag disabled={args.disabled} classModifier="error">
+          <Tag disabled={args.disabled} variant="error">
             Tag Error
           </Tag>
-          <Tag disabled={args.disabled} classModifier="dark">
+          <Tag disabled={args.disabled} variant="dark">
             Tag Black
           </Tag>
-          <Tag disabled={args.disabled} classModifier="purple">
+          <Tag disabled={args.disabled} variant="purple">
             Tag Purple
           </Tag>
-          <Tag disabled={args.disabled} classModifier="gray">
+          <Tag disabled={args.disabled} variant="gray">
             Tag Gray
           </Tag>
         </div>
@@ -123,31 +123,31 @@ export const MultiExamples: StoryObj<typeof Tag> = {
             <i className="glyphicon glyphicon-bell" />
             Tag default
           </Tag>
-          <Tag disabled={args.disabled} classModifier="success">
+          <Tag disabled={args.disabled} variant="success">
             <i className="glyphicon glyphicon-bell" />
             Tag Success
           </Tag>
-          <Tag disabled={args.disabled} classModifier="warning">
+          <Tag disabled={args.disabled} variant="warning">
             <i className="glyphicon glyphicon-bell" />
             Tag Warning
           </Tag>
-          <Tag disabled={args.disabled} classModifier="information">
+          <Tag disabled={args.disabled} variant="information">
             <i className="glyphicon glyphicon-bell" />
             Tag Information
           </Tag>
-          <Tag disabled={args.disabled} classModifier="error">
+          <Tag disabled={args.disabled} variant="error">
             <i className="glyphicon glyphicon-bell" />
             Tag Error
           </Tag>
-          <Tag disabled={args.disabled} classModifier="dark">
+          <Tag disabled={args.disabled} variant="dark">
             <i className="glyphicon glyphicon-bell" />
             Tag Dark
           </Tag>
-          <Tag disabled={args.disabled} classModifier="purple">
+          <Tag disabled={args.disabled} variant="purple">
             <i className="glyphicon glyphicon-bell" />
             Tag Purple
           </Tag>
-          <Tag disabled={args.disabled} classModifier="gray">
+          <Tag disabled={args.disabled} variant="gray">
             <i className="glyphicon glyphicon-bell" />
             Tag Gray
           </Tag>

--- a/apps/slash-stories/src/Tag.stories.tsx
+++ b/apps/slash-stories/src/Tag.stories.tsx
@@ -1,4 +1,5 @@
-import { Tag } from "@axa-fr/design-system-slash-react";
+import { Svg, Tag } from "@axa-fr/design-system-slash-react";
+import iconBell from "@material-symbols/svg-400/outlined/notifications-fill.svg";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Tag> = {
@@ -6,17 +7,15 @@ const meta: Meta<typeof Tag> = {
   component: Tag,
   parameters: {
     layout: "centered",
+    backgrounds: {
+      default: "light",
+      values: [
+        { name: "light", value: "#ffffff" },
+        { name: "blue", value: "#00008f" },
+      ],
+    },
   },
-};
-export default meta;
-
-export const Default: StoryObj<typeof Tag> = {
-  name: "Tag",
-  args: {
-    children: "Lorem ipsum",
-    classModifier: "success",
-    disabled: false,
-  },
+  globals: {},
   argTypes: {
     variant: {
       options: [
@@ -28,12 +27,38 @@ export const Default: StoryObj<typeof Tag> = {
         "dark",
         "purple",
         "gray",
+        "white",
       ],
       control: { type: "select" },
       defaultValue: "success",
     },
   },
 };
+export default meta;
+
+export const Default: StoryObj<typeof Tag> = {
+  name: "Tag",
+  args: {
+    children: "Lorem ipsum",
+    variant: "success",
+    disabled: false,
+  },
+};
+
+export const WhiteTagOnDarkBackground: StoryObj<typeof Tag> = {
+  name: "White Tag on dark background",
+  args: {
+    children: "Lorem ipsum",
+    variant: "white",
+    disabled: false,
+  },
+  parameters: {
+    backgrounds: {
+      default: "blue",
+    },
+  },
+};
+
 export const TagIconStory: StoryObj<typeof Tag> = {
   name: "Tag with Icon",
   args: {
@@ -44,22 +69,6 @@ export const TagIconStory: StoryObj<typeof Tag> = {
     ),
     variant: "success",
     disabled: false,
-  },
-  argTypes: {
-    variant: {
-      options: [
-        "success",
-        "information",
-        "warning",
-        "error",
-        "default",
-        "dark",
-        "purple",
-        "gray",
-      ],
-      control: { type: "select" },
-      defaultValue: "error",
-    },
   },
 };
 
@@ -108,6 +117,9 @@ export const MultiExamples: StoryObj<typeof Tag> = {
           <Tag disabled={args.disabled} variant="gray">
             Tag Gray
           </Tag>
+          <Tag disabled={args.disabled} variant="white">
+            Tag White
+          </Tag>
         </div>
         <div
           style={{
@@ -116,11 +128,11 @@ export const MultiExamples: StoryObj<typeof Tag> = {
             alignItems: "center",
             padding: "2rem",
             flexWrap: "wrap",
-            gap: "5rem",
+            gap: "2rem",
           }}
         >
           <Tag disabled={args.disabled}>
-            <i className="glyphicon glyphicon-bell" />
+            <Svg src={iconBell} />
             Tag default
           </Tag>
           <Tag disabled={args.disabled} variant="success">
@@ -150,6 +162,10 @@ export const MultiExamples: StoryObj<typeof Tag> = {
           <Tag disabled={args.disabled} variant="gray">
             <i className="glyphicon glyphicon-bell" />
             Tag Gray
+          </Tag>
+          <Tag disabled={args.disabled} variant="white">
+            <i className="glyphicon glyphicon-bell" />
+            Tag White
           </Tag>
         </div>
       </div>

--- a/apps/slash-stories/src/VerticalStep.stories.tsx
+++ b/apps/slash-stories/src/VerticalStep.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import { Button, VerticalStep } from "@axa-fr/design-system-slash-react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Components/Steps/VerticalStep",
@@ -16,8 +16,8 @@ export const VerticalStepLockedStory: Story = {
     id: "configuration",
     stepMode: "locked",
     onEdit: () => {},
-    form: <h3>Formulaire de l'étape configuration</h3>,
-    restitution: <h3>Resitution de l'étape configuration</h3>,
+    form: <h3>Formulaire de l&apos;étape configuration</h3>,
+    restitution: <h3>Resitution de l&apos;étape configuration</h3>,
   },
 };
 
@@ -30,14 +30,14 @@ export const VerticalStepEditedStory: Story = {
     onEdit: () => {},
     form: (
       <section>
-        <h3>Formulaire de l'étape configuration</h3>
+        <h3>Formulaire de l&apos;étape configuration</h3>
 
-        <Button type="submit" classModifier="success">
-          Valider l'étape
+        <Button type="submit" variant="validated">
+          Valider l&apos;étape
         </Button>
       </section>
     ),
-    restitution: <h3>Resitution de l'étape configuration</h3>,
+    restitution: <h3>Resitution de l&apos;étape configuration</h3>,
   },
 };
 
@@ -48,8 +48,8 @@ export const VerticalStepValidatedWithoutRestitutionStory: Story = {
     id: "configuration",
     stepMode: "validated",
     onEdit: () => {},
-    form: <h3>Formulaire de l'étape configuration</h3>,
-    restitution: <h3>Resitution de l'étape configuration</h3>,
+    form: <h3>Formulaire de l&apos;étape configuration</h3>,
+    restitution: <h3>Resitution de l&apos;étape configuration</h3>,
     showRestitution: false,
   },
 };
@@ -61,8 +61,8 @@ export const VerticalStepValidatedWithRestitutionStory: Story = {
     id: "configuration",
     stepMode: "validated",
     onEdit: () => {},
-    form: <h3>Formulaire de l'étape configuration</h3>,
-    restitution: <h3>Resitution de l'étape configuration</h3>,
+    form: <h3>Formulaire de l&apos;étape configuration</h3>,
+    restitution: <h3>Resitution de l&apos;étape configuration</h3>,
   },
 };
 
@@ -74,8 +74,8 @@ export const VerticalStepValidatedWithContentRightStory: Story = {
     stepMode: "validated",
     contentRight: "Contenu à droite",
     onEdit: () => {},
-    form: <h3>Formulaire de l'étape configuration</h3>,
-    restitution: <h3>Resitution de l'étape configuration</h3>,
+    form: <h3>Formulaire de l&apos;étape configuration</h3>,
+    restitution: <h3>Resitution de l&apos;étape configuration</h3>,
   },
 };
 

--- a/docs/changelogs/slash/CHANGELOG_v2.0.0.md
+++ b/docs/changelogs/slash/CHANGELOG_v2.0.0.md
@@ -4,10 +4,18 @@
 
 ### Button component
 
-The `Button` component has been updated to include new styles and props. The following changes have been made:
+The `Button` component has been updated to include new styles and props. The
+following changes have been made:
 
-- Added a new `variant` prop to allow for different button styles (`primary` (default variant), `secondary`, `validated`, `danger`, `ghost` and `ghost-reverse`). The `variant` property replace the `classModifier` property. `classModifier` SHOULDN'T be used for this component anymore.
-- The introduction of the `variant` changes also how `className` works. When passing a className to change the appearance of the button (this should be a rare exception, projects should always use the style exported by the design system), you don't need to pass the `af-btn` className anymore. Your className will be added to the `af-btn`.
+- Added a new `variant` prop to allow for different button styles (`primary`
+  (default variant), `secondary`, `validated`, `danger`, `ghost` and
+  `ghost-reverse`). The `variant` property replace the `classModifier` property.
+  `classModifier` SHOULDN'T be used for this component anymore.
+- The introduction of the `variant` changes also how `className` works. When
+  passing a className to change the appearance of the button (this should be a
+  rare exception, projects should always use the style exported by the design
+  system), you don't need to pass the `af-btn` className anymore. Your className
+  will be added to the `af-btn`.
 - Updated the default button styles to match the new design guidelines.
 
 Example :
@@ -33,8 +41,11 @@ The style of each variant are as follow :
 - `ghost`: Transparent background and no border with blue text
 - `ghost-reverse`: Transparent background and no border with white text
 
-If you have icon(s) inside your `Button`, previously you used to add your icon as `children` of the component and add the `classModifier` `hasiconLeft` or `hasiconRight` depending on where you wanted your icon to be placed.
-Now it is easier, you can use the `leftIcon` or `rightIcon` prop to pass your icon directly.
+If you have icon(s) inside your `Button`, previously you used to add your icon
+as `children` of the component and add the `classModifier` `hasiconLeft` or
+`hasiconRight` depending on where you wanted your icon to be placed. Now it is
+easier, you can use the `leftIcon` or `rightIcon` prop to pass your icon
+directly.
 
 ```tsx
 <Button leftIcon={<i className="glyphicon glyphicon-arrow-left" />}>
@@ -42,22 +53,30 @@ Now it is easier, you can use the `leftIcon` or `rightIcon` prop to pass your ic
 </Button>
 ```
 
-You can find the style of each variant on the storybook and a deeper documentation for the migration of the button component [here](./MIGRATION-GUIDE-FROM-V1.md)
+You can find the style of each variant on the storybook and a deeper
+documentation for the migration of the button component
+[here](./MIGRATION-GUIDE-FROM-V1.md)
 
 ### Rename color tokens
 
-In order to match the exact token name of the UX designers, we have renamed two design tokens.
+In order to match the exact token name of the UX designers, we have renamed two
+design tokens.
 
 - `--green40` is now named `--green30`
 - `--green50` is now named `--green40`
 
-If you are using those tokens inside your application, review your usage and update any references accordingly.
+If you are using those tokens inside your application, review your usage and
+update any references accordingly.
 
 ## Added
 
 ### Card component
 
-A new `Card` component has been added to the design system. This component is used to display content in a card format, with a content and optional image. The `orientation` property allows to switch the component between `vertical` and `horizontal`. As this component acts as a button, you can use an `onClick` handler.
+A new `Card` component has been added to the design system. This component is
+used to display content in a card format, with a content and optional image. The
+`orientation` property allows to switch the component between `vertical` and
+`horizontal`. As this component acts as a button, you can use an `onClick`
+handler.
 
 ```jsx
 <Card id="id" onClick={() => action()} iconSrc={villaIcon}>
@@ -69,7 +88,14 @@ A new `Card` component has been added to the design system. This component is us
 
 ### VerticalStep component
 
-The `VerticalStep` component allows you to create a step in a vertical stepper. It is designed to be used in forms or processes where you need to guide the user through multiple steps, each with its own content and actions. The application have the responsibility for the state of the mode of each VerticalStep and the change of those states. The `form` property allows you to pass a form element that will be displayed in the step. The `restitution` property allows you to pass a restitution element that will be displayed when the step's mode is `validated`.
+The `VerticalStep` component allows you to create a step in a vertical stepper.
+It is designed to be used in forms or processes where you need to guide the user
+through multiple steps, each with its own content and actions. The application
+have the responsibility for the state of the mode of each VerticalStep and the
+change of those states. The `form` property allows you to pass a form element
+that will be displayed in the step. The `restitution` property allows you to
+pass a restitution element that will be displayed when the step's mode is
+`validated`.
 
 NB: `VerticalStep` component allows a `contentRight` but only as string.
 
@@ -115,9 +141,12 @@ export const Component = () => {
 
 ### AnchorNavBar for HeaderTitle
 
-`HeaderTitle` now supports an `anchorNavBarItems` property that allows you to create a navigation bar anchored to the header title. This is useful for providing quick access to different sections of the page.
+`HeaderTitle` now supports an `anchorNavBarItems` property that allows you to
+create a navigation bar anchored to the header title. This is useful for
+providing quick access to different sections of the page.
 
-The `anchorNavBarItems` property is an array of objects with the following structure:
+The `anchorNavBarItems` property is an array of objects with the following
+structure:
 
 ```tsx
 interface AnchorNavBarItem {
@@ -161,11 +190,17 @@ export default TitleComponent;
 
 ### Divider component
 
-The `Divider` component is a simple horizontal line that can be used to separate content within a layout. You can use the `mode` property to control its orientation (e.g., `horizontal`, `vertical`).
+The `Divider` component is a simple horizontal line that can be used to separate
+content within a layout. You can use the `mode` property to control its
+orientation (e.g., `horizontal`, `vertical`).
 
 ### Container component
 
-The `Container` component is a layout component that provides a responsive container. It can be used to wrap content, apply consistent margins and set correct background color so that you don't have to repeat these styles in your different projects. To use it, import the `Container` component and wrap your content with it. The component sets a `main` html element.
+The `Container` component is a layout component that provides a responsive
+container. It can be used to wrap content, apply consistent margins and set
+correct background color so that you don't have to repeat these styles in your
+different projects. To use it, import the `Container` component and wrap your
+content with it. The component sets a `main` html element.
 
 ```tsx
 <Container>
@@ -175,8 +210,10 @@ The `Container` component is a layout component that provides a responsive conta
 
 ### Tag component
 
-The `Tag` component is a new component that replaces the deprecated `Badge` component. It is used to display a label inside a block of color.
-You can use the `classModifier` prop to apply different styles to the tag. The values for the `classModifier` prop are as follow:
+The `Tag` component is a new component that replaces the deprecated `Badge`
+component. It is used to display a label inside a block of color. You can use
+the `variant` prop to apply different styles to the tag. The values for the
+`variant` prop are as follow:
 
 - `success`
 - `information`
@@ -188,18 +225,32 @@ You can use the `classModifier` prop to apply different styles to the tag. The v
 - `gray`
 
 ```tsx
-<Tag classModifier="success">Lorem ipsum</Tag>
+<Tag variant="success">Lorem ipsum</Tag>
 ```
+
+#### Backward compatibility
+
+To ensure backward compatibility, the `Tag` component also supports the
+`classModifier` prop with the previous values (`success`, `info`, `danger`,
+`error`). **However this is deprecated and you should use the `variant` prop
+instead. **
 
 ### CardData component
 
-The `CardData` component is used to display a card with a title, an icon, and content. It can also include a subtitle, a description and additional content on the right side of the header.
+The `CardData` component is used to display a card with a title, an icon, and
+content. It can also include a subtitle, a description and additional content on
+the right side of the header.
 
-The content can either take all space available or have specific margins (which is the default mode). If you want content to take all size, use the `contentFitAllSize` property.
+The content can either take all space available or have specific margins (which
+is the default mode). If you want content to take all size, use the
+`contentFitAllSize` property.
 
-The `icon` has a background color that can be set with the `variant` property with one of this value : `error`, `warning`, `information`, `success`, `default`, `dark`, `gray`, and `purple`.
+The `icon` has a background color that can be set with the `variant` property
+with one of this value : `error`, `warning`, `information`, `success`,
+`default`, `dark`, `gray`, and `purple`.
 
-Also, you can remove the divider between the `header` and the `content` of the card by setting the `withDivider` property to `false`.
+Also, you can remove the divider between the `header` and the `content` of the
+card by setting the `withDivider` property to `false`.
 
 ```tsx
 import Svg from "@/assets/ton_svg.svg";
@@ -217,17 +268,27 @@ export const Component = () => (
 
 ### Content on HeaderTitle
 
-The `HeaderTitle` component now has a contentLeft property that allows you to add content to the left side of the title which wasn't possible before. We used to be able to add content at the right with the `children` property, we now support two different solutions. The `children` property is still available and add content at the right side of the title. To add content at the far right of the title bar, you can use the `contentRight` property.
+The `HeaderTitle` component now has a contentLeft property that allows you to
+add content to the left side of the title which wasn't possible before. We used
+to be able to add content at the right with the `children` property, we now
+support two different solutions. The `children` property is still available and
+add content at the right side of the title. To add content at the far right of
+the title bar, you can use the `contentRight` property.
 
 ![HeaderTitle component example](./images/headerTitle_component_v2.0.0.png)
 
 ### Accordion white variant
 
-The `Accordion` has now a new `white` variant that allows you to use the component with a white background. To do so use the `classModifier` property with the value `white`.
+The `Accordion` has now a new `white` variant that allows you to use the
+component with a white background. To do so use the `classModifier` property
+with the value `white`.
 
 ### Radio has a new card mode
 
-The `Radio` component now has a new card mode that allows you to display radio buttons as cards. To enable this mode, use the `mode` property with the value `card`. You can then use the `orientation` property to control the layout of the cards (horizontal or vertical).
+The `Radio` component now has a new card mode that allows you to display radio
+buttons as cards. To enable this mode, use the `mode` property with the value
+`card`. You can then use the `orientation` property to control the layout of the
+cards (horizontal or vertical).
 
 ```tsx
 const options = [
@@ -245,11 +306,13 @@ const MyRadioCard = () => <Radio mode="card" options={options} />;
 
 ### Miscellaneous
 
-- All inputs components have been updated to use the new design tokens. The colors are now aligned with the expected design.
+- All inputs components have been updated to use the new design tokens. The
+  colors are now aligned with the expected design.
 - `Button` has the correct design (color, spacings).
 - `Steps` has the correct design (font, color, spacings, icons).
 - `Message` has the correct design (font, color, spacings, icons).
-- `MultiSelect` now has the correct design validated by the UX designers. Here's an example of the new look of that component.
+- `MultiSelect` now has the correct design validated by the UX designers. Here's
+  an example of the new look of that component.
 
 ![MultiSelect component example](./images/multi_select_v2.0.0.png)
 
@@ -257,7 +320,8 @@ const MyRadioCard = () => <Radio mode="card" options={options} />;
 
 #### Add ariaLabel for Pager and Paging components
 
-The property `selectPageSizeLabel` has been added to the `Paging` component and allows screen readers to announce the purpose of the page size selector.
+The property `selectPageSizeLabel` has been added to the `Paging` component and
+allows screen readers to announce the purpose of the page size selector.
 
 ```jsx
 <Paging
@@ -269,7 +333,10 @@ The property `selectPageSizeLabel` has been added to the `Paging` component and 
 />
 ```
 
-The property `elementsLabel` has been added to the `Pager` component to describe the element being paginated. The property is then used on each navigation number link and on each pagination button (previous and next buttons). By default, this property has the value `éléments`.
+The property `elementsLabel` has been added to the `Pager` component to describe
+the element being paginated. The property is then used on each navigation number
+link and on each pagination button (previous and next buttons). By default, this
+property has the value `éléments`.
 
 ```jsx
 <Pager currentPage={2} elementsLabel="sinistres" numberPages={10} />
@@ -279,4 +346,5 @@ The property `elementsLabel` has been added to the `Pager` component to describe
 
 - `Alert` component is deprecated in favor of the new `Message` component.
 - `Badge` component is deprecated in favor of the new `Tag` component.
-- For the `Badge` component, `classModifier` `danger` and `info` are deprecated in favor of `warning` and `information`, respectively.
+- For the `Badge` component, `classModifier` `danger` and `info` are deprecated
+  in favor of `warning` and `information`, respectively.

--- a/docs/guidelines/documenting-components.md
+++ b/docs/guidelines/documenting-components.md
@@ -1,0 +1,51 @@
+# Using JSDoc to document our components and their props
+
+Every new component should be documented using JSDoc. This allows us to generate
+documentation automatically and provides a consistent way to describe the
+component's functionality, props, and usage.
+
+This allows developers to have documentation in their IDEs about components, and
+their props.
+
+## Writing JSDoc Comments
+
+Use JSDoc comments to describe the component and its props. Here is an example:
+
+````tsx
+type ButtonProps = {
+    /**
+     * The variant of the button, which determines its style.
+     * @default "primary"
+     * Possible values are "primary", "secondary", and "ghost".
+     * @example
+     * ```tsx
+     * <Button variant="primary">Primary Button</Button>
+     * ```
+     */
+    variant: "primary" | "secondary" | "ghost";
+    /**
+     * The type of the button, which determines its behavior.
+     * @default "button"
+     * Possible values are "button", "submit", and "reset".
+     */
+    type?: "button" | "submit" | "reset";
+    /**
+     * The content of the button.
+     */
+    children: React.ReactNode;
+}
+
+/**
+ * A button component that can be used for various actions.
+ */
+const Button = ({ variant, type, children }) => {
+  return (
+    <button className={`button ${classModifier}`} type={type}>
+      {children}
+    </button>
+  );
+````
+
+## Checking the result
+
+These descriptions should show up in the `Controls` pane in the stories.

--- a/slash/css/src/Tag/Tag.scss
+++ b/slash/css/src/Tag/Tag.scss
@@ -3,18 +3,18 @@
 @use "../common/common" as common;
 
 $types: (
-  default var(--axablue80),
-  information var(--cyan40),
+  "default" var(--axablue80),
+  "information" var(--cyan40),
   // deprecated
-  info var(--cyan40),
-  success var(--green40),
-  warning var(--orange40),
+  "info" var(--cyan40),
+  "success" var(--green40),
+  "warning" var(--orange40),
   // deprecated
-  danger var(--orange40),
-  error var(--red30),
-  dark var(--gray80),
-  gray var(--gray50),
-  purple var(--purpletarif40)
+  "danger" var(--orange40),
+  "error" var(--red30),
+  "dark" var(--gray80),
+  "gray" var(--gray50),
+  "purple" var(--purpletarif40)
 );
 
 .af-badge,

--- a/slash/css/src/Tag/Tag.scss
+++ b/slash/css/src/Tag/Tag.scss
@@ -34,11 +34,22 @@ $types: (
     }
   }
 
+  &--white {
+    color: var(--brand-primary);
+    background-color: var(--white);
+  }
+
   &[disabled] {
     opacity: 0.65;
   }
 
   & > * {
     vertical-align: middle;
+  }
+
+  svg {
+    width: 14px;
+    vertical-align: sub;
+    fill: currentcolor;
   }
 }

--- a/slash/css/src/Title/Title.scss
+++ b/slash/css/src/Title/Title.scss
@@ -60,7 +60,7 @@ h4.af-title {
     }
   }
 
-  :first-child {
+  > :first-child {
     margin-left: 1.5rem;
   }
 }

--- a/slash/react/src/Steps/VerticalStep.tsx
+++ b/slash/react/src/Steps/VerticalStep.tsx
@@ -1,10 +1,10 @@
+import check from "@material-symbols/svg-400/sharp/check.svg";
+import edit from "@material-symbols/svg-400/sharp/edit-fill.svg";
+import lock from "@material-symbols/svg-400/sharp/lock-fill.svg";
 import classNames from "classnames";
 import { ReactNode } from "react";
-import edit from "@material-symbols/svg-400/sharp/edit-fill.svg";
-import check from "@material-symbols/svg-400/sharp/check.svg";
-import lock from "@material-symbols/svg-400/sharp/lock-fill.svg";
-import { Title } from "../Title/Title";
 import { Svg } from "../Svg";
+import { Title } from "../Title/Title";
 import type { VerticalStepMode } from "./types";
 
 import "@axa-fr/design-system-slash-css/dist/Steps/VerticalStep.css";
@@ -96,9 +96,9 @@ export const VerticalStep = ({
             <Button
               aria-label={editButtonAriaLabel}
               onClick={onEdit}
-              className="af-vertical-step-title-button"
+              variant="ghost"
+              leftIcon={<Svg role="presentation" src={edit} />}
             >
-              <Svg role="presentation" src={edit} />
               {editButtonLabel}
             </Button>
           ) : undefined

--- a/slash/react/src/Summary/index.tsx
+++ b/slash/react/src/Summary/index.tsx
@@ -23,12 +23,7 @@ export const Summary = ({
   const variant = classModifier === "danger" ? "warning" : classModifier;
 
   return (
-    <Message
-      icon="glyphicon glyphicon-warning-sign"
-      title={title}
-      variant={variant}
-      {...args}
-    >
+    <Message title={title} variant={variant} {...args}>
       <ul className="af-summary__message-list">
         {messages.map((message) => (
           <li

--- a/slash/react/src/Tag/Tag.tsx
+++ b/slash/react/src/Tag/Tag.tsx
@@ -1,8 +1,8 @@
-import { ComponentPropsWithRef, PropsWithChildren, forwardRef } from "react";
-import { getComponentClassName } from "../utilities";
 import "@axa-fr/design-system-slash-css/dist/Tag/Tag.scss";
+import { ComponentPropsWithRef, PropsWithChildren, forwardRef } from "react";
+import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
 
-type TagModifier =
+export type TagVariants =
   | "success"
   | "information"
   | "warning"
@@ -12,13 +12,19 @@ type TagModifier =
   | "purple"
   | "gray";
 
-/**
- * @deprecated instead use warning
- */
-type TagModifierDecrepated = "danger" | "info";
-
 type TagProps = ComponentPropsWithRef<"span"> & {
-  classModifier?: `${TagModifier | TagModifierDecrepated}` | string;
+  /**
+   * Modifier class to apply specific styles. Note: "danger" is deprecated, use "warning" instead. "info" is deprecated, use "information" instead
+   * @deprecated Use `variant` instead
+   */
+  classModifier?: string;
+  /**
+   * Variant of the tag to apply specific styles.
+   * "warning" replaces the deprecated "danger
+   * "information" replaces the deprecated "info"
+   * @default "default"
+   */
+  variant?: TagVariants;
   disabled?: boolean;
 };
 
@@ -28,30 +34,30 @@ type TagProps = ComponentPropsWithRef<"span"> & {
  * @component
  * @example
  * // Basic usage
- * <Tag classModifier="success">Success Tag</Tag>
+ * <Tag variant="success">Success Tag</Tag>
  *
- * @param {object} props - The properties object.
  * @param {React.ReactNode} props.children - The content to be displayed inside the tag.
- * @param {string} [props.className] - Additional class names to apply to the tag.
- * @param {string} [props.classModifier] - Modifier class to apply specific styles. Note: "danger" is deprecated, use "warning" instead. "info" is deprecated, use "information" instead
- * @param {boolean} [props.disabled] - If true, the tag will be disabled.
  * @param {React.Ref<HTMLSpanElement>} ref - The ref to the span element.
  * @returns {JSX.Element} The rendered Tag component.
  */
 export const Tag = forwardRef<HTMLSpanElement, PropsWithChildren<TagProps>>(
-  ({ children, className, classModifier = "default", ...otherProps }, ref) => {
-    const componentClassName = getComponentClassName(
-      className,
-      classModifier,
-      "af-tag",
-    );
+  ({ children, className, classModifier, variant, ...otherProps }, ref) => {
+    const actualModifier = variant || classModifier || "default";
+
+    const componentClassName = getComponentClassNameWithUserClassname({
+      userClassName: className,
+      classModifier: actualModifier,
+      componentClassName: "af-tag",
+    });
 
     // Kept for backward compatibility. May be removed in a future version
-    const badgeClassName = getComponentClassName(
-      className,
-      classModifier,
-      "af-badge",
-    );
+    const badgeClassName = getComponentClassNameWithUserClassname({
+      userClassName: className,
+      classModifier: actualModifier,
+      componentClassName: "af-badge",
+    });
+
+    console.log({ badgeClassName, componentClassName });
 
     return (
       <span

--- a/slash/react/src/Tag/Tag.tsx
+++ b/slash/react/src/Tag/Tag.tsx
@@ -10,7 +10,8 @@ export type TagVariants =
   | "default"
   | "dark"
   | "purple"
-  | "gray";
+  | "gray"
+  | "white";
 
 type TagProps = ComponentPropsWithRef<"span"> & {
   /**
@@ -56,8 +57,6 @@ export const Tag = forwardRef<HTMLSpanElement, PropsWithChildren<TagProps>>(
       classModifier: actualModifier,
       componentClassName: "af-badge",
     });
-
-    console.log({ badgeClassName, componentClassName });
 
     return (
       <span

--- a/slash/react/src/Tag/__tests__/Tag.test.tsx
+++ b/slash/react/src/Tag/__tests__/Tag.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
 import { ComponentProps } from "react";
-import { Tag } from "../Tag";
+import { describe, expect, it } from "vitest";
+import { Tag, TagVariants } from "../Tag";
 
 const classModifiers: ComponentProps<typeof Tag>["classModifier"][] = [
   "success",
@@ -16,48 +16,78 @@ const classModifiers: ComponentProps<typeof Tag>["classModifier"][] = [
   "custom-class",
 ];
 
+const variants: TagVariants[] = [
+  "success",
+  "information",
+  "warning",
+  "error",
+  "default",
+  "dark",
+  "purple",
+  "gray",
+];
 describe("Tag component", () => {
-  it.each(classModifiers)(
-    `should render "%s" correctly with af-tag classname`,
-    (modifier) => {
-      render(<Tag classModifier={modifier}>{modifier}</Tag>);
+  describe("classModifier backward compatibility", () => {
+    it.each(classModifiers)(
+      `should render "%s" correctly with af-tag classname`,
+      (modifier) => {
+        render(<Tag classModifier={modifier}>{modifier}</Tag>);
 
-      const tag = screen.getByText(modifier!);
-      expect(tag).toHaveClass(`af-tag af-tag--${modifier}`);
-    },
-  );
+        const tag = screen.getByText(modifier!);
+        expect(tag).toHaveClass(`af-tag af-tag--${modifier}`);
+      },
+    );
 
-  it.each(classModifiers)(
-    `should render "%s" correctly with af-badge classname`,
-    (modifier) => {
+    it.each(classModifiers)(
+      `should render "%s" correctly with af-badge classname`,
+      (modifier) => {
+        render(<Tag classModifier={modifier}>{modifier}</Tag>);
+
+        const tag = screen.getByText(modifier!);
+        expect(tag).toHaveClass(`af-badge af-badge--${modifier}`);
+      },
+    );
+
+    it("should renders danger with icon and custom class correctly", () => {
       render(
-        <Tag classModifier={modifier} className="af-badge">
-          {modifier}
+        <Tag role="alert" className="custom-class" classModifier="error">
+          <i role="img" className="glyphicon glyphicon-bell" />
         </Tag>,
       );
 
-      const tag = screen.getByText(modifier!);
-      expect(tag).toHaveClass(`af-badge af-badge--${modifier}`);
-    },
-  );
-
-  it("should renders danger with icon and custom class correctly", () => {
-    render(
-      <Tag role="alert" className="custom-class" classModifier="error">
-        <i role="img" className="glyphicon glyphicon-bell" />
-      </Tag>,
-    );
-
-    const tag = screen.getByRole("alert");
-    const icon = screen.getByRole("img");
-    expect(tag).toHaveClass("custom-class custom-class--error");
-    expect(icon).toBeInTheDocument();
+      const tag = screen.getByRole("alert");
+      const icon = screen.getByRole("img");
+      expect(tag).toHaveClass("custom-class");
+      expect(icon).toBeInTheDocument();
+    });
   });
 
   it("should render with custom class and no modifier", () => {
     render(<Tag className="custom-class">Custom Tag</Tag>);
 
     const tag = screen.getByText("Custom Tag");
-    expect(tag).toHaveClass("custom-class");
+    expect(tag).toHaveClass("custom-class af-tag af-badge");
+  });
+
+  describe("variants", () => {
+    it.each(variants)(
+      `should render "%s" correctly with af-tag classname`,
+      (variant) => {
+        render(<Tag variant={variant}>{variant}</Tag>);
+
+        const tag = screen.getByText(variant!);
+        expect(tag).toHaveClass(`af-tag af-tag--${variant}`);
+      },
+    );
+
+    it.each(variants)(
+      `should render "%s" correctly with af-badge classname`,
+      (variant) => {
+        render(<Tag variant={variant}>{variant}</Tag>);
+
+        const tag = screen.getByText(variant!);
+        expect(tag).toHaveClass(`af-badge af-badge--${variant}`);
+      },
+    );
   });
 });

--- a/slash/react/src/index.ts
+++ b/slash/react/src/index.ts
@@ -7,9 +7,6 @@ import { Message } from "./Messages/Message";
 import { Tag } from "./Tag/Tag";
 
 export { Action } from "./Action/Action";
-/** @deprecated Use `Tag` instead. */
-const Badge = Tag;
-export { Badge, Tag };
 export { Button } from "./Button/Button";
 export type { ButtonVariant } from "./Button/Button";
 export { Card } from "./Card/Card";
@@ -83,6 +80,12 @@ export { Svg } from "./Svg";
 export { Tabs } from "./Tabs/Tabs";
 export { Title } from "./Title/Title";
 export { getComponentClassName } from "./utilities";
+
+/** @deprecated Use `Tag` instead. */
+const Badge = Tag;
+
+export type { TagVariants } from "./Tag/Tag";
+export { Badge, Tag };
 
 /**
  * @deprecated `Alert` has been renamed `Message` in order to comply with UX naming of components. Use `Message` instead.

--- a/slash/react/src/index.ts
+++ b/slash/react/src/index.ts
@@ -1,8 +1,10 @@
 import "@axa-fr/design-system-slash-css/dist/common/icons.scss";
 import "@axa-fr/design-system-slash-css/dist/common/reboot.scss";
 import "@axa-fr/design-system-slash-css/dist/common/tokens.css";
+
 import "@fontsource/source-sans-pro";
 import "@fontsource/source-sans-pro/700.css";
+
 import { Message } from "./Messages/Message";
 import { Tag } from "./Tag/Tag";
 


### PR DESCRIPTION
- fix(slash): tag uses variant instead of classmodifer (deprecated)
- fix(slash): VerticalSteps button style is correct
- docs(slash): story for modal now use correct button variants
- fix(slash): icon in summary is correctly displayed
- docs(slash): fix warning story for Messages
- added a white variant for Tag