### PR TITLE
refactor(apollo,look&feel)!: improve modal accessibility and remove apollo from common class name

### DIFF
--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.scss
@@ -5,6 +5,7 @@
   --checkbox-option-color-title: var(--axa-blue-100);
   --checkbox-option-color-subtitle: var(--neutral-80);
   --checkbox-option-gap: calc(8 / var(--font-size-base) * 1rem);
+  --checkbox-option-border-radius: var(--radius-8);
 
   &:hover {
     --checkbox-option-border-color: var(--axa-blue-100);

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
@@ -7,7 +7,7 @@
   position: relative;
   display: flex;
   padding: 1rem;
-  border-radius: calc(8 / var(--font-size-base) * 1rem);
+  border-radius: var(--checkbox-option-border-radius);
   flex-direction: column;
   align-items: center;
   justify-content: space-between;

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.scss
@@ -6,6 +6,7 @@
   --checkbox-option-color-title: var(--color-gray-900);
   --checkbox-option-color-subtitle: var(--color-gray-700);
   --checkbox-option-gap: calc(8 / var(--font-size-base) * 1rem);
+  --checkbox-option-border-radius: var(--radius-4);
 
   &:hover {
     --checkbox-option-border-color: var(--color-axa);

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionApollo.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionApollo.scss
@@ -5,6 +5,7 @@
   --radio-option-color-title: var(--axa-blue-100);
   --radio-option-color-subtitle: var(--neutral-80);
   --radio-option-gap: calc(8 / var(--font-size-base) * 1rem);
+  --radio-option-border-radius: var(--radius-8);
 
   &:hover {
     --radio-option-border-color: var(--axa-blue-100);

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
@@ -7,7 +7,7 @@
   position: relative;
   display: flex;
   padding: 1rem;
-  border-radius: calc(8 / var(--font-size-base) * 1rem);
+  border-radius: var(--radio-option-border-radius);
   flex-direction: column;
   align-items: center;
   justify-content: space-between;

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionLF.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionLF.scss
@@ -6,6 +6,7 @@
   --radio-option-color-title: var(--color-gray-900);
   --radio-option-color-subtitle: var(--color-gray-700);
   --radio-option-gap: calc(8 / var(--font-size-base) * 1rem);
+  --radio-option-border-radius: var(--radius-4);
 
   &:hover {
     --radio-option-border-color: var(--color-axa);

--- a/client/apollo/css/src/Modal/ModalApollo.scss
+++ b/client/apollo/css/src/Modal/ModalApollo.scss
@@ -1,7 +1,7 @@
 @use "../common/breakpoints" as breakpoints;
 @use "./ModalCommon";
 
-.af-apollo-modal {
+.af-modal {
   --modal-bg-color: var(--white);
   --modal-text-color: var(--neutral-100);
   --modal-text-font-size: calc(16 / var(--font-size-base) * 1rem);
@@ -18,11 +18,11 @@
   --modal-footer-horizontal-padding: var(--modal-default-padding);
   --modal-footer-gap: calc(16 / var(--font-size-base) * 1rem);
 
-  &__body:not(:has(~ .af-apollo-modal__footer)) {
+  &__body:not(:has(~ .af-modal__footer)) {
     --modal-body-padding-bottom: var(--modal-default-padding);
   }
 
-  :has(.af-apollo-modal__body-vertical-scroll) {
+  :has(.af-modal__body-vertical-scroll) {
     --modal-footer-border-top: 1px solid var(--axa-blue-20);
     --modal-footer-vertical-padding: calc(12 / var(--font-size-base) * 1rem);
     --modal-footer-horizontal-padding: calc(16 / var(--font-size-base) * 1rem);
@@ -33,7 +33,7 @@
     --modal-default-padding: calc(32 / var(--font-size-base) * 1rem);
     --modal-body-padding-bottom: calc(16 / var(--font-size-base) * 1rem);
 
-    :has(.af-apollo-modal__body-vertical-scroll) {
+    :has(.af-modal__body-vertical-scroll) {
       --modal-footer-vertical-padding: calc(16 / var(--font-size-base) * 1rem);
       --modal-footer-horizontal-padding: var(--modal-default-padding);
       --modal-footer-border-top: none;

--- a/client/apollo/css/src/Modal/ModalCommon.scss
+++ b/client/apollo/css/src/Modal/ModalCommon.scss
@@ -1,6 +1,6 @@
 @use "../common/breakpoints" as breakpoints;
 
-.af-apollo-modal {
+.af-modal {
   --modal-transition-duration: 0.2s;
   --modal-max-height: calc(100% - 5rem);
   --modal-footer-border-top: none;

--- a/client/apollo/css/src/Modal/ModalLF.scss
+++ b/client/apollo/css/src/Modal/ModalLF.scss
@@ -2,7 +2,7 @@
 @use "../common/breakpoints" as breakpoints;
 @use "./ModalCommon";
 
-.af-apollo-modal {
+.af-modal {
   --modal-bg-color: var(--color-white);
   --modal-text-color: var(--color-gray-900);
   --modal-text-font-size: calc(16 / var(--font-size-base) * 1rem);
@@ -19,11 +19,11 @@
   --modal-footer-horizontal-padding: var(--modal-default-padding);
   --modal-footer-gap: var(--modal-default-padding);
 
-  &__body:not(:has(~ .af-apollo-modal__footer)) {
+  &__body:not(:has(~ .af-modal__footer)) {
     --modal-body-padding-bottom: var(--modal-default-padding);
   }
 
-  :has(.af-apollo-modal__body-vertical-scroll) {
+  :has(.af-modal__body-vertical-scroll) {
     --modal-footer-border-top: 1px solid var(--color-blue-400);
     --modal-footer-vertical-padding: calc(12 / var(--font-size-base) * 1rem);
     --modal-footer-horizontal-padding: calc(16 / var(--font-size-base) * 1rem);
@@ -37,7 +37,7 @@
     --modal-body-gap: calc(40 / var(--font-size-base) * 1rem);
     --modal-body-padding-bottom: calc(16 / var(--font-size-base) * 1rem);
 
-    :has(.af-apollo-modal__body-vertical-scroll) {
+    :has(.af-modal__body-vertical-scroll) {
       --modal-footer-border-top: none;
       --modal-footer-vertical-padding: calc(16 / var(--font-size-base) * 1rem);
       --modal-footer-horizontal-padding: calc(

--- a/client/apollo/react/src/Modal/components/ModalCore.tsx
+++ b/client/apollo/react/src/Modal/components/ModalCore.tsx
@@ -13,7 +13,7 @@ const ModalCore = forwardRef<HTMLDialogElement, ModalCoreProps>(
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
     <dialog
       aria-modal
-      aria-labelledby={props["aria-labelledby"] ?? props.title}
+      aria-label={props["aria-label"] ?? props.title}
       className={["af-modal", className].filter(Boolean).join(" ")}
       onClick={props.onClose}
       ref={ref}

--- a/client/apollo/react/src/Modal/components/ModalCore.tsx
+++ b/client/apollo/react/src/Modal/components/ModalCore.tsx
@@ -12,15 +12,16 @@ const ModalCore = forwardRef<HTMLDialogElement, ModalCoreProps>(
   ({ className, children, ...props }: ModalCoreProps, ref) => (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
     <dialog
-      aria-label={props["aria-label"] ?? props.title}
-      className={["af-apollo-modal", className].filter(Boolean).join(" ")}
+      aria-modal
+      aria-labelledby={props["aria-labelledby"] ?? props.title}
+      className={["af-modal", className].filter(Boolean).join(" ")}
       onClick={props.onClose}
       ref={ref}
       {...props}
     >
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
       <section
-        className="af-apollo-modal__content"
+        className="af-modal__content"
         onClick={(e) => e.stopPropagation()}
       >
         {children}

--- a/client/apollo/react/src/Modal/components/ModalCoreBody.tsx
+++ b/client/apollo/react/src/Modal/components/ModalCoreBody.tsx
@@ -14,8 +14,8 @@ export const ModalCoreBody = ({
   return (
     <main
       className={[
-        "af-apollo-modal__body",
-        hasVerticalScroll ? "af-apollo-modal__body-vertical-scroll" : undefined,
+        "af-modal__body",
+        hasVerticalScroll ? "af-modal__body-vertical-scroll" : undefined,
         className,
       ]
         .filter(Boolean)

--- a/client/apollo/react/src/Modal/components/ModalCoreFooterCommon.tsx
+++ b/client/apollo/react/src/Modal/components/ModalCoreFooterCommon.tsx
@@ -13,7 +13,7 @@ const renderFooterButtons = (
           key={variant}
           variant={variant}
           {...props}
-          className={[props?.className, "af-apollo-modal__footer-button"]
+          className={[props?.className, "af-modal__footer-button"]
             .filter(Boolean)
             .join(" ")}
         />
@@ -39,9 +39,7 @@ export const ModalCoreFooterCommon = ({
 }: ModalCoreFooterCommonProps) =>
   (primaryButtonProps || secondaryButtonProps || tertiaryButtonProps) && (
     <footer
-      className={["af-apollo-modal__footer", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={["af-modal__footer", className].filter(Boolean).join(" ")}
       {...rest}
     >
       {renderFooterButtons(ButtonComponent, [

--- a/client/apollo/react/src/Modal/components/ModalCoreHeaderCommon.tsx
+++ b/client/apollo/react/src/Modal/components/ModalCoreHeaderCommon.tsx
@@ -26,16 +26,16 @@ export const ModalCoreHeaderCommon = ({
   ...props
 }: ModalCoreHeaderCommonProps) => (
   <header
-    className={["af-apollo-modal__header", className].filter(Boolean).join(" ")}
+    className={["af-modal__header", className].filter(Boolean).join(" ")}
     {...props}
   >
     <ClickIcon
-      className="af-apollo-modal__header-close-btn"
+      className="af-modal__header-close-btn"
       src={close}
       onClick={onClose}
       aria-label={closeButtonAriaLabel}
     />
-    <div className="af-apollo-modal__header-title">
+    <div className="af-modal__header-title">
       {IconComponent && iconProps ? (
         <IconComponent size="M" {...iconProps} />
       ) : null}

--- a/client/apollo/react/src/Modal/components/__tests__/ModalCoreBody.test.tsx
+++ b/client/apollo/react/src/Modal/components/__tests__/ModalCoreBody.test.tsx
@@ -20,9 +20,7 @@ describe("ModalCoreBody component", () => {
     render(
       <ModalCoreBody className="custom-class">Test Content</ModalCoreBody>,
     );
-    expect(screen.getByRole("main")).toHaveClass(
-      "af-apollo-modal__body custom-class",
-    );
+    expect(screen.getByRole("main")).toHaveClass("af-modal__body custom-class");
   });
 
   it("passes other props to the main element", () => {

--- a/client/apollo/react/src/Modal/components/__tests__/ModalCoreFooter.test.tsx
+++ b/client/apollo/react/src/Modal/components/__tests__/ModalCoreFooter.test.tsx
@@ -13,7 +13,7 @@ describe("ModalCoreFooter", () => {
 
   it("should render with default class", () => {
     render(<ModalCoreFooter primaryButtonProps={{ children: "Primary" }} />);
-    expect(getFooter()).toHaveClass("af-apollo-modal__footer");
+    expect(getFooter()).toHaveClass("af-modal__footer");
   });
 
   it("should render with additional class", () => {
@@ -23,7 +23,7 @@ describe("ModalCoreFooter", () => {
         primaryButtonProps={{ children: "Primary" }}
       />,
     );
-    expect(getFooter()).toHaveClass("af-apollo-modal__footer custom-class");
+    expect(getFooter()).toHaveClass("af-modal__footer custom-class");
   });
 
   it("should render with primary and secondary buttons", () => {
@@ -47,6 +47,6 @@ describe("ModalCoreFooter", () => {
         primaryButtonProps={{ children: "Primary" }}
       />,
     );
-    expect(getFooter()).toHaveClass("af-apollo-modal__footer");
+    expect(getFooter()).toHaveClass("af-modal__footer");
   });
 });


### PR DESCRIPTION
# Description

- add `aria-modal` attribute to dialog element
- fix look&feel border radius of CheckboxCardOption and RadioCardOption from 8px to 4px

# Breaking change

- class `af-apollo-modal` and all variants have been renamed `af-modal`