### PR TITLE
fix(apollo,look&feel): fix CardRadioOption style bugs

### DIFF
--- a/client/apollo/css/src/Form/Radio/CardRadio/CardRadioCommon.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadio/CardRadioCommon.scss
@@ -14,11 +14,14 @@
   }
 
   &__label {
-    display: inline-flex;
-    gap: calc(4 / var(--font-size-base) * 1rem);
+    display: inline;
     font-size: calc(18 / var(--font-size-base) * 1rem);
     font-weight: 600;
     color: var(--card-radio-color);
+
+    span {
+      margin-left: calc(4 / var(--font-size-base) * 1rem);
+    }
   }
 
   &__description {

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionApollo.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionApollo.scss
@@ -7,7 +7,9 @@
   --radio-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --radio-option-border-radius: var(--radius-8);
 
-  &:hover {
+  &:hover,
+  &:focus-visible,
+  &:focus-within {
     --radio-option-border-color: var(--axa-blue-100);
   }
 

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
@@ -23,7 +23,6 @@
   &:focus-visible,
   &:focus-within {
     --radio-option-border-width: 2px;
-    --radio-option-border-color: var(--axa-blue-100);
   }
 
   &__label {

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
@@ -36,17 +36,18 @@
     }
   }
 
-  &:has(input:checked) {
+  &:has(input:checked) .af-card-radio-option__label {
+    font-weight: 600;
+  }
+
+  &:has(input:checked),
+  &--invalid:not(:has(input:checked)) {
     --radio-option-border-width: 2px;
 
     &:hover,
     &:focus-visible,
     &:focus-within {
       --radio-option-border-width: 3px;
-    }
-
-    & .af-card-radio-option__label {
-      font-weight: 600;
     }
   }
 

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionLF.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionLF.scss
@@ -8,7 +8,9 @@
   --radio-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --radio-option-border-radius: var(--radius-4);
 
-  &:hover {
+  &:hover,
+  &:focus-visible,
+  &:focus-within {
     --radio-option-border-color: var(--color-axa);
   }
 


### PR DESCRIPTION
# Description

- fix CardRadioOption border disappearing on focus
- fix required asterisk display when label is on multiple lines
- fix error state border width

# Visuals

## Border disappearing

### Before fix
![msedge_rDHirvCPKq](https://github.com/user-attachments/assets/a7ec94e5-08fa-452e-a2a7-b0b9ea61ca1a)

### After fix
![msedge_au7G1LN1hx](https://github.com/user-attachments/assets/e0e5c178-9a76-4a46-b6f2-0a459c1f1664)

## Asterisk display

### Before fix
<img width="486" height="326" alt="image" src="https://github.com/user-attachments/assets/a73dcc4d-ced2-4193-a773-cbee43361196" />

### After fix
<img width="484" height="317" alt="image" src="https://github.com/user-attachments/assets/03757542-f432-4346-b357-c49a516787dd" />

## Error border width

### Before fix
![msedge_Q8s73s0vs9](https://github.com/user-attachments/assets/83ce50fb-f477-4695-8126-81baceedae7d)

### After fix
![msedge_LDKjNOi0fp](https://github.com/user-attachments/assets/342a628d-2fc4-4322-b4f3-392ba5409915)

