### PR TITLE
fix(slash): text inputs generate correct id when not provided

### DIFF
--- a/slash/react/src/Form/Date/DateInput.tsx
+++ b/slash/react/src/Form/Date/DateInput.tsx
@@ -12,7 +12,13 @@ const DateInput = forwardRef<HTMLInputElement, Props>(
     return (
       <Field
         {...otherProps}
-        renderInput={({ id, classModifier, ariaInvalid, errorId }) => (
+        renderInput={({
+          id,
+          classModifier,
+          ariaInvalid,
+          errorId,
+          ...props
+        }) => (
           <>
             <Date
               id={id}
@@ -20,7 +26,7 @@ const DateInput = forwardRef<HTMLInputElement, Props>(
               ref={inputRef}
               aria-describedby={errorId}
               aria-invalid={ariaInvalid}
-              {...otherProps}
+              {...props}
             />
             {children}
           </>

--- a/slash/react/src/Form/Date/__tests__/DateInput.test.tsx
+++ b/slash/react/src/Form/Date/__tests__/DateInput.test.tsx
@@ -106,4 +106,10 @@ describe("DateInput", () => {
     // Assert
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it.each(["", undefined])("should generate an ID if no id is passed", (id) => {
+    render(<DateInput label="My Input" defaultValue="Hello World" id={id} />);
+
+    expect(screen.getByLabelText("My Input").id).toBeDefined();
+  });
 });

--- a/slash/react/src/Form/Pass/PassInput.tsx
+++ b/slash/react/src/Form/Pass/PassInput.tsx
@@ -51,10 +51,16 @@ const PassInput = ({
     <Field
       {...props}
       classModifier={classModifier}
-      renderInput={({ id, classModifier: modifier, ariaInvalid, errorId }) => (
+      renderInput={({
+        id,
+        classModifier: modifier,
+        ariaInvalid,
+        errorId,
+        ...inputProps
+      }) => (
         <>
           <Pass
-            {...props}
+            {...inputProps}
             type={type}
             id={id}
             disabled={disabled}

--- a/slash/react/src/Form/Pass/__tests__/PassInput.test.tsx
+++ b/slash/react/src/Form/Pass/__tests__/PassInput.test.tsx
@@ -74,4 +74,10 @@ describe("PassInput", () => {
     // Assert
     expect(screen.getByText(/content/i)).toBeInTheDocument();
   });
+
+  it.each(["", undefined])("should generate an ID if no id is passed", (id) => {
+    render(<PassInput label="My Input" defaultValue="Hello World" id={id} />);
+
+    expect(screen.getByLabelText("My Input").id).toBeDefined();
+  });
 });

--- a/slash/react/src/Form/Text/TextInput.tsx
+++ b/slash/react/src/Form/Text/TextInput.tsx
@@ -9,15 +9,22 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     return (
       <Field
         {...props}
-        renderInput={({ id, classModifier, ariaInvalid, errorId }) => (
+        renderInput={({
+          id,
+          classModifier,
+          ariaInvalid,
+          errorId,
+          ...textProps
+        }) => (
           <>
+            {JSON.stringify({ id })}
             <Text
               id={id}
               classModifier={classModifier}
               ref={inputRef}
               aria-describedby={errorId}
               aria-invalid={ariaInvalid}
-              {...props}
+              {...textProps}
             />
             {children}
           </>

--- a/slash/react/src/Form/Text/__tests__/TextInput.test.tsx
+++ b/slash/react/src/Form/Text/__tests__/TextInput.test.tsx
@@ -88,4 +88,10 @@ describe("TextInput", () => {
     // Assert
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it.each(["", undefined])("should generate an ID if no id is passed", (id) => {
+    render(<TextInput label="My Input" defaultValue="Hello World" id={id} />);
+
+    expect(screen.getByLabelText("My Input").id).toBeDefined();
+  });
 });

--- a/slash/react/src/Form/core/Field.tsx
+++ b/slash/react/src/Form/core/Field.tsx
@@ -93,6 +93,10 @@ export type ConsumerFieldProps = Omit<
   children?: ReactNode;
 };
 
+function isIdDefined(id: string | undefined): id is string {
+  return typeof id === "string" && id.length > 0;
+}
+
 export const Field = ({
   classNameContainerInput = "col-md-10",
   classNameContainerLabel = "col-md-2",
@@ -117,7 +121,7 @@ export const Field = ({
   ...otherProps
 }: InputProps) => {
   const inputUseId = useId();
-  const inputId = id ?? inputUseId;
+  const inputId = isIdDefined(id) ? id : inputUseId;
   const actualRequired = required || classModifier.includes("required");
   const isInvalid = useAriaInvalid(message, forceDisplayMessage, messageType);
   const errorId =


### PR DESCRIPTION
fixes #1467 