### PR TITLE
fix(apollo,look&feel): input phone hover/focus radius

### DIFF
--- a/client/apollo/css/src/Form/InputPhone/InputPhoneApollo.scss
+++ b/client/apollo/css/src/Form/InputPhone/InputPhoneApollo.scss
@@ -8,10 +8,12 @@
 
 .country-code-select {
   &__control {
+    --select-color: var(--neutral-80);
     --select-border-color: var(--axa-blue-65);
     --select-border-radius: var(--radius-8);
-    --select-background: url("@material-symbols/svg-400/outlined/keyboard_arrow_down.svg?fill=currentColor")
-      no-repeat right 1.5rem center / 1.5rem 1.5rem;
+    --select-control-background-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 -960 960 960'><path fill='%2300008F' d='M480-344 240-584l43-43 197 197 197-197 43 43-240 240Z'/></svg>");
+    --select-control-background: var(--select-control-background-url) no-repeat
+      right 1rem center / 1.5rem 1.5rem;
 
     &:disabled {
       --select-bg-color-disabled: var(--neutral-50);
@@ -22,6 +24,10 @@
       --select-border-color: var(--axa-blue-100);
       --select-box-shadow: var(--axa-blue-100);
     }
+  }
+
+  &__control--menu-is-open {
+    --select-control-background-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 -960 960 960'><path fill='%2300008F' d='M240-376l240-240 240 240-43 43-197-197-197 197-43-43Z'/></svg>");
   }
 
   &__option {

--- a/client/apollo/css/src/Form/InputPhone/InputPhoneApollo.scss
+++ b/client/apollo/css/src/Form/InputPhone/InputPhoneApollo.scss
@@ -13,18 +13,12 @@
     --select-background: url("@material-symbols/svg-400/outlined/keyboard_arrow_down.svg?fill=currentColor")
       no-repeat right 1.5rem center / 1.5rem 1.5rem;
 
-    &:focus-visible {
-      --select-border-color: var(--axa-blue-100);
-    }
-
     &:disabled {
       --select-bg-color-disabled: var(--neutral-50);
       --select-border-color: var(--neutral-50);
     }
 
-    &:not(:disabled):hover,
-    &:not(:disabled):active {
-      --select-border-radius: 8px;
+    &:not(:disabled):is(:hover, :focus-within, :active) {
       --select-border-color: var(--axa-blue-100);
       --select-box-shadow: var(--axa-blue-100);
     }

--- a/client/apollo/css/src/Form/InputPhone/InputPhoneCommon.scss
+++ b/client/apollo/css/src/Form/InputPhone/InputPhoneCommon.scss
@@ -29,7 +29,7 @@
 .af-form__country-code-wrapper .country-code-select__control {
   display: block;
   width: 7.4rem;
-  padding: calc(10 / var(--font-size-base) * 1rem) 0;
+  padding: calc(11 / var(--font-size-base) * 1rem) 0;
   border: 1px solid var(--select-border-color);
   border-radius: var(--select-border-radius);
   font-size: calc(16 / var(--font-size-base) * 1rem);
@@ -60,8 +60,7 @@
     cursor: not-allowed;
   }
 
-  &:not(:disabled):hover,
-  &:not(:disabled):active {
+  &:not(:disabled):is(:hover, :active, :focus-within) {
     border: 1px solid var(--select-border-color);
     box-shadow: 0 0 0 1px var(--select-border-color) inset;
   }

--- a/client/apollo/css/src/Form/InputPhone/InputPhoneCommon.scss
+++ b/client/apollo/css/src/Form/InputPhone/InputPhoneCommon.scss
@@ -38,7 +38,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--select-color);
-  background: var(--select-background);
+  background: var(--select-control-background);
   background-color: white;
   background-position-x: calc(100% - 0.2rem);
   box-shadow: var(--select-box-shadow);

--- a/client/apollo/css/src/Form/InputPhone/InputPhoneLF.scss
+++ b/client/apollo/css/src/Form/InputPhone/InputPhoneLF.scss
@@ -13,18 +13,12 @@
     --select-background: url("@material-symbols/svg-400/outlined/arrow_drop_down.svg")
       no-repeat right 1rem center / 1.5rem 1.5rem;
 
-    &:focus-visible {
-      --select-border-color: var(--color-axa);
-    }
-
     &:disabled {
       --select-bg-color-disabled: var(--color-gray-500);
       --select-border-color: var(--color-gray-500);
     }
 
-    &:not(:disabled):hover,
-    &:not(:disabled):active {
-      --select-border-radius: 8px;
+    &:not(:disabled):is(:hover, :focus-within, :active) {
       --select-border-color: var(--color-axa);
       --select-box-shadow: var(--color-axa);
     }

--- a/client/apollo/css/src/Form/InputPhone/InputPhoneLF.scss
+++ b/client/apollo/css/src/Form/InputPhone/InputPhoneLF.scss
@@ -8,10 +8,12 @@
 
 .country-code-select {
   &__control {
+    --select-color: var(--color-gray-700);
     --select-border-color: var(--color-gray-700);
     --select-border-radius: var(--default-border-radius);
-    --select-background: url("@material-symbols/svg-400/outlined/arrow_drop_down.svg")
-      no-repeat right 1rem center / 1.5rem 1.5rem;
+    --select-control-background-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'><polygon points='12,18 36,18 24,34' fill='%2300008F'/></svg>");
+    --select-control-background: var(--select-control-background-url) no-repeat
+      right 1rem center / 1.5rem 1.5rem;
 
     &:disabled {
       --select-bg-color-disabled: var(--color-gray-500);
@@ -22,6 +24,10 @@
       --select-border-color: var(--color-axa);
       --select-box-shadow: var(--color-axa);
     }
+  }
+
+  &__control--menu-is-open {
+    --select-control-background-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'><polygon points='12,30 36,30 24,14' fill='%2300008F'/></svg>");
   }
 
   &__option {

--- a/client/apollo/react/src/Form/InputPhone/CountryCodeSelect.tsx
+++ b/client/apollo/react/src/Form/InputPhone/CountryCodeSelect.tsx
@@ -36,7 +36,7 @@ const CountryCodeSelect = ({
       ...provided,
       display: "none",
     }),
-    SingleValue: (provided: Record<string, unknown>) => ({
+    singleValue: (provided: Record<string, unknown>) => ({
       ...provided,
       color: "inherit",
     }),

--- a/client/apollo/react/src/Form/InputPhone/CountryCodeSelect.tsx
+++ b/client/apollo/react/src/Form/InputPhone/CountryCodeSelect.tsx
@@ -36,6 +36,10 @@ const CountryCodeSelect = ({
       ...provided,
       display: "none",
     }),
+    SingleValue: (provided: Record<string, unknown>) => ({
+      ...provided,
+      color: "inherit",
+    }),
   };
 
   const formatOptionLabel = ({ flag, code }: OptionType) => (


### PR DESCRIPTION
**BUG** : 
_En look and Feel :

Au hover sur la droplist, le radius passe de 4px à 8px.
Résultat attendu : Il doit rester à 4px_

**Cette PR ajoute également** 

- la gestion du focus à la tabulation
- Correction du padding block pour avoir la même hauteur que le champ de saisie
- Correction de la couleur des options
- Correction de la couleur de l'icone indicateur
- Ajout de la gestion de la rotation de l'icone indicateur