### PR TITLE
fix(slash): change font and green color of tag

### DIFF
--- a/slash/css/src/Tag/Tag.scss
+++ b/slash/css/src/Tag/Tag.scss
@@ -7,7 +7,7 @@ $types: (
   "information" var(--cyan40),
   // deprecated
   "info" var(--cyan40),
-  "success" var(--green40),
+  "success" var(--green30),
   "warning" var(--orange40),
   // deprecated
   "danger" var(--orange40),
@@ -24,7 +24,7 @@ $types: (
   border-radius: 1rem;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   line-height: 1.25rem;
   color: common.$white;
 

--- a/slash/react/src/Tag/__tests__/Tag.test.tsx
+++ b/slash/react/src/Tag/__tests__/Tag.test.tsx
@@ -13,6 +13,7 @@ const classModifiers: ComponentProps<typeof Tag>["classModifier"][] = [
   "purple",
   "gray",
   "danger",
+  "white",
   "custom-class",
 ];
 
@@ -25,6 +26,7 @@ const variants: TagVariants[] = [
   "dark",
   "purple",
   "gray",
+  "white",
 ];
 describe("Tag component", () => {
   describe("classModifier backward compatibility", () => {


### PR DESCRIPTION
## fixes #876
###Retour de Pair Test
Change `Tags.scss`
Font 12 to 0.875rem
background-color: var(--green40); to background-color: var(--green30);
