### PR TITLE
fix(slash): modificiation du css pour éviter de perdre la fin d'étape

### DIFF
--- a/slash/css/src/Steps/VerticalStep.css
+++ b/slash/css/src/Steps/VerticalStep.css
@@ -13,11 +13,11 @@
     content: "";
   }
 
-  &:last-child:not(.af-vertical-step--edition)::before {
+  &:last-of-type:not(.af-vertical-step--edition)::before {
     background: none;
   }
 
-  &:last-child.af-vertical-step--edition {
+  &:last-of-type.af-vertical-step--edition {
     grid-template-areas:
       "separation icon title"
       "separation content content"
@@ -30,7 +30,7 @@
     }
   }
 
-  &:not(:last-child.af-vertical-step--edition)
+  &:not(:last-of-type.af-vertical-step--edition)
     .af-vertical-step-icon--lastIcon {
     display: none;
   }


### PR DESCRIPTION
Modification du css pour éviter de perdre la fin d'étape si un élément est positionné après le dernier VerticalStep