### PR TITLE
feat(apollo,look&feel): add itemMessage warning variant

### DIFF
--- a/apps/apollo-stories/src/components/ItemMessage/ItemMessage.stories.tsx
+++ b/apps/apollo-stories/src/components/ItemMessage/ItemMessage.stories.tsx
@@ -19,3 +19,10 @@ export const Success: StoryObj<typeof ItemMessage> = {
     messageType: "success",
   },
 };
+
+export const Warning: StoryObj<typeof ItemMessage> = {
+  args: {
+    message: "Warning Message",
+    messageType: "warning",
+  },
+};

--- a/apps/look-and-feel-stories/src/ItemMessage/ItemMessage.stories.tsx
+++ b/apps/look-and-feel-stories/src/ItemMessage/ItemMessage.stories.tsx
@@ -19,3 +19,10 @@ export const Success: StoryObj<typeof ItemMessage> = {
     messageType: "success",
   },
 };
+
+export const Warning: StoryObj<typeof ItemMessage> = {
+  args: {
+    message: "Warning Message",
+    messageType: "warning",
+  },
+};

--- a/client/apollo/css/src/Form/ItemMessage/ItemMessageApollo.scss
+++ b/client/apollo/css/src/Form/ItemMessage/ItemMessageApollo.scss
@@ -10,6 +10,10 @@
     --item-message-color: var(--green-100);
   }
 
+  &--warning {
+    --item-message-color: var(--warning-100);
+  }
+
   @media (width > #{breakpoints.$breakpoint-md}) {
     --item-message-icon-size: calc(24 / var(--font-size-base) * 1rem);
   }

--- a/client/apollo/css/src/Form/ItemMessage/ItemMessageLF.scss
+++ b/client/apollo/css/src/Form/ItemMessage/ItemMessageLF.scss
@@ -9,4 +9,8 @@
   &--success {
     --item-message-color: var(--color-green-600);
   }
+
+  &--warning {
+    --item-message-color: var(--color-orange-700);
+  }
 }

--- a/client/apollo/react/src/Form/ItemMessage/ItemMessageCommon.tsx
+++ b/client/apollo/react/src/Form/ItemMessage/ItemMessageCommon.tsx
@@ -1,12 +1,13 @@
 import successIcon from "@material-symbols/svg-400/outlined/check_circle-fill.svg";
 import errorIcon from "@material-symbols/svg-400/outlined/error-fill.svg";
+import warningIcon from "@material-symbols/svg-400/outlined/warning-fill.svg";
 import type { ReactNode } from "react";
 import { Svg } from "../../Svg/Svg";
 
 export type ItemMessageProps = {
   message?: ReactNode;
   id?: string;
-  messageType?: "error" | "success";
+  messageType?: "error" | "success" | "warning";
 };
 
 export const ItemMessage = ({
@@ -18,15 +19,22 @@ export const ItemMessage = ({
     return null;
   }
 
+  const getIcon = () => {
+    if (messageType === "success") return successIcon;
+    if (messageType === "warning") return warningIcon;
+
+    return errorIcon;
+  };
+
   return (
     <small
       id={id}
       className={`af-item-message af-item-message--${messageType}`}
-      role={messageType === "error" ? "alert" : undefined}
+      role={messageType === "success" ? undefined : "alert"}
       aria-live="assertive"
     >
       <Svg
-        src={messageType === "error" ? errorIcon : successIcon}
+        src={getIcon()}
         className="af-item-message__icon"
         aria-hidden="true"
       />

--- a/client/apollo/react/src/Form/ItemMessage/__tests__/ItemMessage.test.tsx
+++ b/client/apollo/react/src/Form/ItemMessage/__tests__/ItemMessage.test.tsx
@@ -26,4 +26,13 @@ describe("ItemMessageCommon", () => {
       "af-item-message--success",
     );
   });
+
+  it("renders the component with warning type", () => {
+    const { container } = render(
+      <ItemMessage message={message} messageType="warning" />,
+    );
+    expect(container.querySelector(".af-item-message")).toHaveClass(
+      "af-item-message--warning",
+    );
+  });
 });


### PR DESCRIPTION
# Description

- add warning variant to itemMessage atom

# Visuals

## Apollo
<img width="168" height="36" alt="image" src="https://github.com/user-attachments/assets/5bc41c62-1a2c-47c1-a4c6-3885bda0a7dc" />

# Look&Feel
<img width="157" height="36" alt="image" src="https://github.com/user-attachments/assets/58371adc-75f2-4faa-98ac-2c528911bf40" />
