### PR TITLE
fix(apollo,look&feel): fix CardCheckboxOption style bugs

### DIFF
--- a/client/apollo/css/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.scss
@@ -14,11 +14,14 @@
   }
 
   &__label {
-    display: inline-flex;
-    gap: calc(4 / var(--font-size-base) * 1rem);
+    display: inline;
     font-size: calc(18 / var(--font-size-base) * 1rem);
     font-weight: 600;
     color: var(--card-checkbox-color);
+
+    span {
+      margin-left: calc(4 / var(--font-size-base) * 1rem);
+    }
   }
 
   &__description {

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.scss
@@ -7,7 +7,9 @@
   --checkbox-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --checkbox-option-border-radius: var(--radius-8);
 
-  &:hover {
+  &:hover,
+  &:focus-visible,
+  &:focus-within {
     --checkbox-option-border-color: var(--axa-blue-100);
   }
 

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
@@ -36,17 +36,21 @@
     }
   }
 
-  &:has(input:checked) {
+  &:has(input:checked) .af-card-checkbox-option__label {
+    font-weight: 600;
+  }
+
+  &:has(input:checked),
+  &:has(input[aria-invalid="true"]):not(:has(input:checked)) {
     --checkbox-option-border-width: 2px;
 
+    /* stylelint-disable-next-line no-descending-specificity */
     &:hover,
+    /* stylelint-disable-next-line no-descending-specificity */
     &:focus-visible,
+    /* stylelint-disable-next-line no-descending-specificity */
     &:focus-within {
       --checkbox-option-border-width: 3px;
-    }
-
-    & .af-card-checkbox-option__label {
-      font-weight: 600;
     }
   }
 

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
@@ -23,7 +23,6 @@
   &:focus-visible,
   &:focus-within {
     --checkbox-option-border-width: 2px;
-    --checkbox-option-border-color: var(--axa-blue-100);
   }
 
   &__label {

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.scss
@@ -8,7 +8,9 @@
   --checkbox-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --checkbox-option-border-radius: var(--radius-4);
 
-  &:hover {
+  &:hover,
+  &:focus-visible,
+  &:focus-within {
     --checkbox-option-border-color: var(--color-axa);
   }
 


### PR DESCRIPTION
# Description

- fix CardCheckboxOption border disappearing on focus
- fix required asterisk display when label is on multiple lines
- fix error state border width

# Visuals

## Border disappearing

### Before fix
![msedge_pobCPou5dj](https://github.com/user-attachments/assets/b983a436-5b85-4bed-8b94-e125d5433b42)

### After fix
![msedge_5Krua769Ya](https://github.com/user-attachments/assets/4bc43605-4901-4a8d-842c-a6613c6ca31f)

## Asterisk display

### Before fix
<img width="581" height="404" alt="image" src="https://github.com/user-attachments/assets/985a1c8a-891c-4a8a-84e6-7636e9badd65" />

### After fix
<img width="582" height="394" alt="image" src="https://github.com/user-attachments/assets/64e6a874-4abb-4f2f-bb9a-d99b8e810a48" />

## Error border width

### Before fix
![msedge_1vgvTW2dPs](https://github.com/user-attachments/assets/8c8ca66c-2e18-46e7-aae9-bca8c2523cdf)

### After fix
![msedge_pco6qZ8NWR](https://github.com/user-attachments/assets/dfd60f56-88bc-4205-acda-00da14bc02dc)
