### PR TITLE
Fixing accessibility and interaction issues caused by InputDate hidePicker=true

### DIFF
--- a/apps/apollo-stories/src/components/InputDate/InputDate.mdx
+++ b/apps/apollo-stories/src/components/InputDate/InputDate.mdx
@@ -1,0 +1,38 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import * as InputDateStories from "./InputDate.stories";
+
+<Meta of={InputDateStories} name="InputDate" />
+
+# InputDate
+
+To use the InputDate import it like that:
+
+```tsx
+import { InputDate } from "@axa-fr/design-system-apollo-react";
+
+const MyComponent = () => (
+  <>
+    <InputDate
+      buttonLabel="En savoir plus"
+      description="Description"
+      helper="Informations complémentaires"
+      id="uniqueId"
+      label="Date de naissance"
+      message=""
+      name="birthDate"
+      onChange={() => {}}
+      hidePicker={false}
+      required
+    />
+  </>
+);
+```
+
+**(Important) Note:** the `hidePicker={true}` prop both visually hides and functionnaly disables the date picker on browsers supporting WebKit without impacting accessibility.
+For browsers _**not supporting WebKit**_ (such as Firefox), the date picker _**is still visually visible**_ but the functionnality is disabled (we use a JavaScript trick to achieve that). _**Be aware that there might be some accessibility issues**_ (specifically with form submissions on Enter key press).
+
+## Playground
+
+<Canvas of={InputDateStories.InputDateDefaultStory} />
+
+<Controls of={InputDateStories.InputDateDefaultStory} />

--- a/apps/look-and-feel-stories/src/InputDate/InputDate.mdx
+++ b/apps/look-and-feel-stories/src/InputDate/InputDate.mdx
@@ -1,0 +1,38 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import * as InputDateStories from "./InputDate.stories";
+
+<Meta of={InputDateStories} name="InputDate" />
+
+# InputDate
+
+To use the InputDate import it like that:
+
+```tsx
+import { InputDate } from "@axa-fr/design-system-apollo-react/lf";
+
+const MyComponent = () => (
+  <>
+    <InputDate
+      buttonLabel="En savoir plus"
+      description="Description"
+      helper="Informations complémentaires"
+      id="uniqueId"
+      label="Date de naissance"
+      message=""
+      name="birthDate"
+      onChange={() => {}}
+      hidePicker={false}
+      required
+    />
+  </>
+);
+```
+
+**(Important) Note:** the `hidePicker={true}` prop both visually hides and functionnaly disables the date picker on browsers supporting WebKit without impacting accessibility.
+For browsers _**not supporting WebKit**_ (such as Firefox), the date picker _**is still visually visible**_ but the functionnality is disabled (we use a JavaScript trick to achieve that). _**Be aware that there might be some accessibility issues**_ (specifically with form submissions on Enter key press).
+
+## Playground
+
+<Canvas of={InputDateStories.InputDateDefaultStory} />
+
+<Controls of={InputDateStories.InputDateDefaultStory} />

--- a/client/apollo/react/src/Form/InputDate/InputDateCommon.tsx
+++ b/client/apollo/react/src/Form/InputDate/InputDateCommon.tsx
@@ -3,9 +3,9 @@ import {
   type ComponentPropsWithRef,
   type ComponentType,
   forwardRef,
-  RefCallback,
   useEffect,
   useId,
+  useImperativeHandle,
   useRef,
 } from "react";
 import { getComponentClassName } from "../../utilities/getComponentClassName";
@@ -86,17 +86,10 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
     const idHelp = useId();
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const refCallback: RefCallback<HTMLInputElement> = (inputElement) => {
-      inputRef.current = inputElement;
-      if (typeof ref === "function") {
-        ref(inputElement);
-        return;
-      }
-      if (ref) {
-        // eslint-disable-next-line no-param-reassign
-        ref.current = inputElement;
-      }
-    };
+    useImperativeHandle<typeof inputRef.current, typeof inputRef.current>(
+      ref,
+      () => inputRef.current,
+    );
 
     const ariaDescribedby = [helper && idHelp, success && idMessage].filter(
       Boolean,
@@ -128,7 +121,7 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
         window.removeEventListener("keydown", handleKeydown);
         window.removeEventListener("click", handleClick);
       };
-    }, [hidePicker, inputRef]);
+    }, [hidePicker]);
 
     const hasError =
       (Boolean(message) && messageType === "error") || Boolean(error);
@@ -148,7 +141,7 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
           id={inputId}
           className={componentClassName}
           type="date"
-          ref={refCallback}
+          ref={inputRef}
           defaultValue={formatInputDateValue(defaultValue)}
           value={formatInputDateValue(value)}
           aria-errormessage={hasError ? idMessage : undefined}

--- a/client/apollo/react/src/Form/InputDate/__tests__/InputDate.test.tsx
+++ b/client/apollo/react/src/Form/InputDate/__tests__/InputDate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { InputDate } from "../InputDateApollo";
@@ -155,9 +155,20 @@ describe("<InputDate />", () => {
     expect(inputDate).not.toHaveClass("af-form__input-date--no-picker");
   });
 
-  describe("blocks space keydown and click events when hidePicker is true", () => {
+  describe("date picker visibility management", () => {
     const originalPreventDefault = Event.prototype.preventDefault;
+    const originalWindowNavigator = global.window.navigator;
     const preventDefaultMock = vi.fn();
+    const keypressOptions = {
+      space: {
+        keyCode: 32,
+        code: "Space",
+      },
+      enter: {
+        keyCode: 13,
+        code: "Enter",
+      },
+    };
 
     beforeAll(() => {
       Event.prototype.preventDefault = preventDefaultMock;
@@ -171,6 +182,16 @@ describe("<InputDate />", () => {
       preventDefaultMock.mockReset();
     });
 
+    const mockUserAgent = (agent: string) => {
+      global.window.navigator = {
+        ...originalWindowNavigator,
+        userAgent: agent,
+      };
+    };
+    const restoreUserAgent = () => {
+      global.window.navigator = originalWindowNavigator;
+    };
+
     it.each([
       vi.fn(),
       null,
@@ -181,18 +202,88 @@ describe("<InputDate />", () => {
       const inputDate = screen.getByLabelText(/Date de naissance/);
 
       await userEvent.click(inputDate);
+      expect(preventDefaultMock.mock.contexts).toHaveLength(1);
+      expect(preventDefaultMock.mock.contexts[0]).toMatchObject<
+        Partial<MouseEvent>
+      >({
+        type: "click",
+      });
       expect(preventDefaultMock).toHaveBeenCalledTimes(1);
     });
 
-    it("prevents space keydown events when hidePicker is true", async () => {
+    it("prevents space keypress events when hidePicker is true", async () => {
       render(<InputDate label="Date de naissance" hidePicker />);
       const inputDate = screen.getByLabelText(/Date de naissance/);
 
       await userEvent.clear(inputDate);
       expect(inputDate).toHaveFocus();
-      expect(preventDefaultMock).not.toHaveBeenCalled();
-      await userEvent.keyboard(" ");
+      fireEvent.keyDown(inputDate, keypressOptions.space);
       expect(preventDefaultMock).toHaveBeenCalledTimes(1);
+      expect(preventDefaultMock.mock.contexts).toHaveLength(1);
+      expect(preventDefaultMock.mock.contexts[0]).toMatchObject<
+        Partial<KeyboardEvent>
+      >({
+        type: "keydown",
+        ...keypressOptions.space,
+      });
+    });
+
+    it("does not prevent enter keypress events when hidePicker is true on webkit agent", async () => {
+      render(<InputDate label="Date de naissance" hidePicker />);
+      const inputDate = screen.getByLabelText(/Date de naissance/);
+      // Mock a WebKit user agent
+      mockUserAgent("WebKit");
+
+      await userEvent.clear(inputDate);
+      expect(inputDate).toHaveFocus();
+      fireEvent.keyDown(inputDate, keypressOptions.enter);
+      expect(preventDefaultMock).not.toHaveBeenCalled();
+
+      // Restore the original user agent
+      restoreUserAgent();
+    });
+
+    it("prevents enter keypress events when hidePicker is true on a non webkit agent", async () => {
+      render(<InputDate label="Date de naissance" hidePicker />);
+      const inputDate = screen.getByLabelText(/Date de naissance/);
+      // Mock a non WebKit user agent
+      mockUserAgent("Firefox");
+
+      await userEvent.clear(inputDate);
+      expect(inputDate).toHaveFocus();
+      fireEvent.keyDown(inputDate, keypressOptions.enter);
+      expect(preventDefaultMock.mock.contexts).toHaveLength(1);
+      expect(preventDefaultMock.mock.contexts[0]).toMatchObject<
+        Partial<KeyboardEvent>
+      >({
+        type: "keydown",
+        ...keypressOptions.enter,
+      });
+
+      // Restore the original user agent
+      restoreUserAgent();
+    });
+
+    it("does not prevent space and enter keypress and click when hidePicker is true on non a webkit agent but the event target is a different element", async () => {
+      render(
+        <>
+          <input type="date" aria-label="different input date" />
+          <InputDate label="Date de naissance" hidePicker />
+        </>,
+      );
+      const differentInputDate = screen.getByLabelText(/different input date/);
+      // Mock a non-WebKit user agent
+      mockUserAgent("Firefox");
+
+      await userEvent.clear(differentInputDate);
+      expect(differentInputDate).toHaveFocus();
+      fireEvent.keyDown(differentInputDate, keypressOptions.space);
+      fireEvent.keyDown(differentInputDate, keypressOptions.enter);
+      await userEvent.click(differentInputDate);
+      expect(preventDefaultMock).not.toHaveBeenCalled();
+
+      // Restore the original user agent
+      restoreUserAgent();
     });
   });
 });


### PR DESCRIPTION
## Description of changes

The `hidePicker={true}` prop of InputDate blocked all click, form submission and Space keypress events on the page affecting all elements. The changes made here fix these issues and restore accessibility and interactions  (mouse click, keyboard Space and Enter keypress) on other form elements and form submission.