### PR TITLE
fix(look&feel,apollo): styling fixes for radio cards

### DIFF
--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.scss
@@ -78,6 +78,7 @@
 
     & .af-card-radio-option__content {
       align-items: flex-start;
+      text-align: left;
     }
 
     & .af-radio {

--- a/client/apollo/css/src/Form/Radio/Radio/RadioCommon.scss
+++ b/client/apollo/css/src/Form/Radio/Radio/RadioCommon.scss
@@ -10,6 +10,7 @@
   margin: 0;
   padding: 0;
   border-radius: 50%;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   background-color: var(--radio-background-color);


### PR DESCRIPTION
This pull request addresses the text alignment issue of radio card options in horizontal mode and prevents the radio option from shrinking.

<img width="404" height="303" alt="image" src="https://github.com/user-attachments/assets/76092b3f-a890-47d9-841b-3ba3fd5a5bc3" />
