### PR TITLE
fix(look&feel,apollo): correction des styles des card checkbox

### DIFF
--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.scss
@@ -81,6 +81,7 @@
 
     & .af-card-checkbox-option__content {
       align-items: flex-start;
+      text-align: left;
     }
 
     & .af-checkbox {

--- a/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
+++ b/client/apollo/css/src/Form/Checkbox/Checkbox/CheckboxCommon.scss
@@ -5,6 +5,7 @@
   height: calc(24 / var(--font-size-base) * 1rem);
   margin: 0;
   border-radius: var(--checkbox-border-radius);
+  flex-shrink: 0;
   align-items: center;
   background-color: var(--checkbox-background-color);
   outline: var(--checkbox-border-width) solid var(--checkbox-border-color);


### PR DESCRIPTION
This pull request addresses the text alignment issue of checkbox card options in horizontal mode and prevents the checkbox option from shrinking.

<img width="482" height="305" alt="image" src="https://github.com/user-attachments/assets/90a59af9-20a4-41ec-8f56-d81af7943b42" />
