### PR TITLE
feat(slash,apollo): create classname guideline and getClassName function

### DIFF
--- a/client/apollo/react/src/index.ts
+++ b/client/apollo/react/src/index.ts
@@ -6,23 +6,24 @@ import "@fontsource/source-sans-pro";
 export {
   Accordion,
   accordionVariants,
-  type AccordionVariants
+  type AccordionVariants,
 } from "./Accordion/AccordionApollo";
 export { AccordionCore } from "./AccordionCore/AccordionCoreApollo";
 export { BasePicture } from "./BasePicture/BasePicture";
 export {
   Button,
   buttonVariants,
-  type ButtonVariants
+  type ButtonVariants,
 } from "./Button/ButtonApollo";
 export {
   CardMessage,
   cardMessageVariants,
-  type CardMessageVariants
+  type CardMessageVariants,
 } from "./CardMessage/CardMessageApollo";
 export { ClickIcon } from "./ClickIcon/ClickIconApollo";
 export {
-  ContentItemDuoAction, type ContentItemDuoActionState
+  ContentItemDuoAction,
+  type ContentItemDuoActionState,
 } from "./ContentItemDuoAction/ContentItemDuoActionApollo";
 export { ContentItemMono } from "./ContentItemMono/ContentItemMonoApollo";
 export { DataAgent } from "./DataAgent/DataAgentApollo";
@@ -30,7 +31,7 @@ export { Divider } from "./Divider/DividerApollo";
 export {
   CardCheckbox,
   /** @deprecated Use `CardCheckbox` instead. */
-  CardCheckbox as CheckboxCard
+  CardCheckbox as CheckboxCard,
 } from "./Form/Checkbox/CardCheckbox/CardCheckboxApollo";
 export { CardCheckboxOption } from "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo";
 export { Checkbox } from "./Form/Checkbox/Checkbox/CheckboxApollo";
@@ -48,7 +49,7 @@ export { ItemLabel } from "./Form/ItemLabel/ItemLabelApollo";
 export {
   ItemMessage,
   itemMessageVariants,
-  type ItemMessageVariants
+  type ItemMessageVariants,
 } from "./Form/ItemMessage/ItemMessageApollo";
 export { CardRadio } from "./Form/Radio/CardRadio/CardRadioApollo";
 export { CardRadioOption } from "./Form/Radio/CardRadioOption/CardRadioOptionApollo";
@@ -61,11 +62,11 @@ export {
   iconSizeVariants,
   iconVariants,
   type IconSizeVariants,
-  type IconVariants
+  type IconVariants,
 } from "./Icon/IconApollo";
 export {
   ItemTabBar,
-  type ItemTabBarProps
+  type ItemTabBarProps,
 } from "./ItemTabBar/ItemTabBarApollo";
 export { Footer, type FooterProps } from "./Layout/Footer/FooterApollo";
 export { Link, linkVariants, type LinkVariants } from "./Link/LinkApollo";
@@ -74,37 +75,36 @@ export {
   clickItemStates,
   clickItemVariants,
   type ClickItemStates,
-  type ClickItemVariants
+  type ClickItemVariants,
 } from "./List/ClickItem/ClickItemApollo";
 export { ContentItemDuo } from "./List/ContentItemDuo/ContentItemDuoApollo";
 export {
   Message,
   messageVariants,
-  type MessageVariants
+  type MessageVariants,
 } from "./Message/MessageApollo";
 export {
   Modal,
   ModalCore,
   ModalCoreBody,
   ModalCoreFooter,
-  ModalCoreHeader
+  ModalCoreHeader,
 } from "./Modal/ModalApollo";
 export { ProgressBar } from "./ProgressBar/ProgressBarApollo";
 export { ProgressBarGroup } from "./ProgressBarGroup/ProgressBarGroupApollo";
 export {
   Spinner,
   spinnerVariants,
-  type SpinnerVariants
+  type SpinnerVariants,
 } from "./Spinner/SpinnerApollo";
 export { Stepper } from "./Stepper/StepperApollo";
 export { Svg } from "./Svg/Svg";
 export {
-  TabBar, tabBarDirection,
-  type TabBarDirection, type TabBarProps
+  TabBar,
+  tabBarDirection,
+  type TabBarDirection,
+  type TabBarProps,
 } from "./TabBar/TabBarApollo";
 export { Tag, tagVariants, type TagVariants } from "./Tag/TagApollo";
 export { TimelineVertical } from "./TimelineVertical/TimelineVerticalApollo";
 export { Toggle } from "./Toggle/ToggleApollo";
-
-export { clsx } from "./utilities/getClassName";
-

--- a/client/apollo/react/src/index.ts
+++ b/client/apollo/react/src/index.ts
@@ -6,33 +6,39 @@ import "@fontsource/source-sans-pro";
 export {
   Accordion,
   accordionVariants,
-  type AccordionVariants,
+  type AccordionVariants
 } from "./Accordion/AccordionApollo";
 export { AccordionCore } from "./AccordionCore/AccordionCoreApollo";
 export { BasePicture } from "./BasePicture/BasePicture";
 export {
   Button,
   buttonVariants,
-  type ButtonVariants,
+  type ButtonVariants
 } from "./Button/ButtonApollo";
 export {
   CardMessage,
   cardMessageVariants,
-  type CardMessageVariants,
+  type CardMessageVariants
 } from "./CardMessage/CardMessageApollo";
 export { ClickIcon } from "./ClickIcon/ClickIconApollo";
+export {
+  ContentItemDuoAction, type ContentItemDuoActionState
+} from "./ContentItemDuoAction/ContentItemDuoActionApollo";
 export { ContentItemMono } from "./ContentItemMono/ContentItemMonoApollo";
 export { DataAgent } from "./DataAgent/DataAgentApollo";
 export { Divider } from "./Divider/DividerApollo";
 export {
   CardCheckbox,
   /** @deprecated Use `CardCheckbox` instead. */
-  CardCheckbox as CheckboxCard,
+  CardCheckbox as CheckboxCard
 } from "./Form/Checkbox/CardCheckbox/CardCheckboxApollo";
 export { CardCheckboxOption } from "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo";
 export { Checkbox } from "./Form/Checkbox/Checkbox/CheckboxApollo";
 export { CheckboxText } from "./Form/Checkbox/CheckboxText/CheckboxTextApollo";
 export { Dropdown } from "./Form/Dropdown/DropdownApollo";
+export { FileUpload } from "./Form/FileUpload/FileUpload/FileUploadApollo";
+export { InputFile } from "./Form/FileUpload/InputFile/InputFileApollo";
+export { ItemFile } from "./Form/FileUpload/ItemFile/ItemFileApollo";
 export { InputDate } from "./Form/InputDate/InputDateApollo";
 export { type OptionType } from "./Form/InputPhone/InputPhone.types";
 export { InputPhone } from "./Form/InputPhone/InputPhoneApollo";
@@ -42,7 +48,7 @@ export { ItemLabel } from "./Form/ItemLabel/ItemLabelApollo";
 export {
   ItemMessage,
   itemMessageVariants,
-  type ItemMessageVariants,
+  type ItemMessageVariants
 } from "./Form/ItemMessage/ItemMessageApollo";
 export { CardRadio } from "./Form/Radio/CardRadio/CardRadioApollo";
 export { CardRadioOption } from "./Form/Radio/CardRadioOption/CardRadioOptionApollo";
@@ -55,18 +61,12 @@ export {
   iconSizeVariants,
   iconVariants,
   type IconSizeVariants,
-  type IconVariants,
+  type IconVariants
 } from "./Icon/IconApollo";
 export {
   ItemTabBar,
-  type ItemTabBarProps,
+  type ItemTabBarProps
 } from "./ItemTabBar/ItemTabBarApollo";
-export {
-  TabBar,
-  type TabBarProps,
-  tabBarDirection,
-  type TabBarDirection,
-} from "./TabBar/TabBarApollo";
 export { Footer, type FooterProps } from "./Layout/Footer/FooterApollo";
 export { Link, linkVariants, type LinkVariants } from "./Link/LinkApollo";
 export {
@@ -74,37 +74,37 @@ export {
   clickItemStates,
   clickItemVariants,
   type ClickItemStates,
-  type ClickItemVariants,
+  type ClickItemVariants
 } from "./List/ClickItem/ClickItemApollo";
 export { ContentItemDuo } from "./List/ContentItemDuo/ContentItemDuoApollo";
 export {
-  type ContentItemDuoActionState,
-  ContentItemDuoAction,
-} from "./ContentItemDuoAction/ContentItemDuoActionApollo";
-export {
   Message,
   messageVariants,
-  type MessageVariants,
+  type MessageVariants
 } from "./Message/MessageApollo";
 export {
   Modal,
   ModalCore,
   ModalCoreBody,
   ModalCoreFooter,
-  ModalCoreHeader,
+  ModalCoreHeader
 } from "./Modal/ModalApollo";
 export { ProgressBar } from "./ProgressBar/ProgressBarApollo";
 export { ProgressBarGroup } from "./ProgressBarGroup/ProgressBarGroupApollo";
 export {
   Spinner,
   spinnerVariants,
-  type SpinnerVariants,
+  type SpinnerVariants
 } from "./Spinner/SpinnerApollo";
 export { Stepper } from "./Stepper/StepperApollo";
 export { Svg } from "./Svg/Svg";
+export {
+  TabBar, tabBarDirection,
+  type TabBarDirection, type TabBarProps
+} from "./TabBar/TabBarApollo";
 export { Tag, tagVariants, type TagVariants } from "./Tag/TagApollo";
 export { TimelineVertical } from "./TimelineVertical/TimelineVerticalApollo";
 export { Toggle } from "./Toggle/ToggleApollo";
-export { InputFile } from "./Form/FileUpload/InputFile/InputFileApollo";
-export { ItemFile } from "./Form/FileUpload/ItemFile/ItemFileApollo";
-export { FileUpload } from "./Form/FileUpload/FileUpload/FileUploadApollo";
+
+export { clsx } from "./utilities/getClassName";
+

--- a/client/apollo/react/src/indexLF.ts
+++ b/client/apollo/react/src/indexLF.ts
@@ -7,7 +7,7 @@ import "@fontsource/source-sans-pro";
 export {
   Accordion,
   accordionVariants,
-  type AccordionVariants
+  type AccordionVariants,
 } from "./Accordion/AccordionLF";
 export { AccordionCore } from "./AccordionCore/AccordionCoreLF";
 export { BasePicture } from "./BasePicture/BasePicture";
@@ -15,11 +15,12 @@ export { Button, buttonVariants, type ButtonVariants } from "./Button/ButtonLF";
 export {
   CardMessage,
   cardMessageVariants,
-  type CardMessageVariants
+  type CardMessageVariants,
 } from "./CardMessage/CardMessageLF";
 export { ClickIcon } from "./ClickIcon/ClickIconLF";
 export {
-  ContentItemDuoAction, type ContentItemDuoActionState
+  ContentItemDuoAction,
+  type ContentItemDuoActionState,
 } from "./ContentItemDuoAction/ContentItemDuoActionLF";
 export { ContentItemMono } from "./ContentItemMono/ContentItemMonoLF";
 export { DataAgent } from "./DataAgent/DataAgentLF";
@@ -27,7 +28,7 @@ export { Divider } from "./Divider/DividerLF";
 export {
   CardCheckbox,
   /** @deprecated Use `CardCheckbox` instead. */
-  CardCheckbox as CheckboxCard
+  CardCheckbox as CheckboxCard,
 } from "./Form/Checkbox/CardCheckbox/CardCheckboxLF";
 export { CardCheckboxOption } from "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF";
 export { Checkbox } from "./Form/Checkbox/Checkbox/CheckboxLF";
@@ -39,21 +40,21 @@ export { ItemFile } from "./Form/FileUpload/ItemFile/ItemFileLF";
 export {
   /** @deprecated Use `InputDate` instead. */
   InputDate as DateInput,
-  InputDate
+  InputDate,
 } from "./Form/InputDate/InputDateLF";
 export { type OptionType } from "./Form/InputPhone/InputPhone.types";
 export { InputPhone } from "./Form/InputPhone/InputPhoneLF";
 export {
   InputText,
   /** @deprecated Use `InputText` instead. */
-  InputText as TextInput
+  InputText as TextInput,
 } from "./Form/InputText/InputTextLF";
 export { InputTextAtom } from "./Form/InputTextAtom/InputTextAtomLF";
 export { ItemLabel } from "./Form/ItemLabel/ItemLabelLF";
 export {
   ItemMessage,
   itemMessageVariants,
-  type ItemMessageVariants
+  type ItemMessageVariants,
 } from "./Form/ItemMessage/ItemMessageLF";
 export { CardRadio } from "./Form/Radio/CardRadio/CardRadioLF";
 export { CardRadioOption } from "./Form/Radio/CardRadioOption/CardRadioOptionLF";
@@ -66,7 +67,7 @@ export {
   iconSizeVariants,
   iconVariants,
   type IconSizeVariants,
-  type IconVariants
+  type IconVariants,
 } from "./Icon/IconLF";
 export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBar/ItemTabBarLF";
 export { Footer, type FooterProps } from "./Layout/Footer/FooterLF";
@@ -76,37 +77,36 @@ export {
   clickItemStates,
   clickItemVariants,
   type ClickItemStates,
-  type ClickItemVariants
+  type ClickItemVariants,
 } from "./List/ClickItem/ClickItemLF";
 export { ContentItemDuo } from "./List/ContentItemDuo/ContentItemDuoLF";
 export {
   Message,
   messageVariants,
-  type MessageVariants
+  type MessageVariants,
 } from "./Message/MessageLF";
 export {
   Modal,
   ModalCore,
   ModalCoreBody,
   ModalCoreFooter,
-  ModalCoreHeader
+  ModalCoreHeader,
 } from "./Modal/ModalLF";
 export { ProgressBar } from "./ProgressBar/ProgressBarLF";
 export { ProgressBarGroup } from "./ProgressBarGroup/ProgressBarGroupLF";
 export {
   Spinner,
   spinnerVariants,
-  type SpinnerVariants
+  type SpinnerVariants,
 } from "./Spinner/SpinnerLF";
 export { Stepper } from "./Stepper/StepperLF";
 export { Svg } from "./Svg/Svg";
 export {
-  TabBar, tabBarDirection,
-  type TabBarDirection, type TabBarProps
+  TabBar,
+  tabBarDirection,
+  type TabBarDirection,
+  type TabBarProps,
 } from "./TabBar/TabBarLF";
 export { Tag, tagVariants, type TagVariants } from "./Tag/TagLF";
 export { TimelineVertical } from "./TimelineVertical/TimelineVerticalLF";
 export { Toggle } from "./Toggle/ToggleLF";
-
-export { clsx } from "./utilities/getClassName";
-

--- a/client/apollo/react/src/indexLF.ts
+++ b/client/apollo/react/src/indexLF.ts
@@ -7,7 +7,7 @@ import "@fontsource/source-sans-pro";
 export {
   Accordion,
   accordionVariants,
-  type AccordionVariants,
+  type AccordionVariants
 } from "./Accordion/AccordionLF";
 export { AccordionCore } from "./AccordionCore/AccordionCoreLF";
 export { BasePicture } from "./BasePicture/BasePicture";
@@ -15,39 +15,45 @@ export { Button, buttonVariants, type ButtonVariants } from "./Button/ButtonLF";
 export {
   CardMessage,
   cardMessageVariants,
-  type CardMessageVariants,
+  type CardMessageVariants
 } from "./CardMessage/CardMessageLF";
 export { ClickIcon } from "./ClickIcon/ClickIconLF";
+export {
+  ContentItemDuoAction, type ContentItemDuoActionState
+} from "./ContentItemDuoAction/ContentItemDuoActionLF";
 export { ContentItemMono } from "./ContentItemMono/ContentItemMonoLF";
 export { DataAgent } from "./DataAgent/DataAgentLF";
 export { Divider } from "./Divider/DividerLF";
 export {
   CardCheckbox,
   /** @deprecated Use `CardCheckbox` instead. */
-  CardCheckbox as CheckboxCard,
+  CardCheckbox as CheckboxCard
 } from "./Form/Checkbox/CardCheckbox/CardCheckboxLF";
 export { CardCheckboxOption } from "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF";
 export { Checkbox } from "./Form/Checkbox/Checkbox/CheckboxLF";
 export { CheckboxText } from "./Form/Checkbox/CheckboxText/CheckboxTextLF";
 export { Dropdown } from "./Form/Dropdown/DropdownLF";
+export { FileUpload } from "./Form/FileUpload/FileUpload/FileUploadLF";
+export { InputFile } from "./Form/FileUpload/InputFile/InputFileLF";
+export { ItemFile } from "./Form/FileUpload/ItemFile/ItemFileLF";
 export {
   /** @deprecated Use `InputDate` instead. */
   InputDate as DateInput,
-  InputDate,
+  InputDate
 } from "./Form/InputDate/InputDateLF";
 export { type OptionType } from "./Form/InputPhone/InputPhone.types";
 export { InputPhone } from "./Form/InputPhone/InputPhoneLF";
 export {
   InputText,
   /** @deprecated Use `InputText` instead. */
-  InputText as TextInput,
+  InputText as TextInput
 } from "./Form/InputText/InputTextLF";
 export { InputTextAtom } from "./Form/InputTextAtom/InputTextAtomLF";
 export { ItemLabel } from "./Form/ItemLabel/ItemLabelLF";
 export {
   ItemMessage,
   itemMessageVariants,
-  type ItemMessageVariants,
+  type ItemMessageVariants
 } from "./Form/ItemMessage/ItemMessageLF";
 export { CardRadio } from "./Form/Radio/CardRadio/CardRadioLF";
 export { CardRadioOption } from "./Form/Radio/CardRadioOption/CardRadioOptionLF";
@@ -60,15 +66,9 @@ export {
   iconSizeVariants,
   iconVariants,
   type IconSizeVariants,
-  type IconVariants,
+  type IconVariants
 } from "./Icon/IconLF";
 export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBar/ItemTabBarLF";
-export {
-  TabBar,
-  type TabBarProps,
-  tabBarDirection,
-  type TabBarDirection,
-} from "./TabBar/TabBarLF";
 export { Footer, type FooterProps } from "./Layout/Footer/FooterLF";
 export { Link, linkVariants, type LinkVariants } from "./Link/LinkLF";
 export {
@@ -76,37 +76,37 @@ export {
   clickItemStates,
   clickItemVariants,
   type ClickItemStates,
-  type ClickItemVariants,
+  type ClickItemVariants
 } from "./List/ClickItem/ClickItemLF";
 export { ContentItemDuo } from "./List/ContentItemDuo/ContentItemDuoLF";
 export {
-  type ContentItemDuoActionState,
-  ContentItemDuoAction,
-} from "./ContentItemDuoAction/ContentItemDuoActionLF";
-export {
   Message,
   messageVariants,
-  type MessageVariants,
+  type MessageVariants
 } from "./Message/MessageLF";
 export {
   Modal,
   ModalCore,
   ModalCoreBody,
   ModalCoreFooter,
-  ModalCoreHeader,
+  ModalCoreHeader
 } from "./Modal/ModalLF";
 export { ProgressBar } from "./ProgressBar/ProgressBarLF";
 export { ProgressBarGroup } from "./ProgressBarGroup/ProgressBarGroupLF";
 export {
   Spinner,
   spinnerVariants,
-  type SpinnerVariants,
+  type SpinnerVariants
 } from "./Spinner/SpinnerLF";
 export { Stepper } from "./Stepper/StepperLF";
 export { Svg } from "./Svg/Svg";
+export {
+  TabBar, tabBarDirection,
+  type TabBarDirection, type TabBarProps
+} from "./TabBar/TabBarLF";
 export { Tag, tagVariants, type TagVariants } from "./Tag/TagLF";
 export { TimelineVertical } from "./TimelineVertical/TimelineVerticalLF";
 export { Toggle } from "./Toggle/ToggleLF";
-export { InputFile } from "./Form/FileUpload/InputFile/InputFileLF";
-export { ItemFile } from "./Form/FileUpload/ItemFile/ItemFileLF";
-export { FileUpload } from "./Form/FileUpload/FileUpload/FileUploadLF";
+
+export { clsx } from "./utilities/getClassName";
+

--- a/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
+++ b/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
@@ -3,13 +3,13 @@ import { getClassName } from "../getClassName";
 
 describe("getClassName", () => {
   it("returns only the component class name if no modifiers or custom class", () => {
-    expect(getClassName({ defaultClassName: "af-test" })).toBe("af-test");
+    expect(getClassName({ baseClassName: "af-test" })).toBe("af-test");
   });
 
   it("appends modifiers as BEM classes and ignores falsy values", () => {
     expect(
       getClassName({
-        defaultClassName: "af-test",
+        baseClassName: "af-test",
         modifiers: ["primary", false, undefined, "secondary"],
       }),
     ).toBe("af-test af-test--primary af-test--secondary");
@@ -18,7 +18,7 @@ describe("getClassName", () => {
   it("appends custom class name", () => {
     expect(
       getClassName({
-        defaultClassName: "af-test",
+        baseClassName: "af-test",
         className: "my-custom-class",
       }),
     ).toBe("af-test my-custom-class");
@@ -27,7 +27,7 @@ describe("getClassName", () => {
   it("appends both modifiers and custom class name", () => {
     expect(
       getClassName({
-        defaultClassName: "af-test",
+        baseClassName: "af-test",
         modifiers: ["primary"],
         className: "my-custom-class",
       }),

--- a/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
+++ b/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { clsx, getClassName } from "../getClassName";
+
+describe("clsx", () => {
+  it("returns an empty string if no arguments", () => {
+    expect(clsx()).toBe("");
+  });
+
+  it("joins multiple class names", () => {
+    expect(clsx("a", "b", "c")).toBe("a b c");
+  });
+
+  it("ignores falsy values (false, undefined, empty string)", () => {
+    expect(clsx("a", false, undefined, "", "b")).toBe("a b");
+  });
+
+  it("returns only truthy class names", () => {
+    expect(clsx(false, undefined, "foo")).toBe("foo");
+  });
+});
+
+describe("getClassName", () => {
+  it("returns only the component class name if no modifiers or custom class", () => {
+    expect(getClassName({ defaultClassName: "af-test" })).toBe("af-test");
+  });
+
+  it("appends modifiers as BEM classes and ignores falsy values", () => {
+    expect(
+      getClassName({
+        defaultClassName: "af-test",
+        modifiers: ["primary", false, undefined, "secondary"],
+      }),
+    ).toBe("af-test af-test--primary af-test--secondary");
+  });
+
+  it("appends custom class name", () => {
+    expect(
+      getClassName({
+        defaultClassName: "af-test",
+        className: "my-custom-class",
+      }),
+    ).toBe("af-test my-custom-class");
+  });
+
+  it("appends both modifiers and custom class name", () => {
+    expect(
+      getClassName({
+        defaultClassName: "af-test",
+        modifiers: ["primary"],
+        className: "my-custom-class",
+      }),
+    ).toBe("af-test af-test--primary my-custom-class");
+  });
+});

--- a/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
+++ b/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
@@ -3,7 +3,7 @@ import { getClassName } from "../getClassName";
 
 describe("getClassName", () => {
   it("returns only the component class name if no modifiers or custom class", () => {
-    expect(getClassName({ baseClassName: "af-test" })).toBe("af-test");
+    expect(getClassName({ baseClassName: "af-test" })).toStrictEqual("af-test");
   });
 
   it("appends modifiers as BEM classes and ignores falsy values", () => {
@@ -12,7 +12,7 @@ describe("getClassName", () => {
         baseClassName: "af-test",
         modifiers: ["primary", false, undefined, "secondary"],
       }),
-    ).toBe("af-test af-test--primary af-test--secondary");
+    ).toStrictEqual("af-test af-test--primary af-test--secondary");
   });
 
   it("appends custom class name", () => {
@@ -21,7 +21,7 @@ describe("getClassName", () => {
         baseClassName: "af-test",
         className: "my-custom-class",
       }),
-    ).toBe("af-test my-custom-class");
+    ).toStrictEqual("af-test my-custom-class");
   });
 
   it("appends both modifiers and custom class name", () => {
@@ -31,6 +31,16 @@ describe("getClassName", () => {
         modifiers: ["primary"],
         className: "my-custom-class",
       }),
-    ).toBe("af-test af-test--primary my-custom-class");
+    ).toStrictEqual("af-test af-test--primary my-custom-class");
+  });
+
+  it("removes duplicate class names in the result", () => {
+    expect(
+      getClassName({
+        baseClassName: "af-test",
+        modifiers: ["primary", "primary"],
+        className: "af-test af-test--primary my-custom-class",
+      }),
+    ).toStrictEqual("af-test af-test--primary my-custom-class");
   });
 });

--- a/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
+++ b/client/apollo/react/src/utilities/__tests__/getClassName.test.ts
@@ -1,23 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { clsx, getClassName } from "../getClassName";
-
-describe("clsx", () => {
-  it("returns an empty string if no arguments", () => {
-    expect(clsx()).toBe("");
-  });
-
-  it("joins multiple class names", () => {
-    expect(clsx("a", "b", "c")).toBe("a b c");
-  });
-
-  it("ignores falsy values (false, undefined, empty string)", () => {
-    expect(clsx("a", false, undefined, "", "b")).toBe("a b");
-  });
-
-  it("returns only truthy class names", () => {
-    expect(clsx(false, undefined, "foo")).toBe("foo");
-  });
-});
+import { getClassName } from "../getClassName";
 
 describe("getClassName", () => {
   it("returns only the component class name if no modifiers or custom class", () => {

--- a/client/apollo/react/src/utilities/getClassName.ts
+++ b/client/apollo/react/src/utilities/getClassName.ts
@@ -1,19 +1,33 @@
 type getClassNameParams = {
-  defaultClassName: string;
+  baseClassName: string;
   modifiers?: Array<string | boolean | undefined>;
   className?: string;
 };
 
+
+/**
+ * Génère une chaîne de classes CSS à partir d'un nom de base, de modificateurs optionnels et d'une classe additionnelle.
+ *
+ * @param {Object} params - Les paramètres de la fonction.
+ * @param {string} params.baseClassName - Le nom de classe de base (obligatoire).
+ * @param {Array<string|boolean|undefined>} [params.modifiers] - Liste de modificateurs à ajouter sous la forme `${baseClassName}--{modificateur}`. Les valeurs falsy sont ignorées.
+ * @param {string} [params.className] - Classe(s) additionnelle(s) à ajouter à la chaîne finale.
+ * @returns {string} La chaîne de classes CSS concaténées, séparées par un espace.
+ *
+ * @example
+ * getClassName({ baseClassName: 'btn', modifiers: ['large', false, 'primary'], className: 'custom' })
+ * // Retourne : 'btn btn--large btn--primary custom'
+ */
 export const getClassName = ({
-  defaultClassName,
+  baseClassName,
   modifiers = [],
   className,
 }: getClassNameParams) => {
   const parsedModifiers = modifiers
     .filter(Boolean)
-    .map((modifier) => `${defaultClassName}--${modifier}`);
+    .map((modifier) => `${baseClassName}--${modifier}`);
 
-  return [defaultClassName, ...parsedModifiers, className]
+  return [baseClassName, ...parsedModifiers, className]
     .filter(Boolean)
     .join(" ");
 };

--- a/client/apollo/react/src/utilities/getClassName.ts
+++ b/client/apollo/react/src/utilities/getClassName.ts
@@ -4,19 +4,18 @@ type getClassNameParams = {
   className?: string;
 };
 
-
 /**
- * Génère une chaîne de classes CSS à partir d'un nom de base, de modificateurs optionnels et d'une classe additionnelle.
+ * Generates a CSS class string from a base class name, optional modifiers, and an additional class name.
  *
- * @param {Object} params - Les paramètres de la fonction.
- * @param {string} params.baseClassName - Le nom de classe de base (obligatoire).
- * @param {Array<string|boolean|undefined>} [params.modifiers] - Liste de modificateurs à ajouter sous la forme `${baseClassName}--{modificateur}`. Les valeurs falsy sont ignorées.
- * @param {string} [params.className] - Classe(s) additionnelle(s) à ajouter à la chaîne finale.
- * @returns {string} La chaîne de classes CSS concaténées, séparées par un espace.
+ * @param {string} params.baseClassName - The base class name (required).
+ * @param {Array<string|boolean|undefined>} [params.modifiers] - List of modifiers to append as `${baseClassName}--{modifier}`. Falsy values are ignored.
+ * @param {string} [params.className] - Additional class name(s) to append to the final string.
+ * @returns {string} The concatenated CSS class string, separated by spaces.
  *
  * @example
- * getClassName({ baseClassName: 'btn', modifiers: ['large', false, 'primary'], className: 'custom' })
- * // Retourne : 'btn btn--large btn--primary custom'
+ * const isLarge = false;
+ * getClassName({ baseClassName: 'af-button', modifiers: ['primary', isLarge && 'large'], className: 'custom-class' })
+ * // Returns: 'af-button af-button--primary custom-class'
  */
 export const getClassName = ({
   baseClassName,

--- a/client/apollo/react/src/utilities/getClassName.ts
+++ b/client/apollo/react/src/utilities/getClassName.ts
@@ -20,13 +20,17 @@ type getClassNameParams = {
 export const getClassName = ({
   baseClassName,
   modifiers = [],
-  className,
+  className = "",
 }: getClassNameParams) => {
   const parsedModifiers = modifiers
     .filter(Boolean)
     .map((modifier) => `${baseClassName}--${modifier}`);
 
-  return [baseClassName, ...parsedModifiers, className]
-    .filter(Boolean)
-    .join(" ");
+  const classList = [
+    baseClassName,
+    ...parsedModifiers,
+    ...className.split(" "),
+  ].filter(Boolean);
+
+  return Array.from(new Set(classList)).join(" ");
 };

--- a/client/apollo/react/src/utilities/getClassName.ts
+++ b/client/apollo/react/src/utilities/getClassName.ts
@@ -1,0 +1,21 @@
+export const clsx = (...classNames: Array<string | boolean | undefined>) => {
+  return classNames.filter(Boolean).join(" ");
+};
+
+type getClassNameParams = {
+  defaultClassName: string;
+  modifiers?: Array<string | boolean | undefined>;
+  className?: string;
+};
+
+export const getClassName = ({
+  defaultClassName,
+  modifiers = [],
+  className,
+}: getClassNameParams) => {
+  const parsedModifiers = modifiers
+    .filter(Boolean)
+    .map((modifier) => `${defaultClassName}--${modifier}`);
+
+  return clsx(defaultClassName, ...parsedModifiers, className);
+};

--- a/client/apollo/react/src/utilities/getClassName.ts
+++ b/client/apollo/react/src/utilities/getClassName.ts
@@ -1,7 +1,3 @@
-export const clsx = (...classNames: Array<string | boolean | undefined>) => {
-  return classNames.filter(Boolean).join(" ");
-};
-
 type getClassNameParams = {
   defaultClassName: string;
   modifiers?: Array<string | boolean | undefined>;
@@ -17,5 +13,7 @@ export const getClassName = ({
     .filter(Boolean)
     .map((modifier) => `${defaultClassName}--${modifier}`);
 
-  return clsx(defaultClassName, ...parsedModifiers, className);
+  return [defaultClassName, ...parsedModifiers, className]
+    .filter(Boolean)
+    .join(" ");
 };

--- a/client/apollo/react/src/utilities/getComponentClassName.ts
+++ b/client/apollo/react/src/utilities/getComponentClassName.ts
@@ -16,6 +16,9 @@ const listClassModifier = (classModifier?: string) => {
   return classModifier.split(" ");
 };
 
+/**
+ * @deprecated This function is deprecated and will be removed in a future release. Use getClassName instead.
+ */
 export const getComponentClassName = (
   defaultClassName: string,
   className?: string,

--- a/docs/guidelines/className-prop.md
+++ b/docs/guidelines/className-prop.md
@@ -18,7 +18,7 @@ function Button({ className, variant = 'primary', isLarge = false, ...props }) {
   return (
     <button
       className={getClassName({
-        defaultClassName: "af-button",
+        baseClassName: "af-button",
         modifiers: [variant, isLarge && "large"],
         className,
       })}
@@ -32,7 +32,7 @@ function Button({ className, variant = 'primary', isLarge = false, ...props }) {
 function Field({className, required, ...props}) {
   return (
     <div className={getClassName({
-        defaultClassName: "af-field",
+        baseClassName: "af-field",
         modifiers: [required && "required"],
         className,
       })}

--- a/docs/guidelines/className-prop.md
+++ b/docs/guidelines/className-prop.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-All React components in the design system must have a `className` prop. This prop allows the developers to add one or more custom CSS classes to the parent element of the component.
+All React components in the design system must have a `className` prop. This prop allows the developers to add one or more custom CSS classes to the **parent element of the component**.
 
 ## Rules
 
@@ -25,6 +25,22 @@ function Button({ className, variant = 'primary', isLarge = false, ...props }) {
       {...props}
     />
   );
+}
+```
+
+```tsx
+function Field({className, required, ...props}) {
+  return (
+    <div className={getClassName({
+        defaultClassName: "af-field",
+        modifiers: [required && "required"],
+        className,
+      })}
+    >
+      <Label className="af-field__label" />
+      <Input className="af-field__input" />
+    </div>
+  )
 }
 ```
 

--- a/docs/guidelines/className-prop.md
+++ b/docs/guidelines/className-prop.md
@@ -1,0 +1,34 @@
+# Guideline: `className` Prop for React Components
+
+## Purpose
+
+All React components in the design system must have a `className` prop. This prop allows the developers to add one or more custom CSS classes to the parent element of the component.
+
+## Rules
+
+- The `className` prop must be of type `string`.
+- Its value (one or more classes separated by a space) must be added to the `className` property of the parent element of the component.
+- The design system's default classes must always be present; the `className` prop should be appended.
+- You must use the `getClassName` utility function to generate the `className` for the parent element of the component. This ensures consistent handling of base classes, modifiers (mainly for variants), and developer-provided classes.
+- The `modifier` parameter (sometimes called `classModifier`) is mainly used for variants and should be passed to `getClassName` as the second argument.
+- Example implementation:
+
+```tsx
+function Button({ className, variant = 'primary', isLarge = false, ...props }) {
+  return (
+    <button
+      className={getClassName({
+        defaultClassName: "af-button",
+        modifiers: [variant, isLarge && "large"],
+        className,
+      })}
+      {...props}
+    />
+  );
+}
+```
+
+## Why?
+
+- Allows visual customization of components without breaking the base design system style.
+- Facilitates integration in various contexts (e.g., local overrides, tests, etc.).

--- a/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
+++ b/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
@@ -3,13 +3,13 @@ import { getClassName } from "../getClassName";
 
 describe("getClassName", () => {
   it("returns only the component class name if no modifiers or custom class", () => {
-    expect(getClassName({ defaultClassName: "af-test" })).toBe("af-test");
+    expect(getClassName({ baseClassName: "af-test" })).toBe("af-test");
   });
 
   it("appends modifiers as BEM classes and ignores falsy values", () => {
     expect(
       getClassName({
-        defaultClassName: "af-test",
+        baseClassName: "af-test",
         modifiers: ["primary", false, undefined, "secondary"],
       }),
     ).toBe("af-test af-test--primary af-test--secondary");
@@ -18,7 +18,7 @@ describe("getClassName", () => {
   it("appends custom class name", () => {
     expect(
       getClassName({
-        defaultClassName: "af-test",
+        baseClassName: "af-test",
         className: "my-custom-class",
       }),
     ).toBe("af-test my-custom-class");
@@ -27,7 +27,7 @@ describe("getClassName", () => {
   it("appends both modifiers and custom class name", () => {
     expect(
       getClassName({
-        defaultClassName: "af-test",
+        baseClassName: "af-test",
         modifiers: ["primary"],
         className: "my-custom-class",
       }),

--- a/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
+++ b/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { clsx, getClassName } from "../getClassName";
+
+describe("clsx", () => {
+  it("returns an empty string if no arguments", () => {
+    expect(clsx()).toBe("");
+  });
+
+  it("joins multiple class names", () => {
+    expect(clsx("a", "b", "c")).toBe("a b c");
+  });
+
+  it("ignores falsy values (false, undefined, empty string)", () => {
+    expect(clsx("a", false, undefined, "", "b")).toBe("a b");
+  });
+
+  it("returns only truthy class names", () => {
+    expect(clsx(false, undefined, "foo")).toBe("foo");
+  });
+});
+
+describe("getClassName", () => {
+  it("returns only the component class name if no modifiers or custom class", () => {
+    expect(getClassName({ defaultClassName: "af-test" })).toBe("af-test");
+  });
+
+  it("appends modifiers as BEM classes and ignores falsy values", () => {
+    expect(
+      getClassName({
+        defaultClassName: "af-test",
+        modifiers: ["primary", false, undefined, "secondary"],
+      }),
+    ).toBe("af-test af-test--primary af-test--secondary");
+  });
+
+  it("appends custom class name", () => {
+    expect(
+      getClassName({
+        defaultClassName: "af-test",
+        className: "my-custom-class",
+      }),
+    ).toBe("af-test my-custom-class");
+  });
+
+  it("appends both modifiers and custom class name", () => {
+    expect(
+      getClassName({
+        defaultClassName: "af-test",
+        modifiers: ["primary"],
+        className: "my-custom-class",
+      }),
+    ).toBe("af-test af-test--primary my-custom-class");
+  });
+});

--- a/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
+++ b/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
@@ -3,7 +3,7 @@ import { getClassName } from "../getClassName";
 
 describe("getClassName", () => {
   it("returns only the component class name if no modifiers or custom class", () => {
-    expect(getClassName({ baseClassName: "af-test" })).toBe("af-test");
+    expect(getClassName({ baseClassName: "af-test" })).toStrictEqual("af-test");
   });
 
   it("appends modifiers as BEM classes and ignores falsy values", () => {
@@ -12,7 +12,7 @@ describe("getClassName", () => {
         baseClassName: "af-test",
         modifiers: ["primary", false, undefined, "secondary"],
       }),
-    ).toBe("af-test af-test--primary af-test--secondary");
+    ).toStrictEqual("af-test af-test--primary af-test--secondary");
   });
 
   it("appends custom class name", () => {
@@ -21,7 +21,7 @@ describe("getClassName", () => {
         baseClassName: "af-test",
         className: "my-custom-class",
       }),
-    ).toBe("af-test my-custom-class");
+    ).toStrictEqual("af-test my-custom-class");
   });
 
   it("appends both modifiers and custom class name", () => {
@@ -31,6 +31,16 @@ describe("getClassName", () => {
         modifiers: ["primary"],
         className: "my-custom-class",
       }),
-    ).toBe("af-test af-test--primary my-custom-class");
+    ).toStrictEqual("af-test af-test--primary my-custom-class");
+  });
+
+  it("removes duplicate class names in the result", () => {
+    expect(
+      getClassName({
+        baseClassName: "af-test",
+        modifiers: ["primary", "primary"],
+        className: "af-test af-test--primary my-custom-class",
+      }),
+    ).toStrictEqual("af-test af-test--primary my-custom-class");
   });
 });

--- a/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
+++ b/slash/react/src/utilities/helpers/__tests__/getClassName.test.ts
@@ -1,23 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { clsx, getClassName } from "../getClassName";
-
-describe("clsx", () => {
-  it("returns an empty string if no arguments", () => {
-    expect(clsx()).toBe("");
-  });
-
-  it("joins multiple class names", () => {
-    expect(clsx("a", "b", "c")).toBe("a b c");
-  });
-
-  it("ignores falsy values (false, undefined, empty string)", () => {
-    expect(clsx("a", false, undefined, "", "b")).toBe("a b");
-  });
-
-  it("returns only truthy class names", () => {
-    expect(clsx(false, undefined, "foo")).toBe("foo");
-  });
-});
+import { getClassName } from "../getClassName";
 
 describe("getClassName", () => {
   it("returns only the component class name if no modifiers or custom class", () => {

--- a/slash/react/src/utilities/helpers/getClassName.ts
+++ b/slash/react/src/utilities/helpers/getClassName.ts
@@ -20,13 +20,17 @@ type getClassNameParams = {
 export const getClassName = ({
   baseClassName,
   modifiers = [],
-  className,
+  className = "",
 }: getClassNameParams) => {
   const parsedModifiers = modifiers
     .filter(Boolean)
     .map((modifier) => `${baseClassName}--${modifier}`);
 
-  return [baseClassName, ...parsedModifiers, className]
-    .filter(Boolean)
-    .join(" ");
+  const classList = [
+    baseClassName,
+    ...parsedModifiers,
+    ...className.split(" "),
+  ].filter(Boolean);
+
+  return Array.from(new Set(classList)).join(" ");
 };

--- a/slash/react/src/utilities/helpers/getClassName.ts
+++ b/slash/react/src/utilities/helpers/getClassName.ts
@@ -4,6 +4,19 @@ type getClassNameParams = {
   className?: string;
 };
 
+/**
+ * Generates a CSS class string from a base class name, optional modifiers, and an additional class name.
+ *
+ * @param {string} params.baseClassName - The base class name (required).
+ * @param {Array<string|boolean|undefined>} [params.modifiers] - List of modifiers to append as `${baseClassName}--{modifier}`. Falsy values are ignored.
+ * @param {string} [params.className] - Additional class name(s) to append to the final string.
+ * @returns {string} The concatenated CSS class string, separated by spaces.
+ *
+ * @example
+ * const isLarge = false;
+ * getClassName({ baseClassName: 'af-button', modifiers: ['primary', isLarge && 'large'], className: 'custom-class' })
+ * // Returns: 'af-button af-button--primary custom-class'
+ */
 export const getClassName = ({
   baseClassName,
   modifiers = [],

--- a/slash/react/src/utilities/helpers/getClassName.ts
+++ b/slash/react/src/utilities/helpers/getClassName.ts
@@ -1,19 +1,19 @@
 type getClassNameParams = {
-  defaultClassName: string;
+  baseClassName: string;
   modifiers?: Array<string | boolean | undefined>;
   className?: string;
 };
 
 export const getClassName = ({
-  defaultClassName,
+  baseClassName,
   modifiers = [],
   className,
 }: getClassNameParams) => {
   const parsedModifiers = modifiers
     .filter(Boolean)
-    .map((modifier) => `${defaultClassName}--${modifier}`);
+    .map((modifier) => `${baseClassName}--${modifier}`);
 
-  return [defaultClassName, ...parsedModifiers, className]
+  return [baseClassName, ...parsedModifiers, className]
     .filter(Boolean)
     .join(" ");
 };

--- a/slash/react/src/utilities/helpers/getClassName.ts
+++ b/slash/react/src/utilities/helpers/getClassName.ts
@@ -1,0 +1,21 @@
+export const clsx = (...classNames: Array<string | boolean | undefined>) => {
+  return classNames.filter(Boolean).join(" ");
+};
+
+type getClassNameParams = {
+  defaultClassName: string;
+  modifiers?: Array<string | boolean | undefined>;
+  className?: string;
+};
+
+export const getClassName = ({
+  defaultClassName,
+  modifiers = [],
+  className,
+}: getClassNameParams) => {
+  const parsedModifiers = modifiers
+    .filter(Boolean)
+    .map((modifier) => `${defaultClassName}--${modifier}`);
+
+  return clsx(defaultClassName, ...parsedModifiers, className);
+};

--- a/slash/react/src/utilities/helpers/getClassName.ts
+++ b/slash/react/src/utilities/helpers/getClassName.ts
@@ -1,7 +1,3 @@
-export const clsx = (...classNames: Array<string | boolean | undefined>) => {
-  return classNames.filter(Boolean).join(" ");
-};
-
 type getClassNameParams = {
   defaultClassName: string;
   modifiers?: Array<string | boolean | undefined>;
@@ -17,5 +13,7 @@ export const getClassName = ({
     .filter(Boolean)
     .map((modifier) => `${defaultClassName}--${modifier}`);
 
-  return clsx(defaultClassName, ...parsedModifiers, className);
+  return [defaultClassName, ...parsedModifiers, className]
+    .filter(Boolean)
+    .join(" ");
 };

--- a/slash/react/src/utilities/helpers/getComponentClassName.ts
+++ b/slash/react/src/utilities/helpers/getComponentClassName.ts
@@ -17,6 +17,7 @@ const listClassModifier = (classModifier?: string) => {
 };
 
 /**
+ * @deprecated This function is deprecated and will be removed in a future release. Use getClassName instead.
  * Generates a component class name string based on provided class names and modifiers.
  *
  * @param {string} [className] - The base class name.
@@ -54,6 +55,9 @@ type getComponentClassNameWithUserClassnameParams = {
   componentClassName: string;
 };
 
+/**
+ * @deprecated This function is deprecated and will be removed in a future release. Use getClassName instead.
+ */
 export const getComponentClassNameWithUserClassname = ({
   componentClassName,
   userClassName,


### PR DESCRIPTION
This pull request introduces a new utility function, `getClassName`, to standardize and simplify the generation of CSS class names for React components across both the Apollo and Slash packages. It also deprecates older functions and adds documentation to guide usage. The most important changes are grouped below:

### Utility Function Introduction and Adoption

* Added the new `getClassName` utility to both `client/apollo/react/src/utilities/getClassName.ts` and `slash/react/src/utilities/helpers/getClassName.ts`, which generates BEM-style class names and appends custom classes in a consistent manner.
* Created comprehensive unit tests for `getClassName` in both codebases to ensure correct behavior with various combinations of base class, modifiers, and custom class names.

### Deprecation of Old Utilities

* Marked `getComponentClassName` and `getComponentClassNameWithUserClassname` as deprecated in both codebases, advising developers to use `getClassName` instead for future development. [[1]](diffhunk://#diff-808fbdfe400f38ebf75101cc868d22c35cc67b975811e16f3e3a0ea2b378cca1R19-R21) [[2]](diffhunk://#diff-35c8937fa0ed03ec448b39bd2db4c103e2b68ed6d2020cb86536a6b0a21a7c19R20) [[3]](diffhunk://#diff-35c8937fa0ed03ec448b39bd2db4c103e2b68ed6d2020cb86536a6b0a21a7c19R58-R60)

### Documentation and Guidelines

* Added a new guideline document (`docs/guidelines/className-prop.md`) explaining the rationale, rules, and usage examples for the `className` prop and the new `getClassName` utility in React components.