### PR TITLE
fix(apollo,look&feel): move flex-shrink: 0 from ItemMessage icon to Svg to apply fix at every usage of Svg

### DIFF
--- a/client/apollo/css/package.json
+++ b/client/apollo/css/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist && npm run copyfiles",
-    "build": "postcss \"src/**/*{Apollo,LF,Grid,DebugGrid,All}.css\" \"src/common\"  \"src/*.css\" --base src --dir dist --verbose --env production",
+    "build": "postcss \"src/**/*{Apollo,LF,Grid,DebugGrid,Svg,All}.css\" \"src/common\"  \"src/*.css\" --base src --dir dist --verbose --env production",
     "dev": "npm run build -- --watch",
     "copyfiles": "copyfiles --up 1 \"src/**/*.scss\" files/**/*.svg dist",
     "stylelint": "stylelint \"src/**/*.{scss,css}\" --ignore-pattern \"src/common/tokens*.css\"",

--- a/client/apollo/css/src/Form/ItemMessage/ItemMessageCommon.css
+++ b/client/apollo/css/src/Form/ItemMessage/ItemMessageCommon.css
@@ -13,7 +13,6 @@
 .af-item-message__icon {
   width: var(--item-message-icon-size);
   height: var(--item-message-icon-size);
-  flex-shrink: 0;
   color: var(--item-message-color);
   fill: currentcolor;
 }

--- a/client/apollo/css/src/Svg/Svg.css
+++ b/client/apollo/css/src/Svg/Svg.css
@@ -1,0 +1,3 @@
+.af-svg {
+  flex-shrink: 0;
+}

--- a/client/apollo/css/src/apollo.css
+++ b/client/apollo/css/src/apollo.css
@@ -44,3 +44,4 @@
 @import "./Form/InputPhone/InputPhoneApollo.css";
 @import "./Modal/ModalApollo.css";
 @import "./Layout/Footer/FooterApollo.css";
+@import "./Svg/Svg.css";

--- a/client/apollo/css/src/look-and-feel.css
+++ b/client/apollo/css/src/look-and-feel.css
@@ -44,3 +44,4 @@
 @import "./Form/InputPhone/InputPhoneLF.css";
 @import "./Modal/ModalLF.css";
 @import "./Layout/Footer/FooterLF.css";
+@import "./Svg/Svg.css";

--- a/client/apollo/react/src/Svg/Svg.tsx
+++ b/client/apollo/react/src/Svg/Svg.tsx
@@ -1,3 +1,4 @@
+import "@axa-fr/design-system-apollo-css/dist/Svg/Svg.css";
 import React, { type ComponentProps, type SVGAttributes } from "react";
 import { svgInjector } from "./svgInjector";
 
@@ -20,6 +21,7 @@ const cloneAttributes = (
  * @deprecated Use Icon instead
  */
 export const Svg = ({
+  className,
   src,
   alt,
   width = 24,
@@ -78,6 +80,7 @@ export const Svg = ({
   return (
     <svg
       ref={rootRef}
+      className={["af-svg", className].filter(Boolean).join(" ")}
       data-src={src}
       width={width}
       height={height}

--- a/client/apollo/react/src/Svg/__tests__/Svg.test.tsx
+++ b/client/apollo/react/src/Svg/__tests__/Svg.test.tsx
@@ -1,6 +1,6 @@
-import { vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { vi } from "vitest";
 import { Svg } from "../Svg";
 
 const mocks = vi.hoisted(() => {
@@ -24,6 +24,7 @@ describe("<Svg />", () => {
       const svg = screen.getByLabelText("test");
       expect(svg).toBeInTheDocument();
       expect(svg).toHaveAttribute("data-src", svgSrc);
+      expect(svg).toHaveClass("af-svg");
     });
 
     it("renders fallback when src not found", async () => {


### PR DESCRIPTION
**Type of Pull Request:**

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
The `flex-shrink: 0` property was previously applied to the `.af-item-message__icon` class, which fixed size issues for SVGs. 
Now i suggest to apply this fix on the Svg component directly instead of each usage of this component.

This PR is related to [#1186](https://github.com/AxaFrance/design-system/pull/1186), but instead of fixing the issue only for `ItemMessage`, it provides a solution for all usages of the `Svg` component.

**Proposed Changes:**
- Remove `flex-shrink: 0` from `.af-item-message__icon` in `ItemMessageCommon.css`
- Create a new `Svg.css` file
- Import the new `Svg.css` in both `apollo.css` and `look-and-feel.css`
- Update the `Svg.tsx` React component to import the new CSS file
- Update the build script in `package.json` to include `Svg.css`

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [X] I have thought to rebase my branch
- [X] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None