### PR TITLE
feat(apollo,look&feel): apply the remaining props to the ContentItemDuo container

### DIFF
--- a/client/apollo/react/src/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/client/apollo/react/src/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -1,4 +1,9 @@
-import { type ComponentType, type ReactNode, useMemo } from "react";
+import {
+  type ComponentProps,
+  type ComponentType,
+  type ReactNode,
+  useMemo,
+} from "react";
 import type { ButtonProps } from "../../Button/ButtonCommon";
 import { getComponentClassName } from "../../utilities/getComponentClassName";
 
@@ -10,7 +15,7 @@ export type ContentItemDuoProps = {
   classModifier?: string;
   buttonText?: string;
   onButtonClick?: () => void;
-};
+} & ComponentProps<"div">;
 
 type ContentItemDuoCommonProps = ContentItemDuoProps & {
   ButtonComponent: ComponentType<ButtonProps>;
@@ -25,6 +30,7 @@ export const ContentItemDuoCommon = ({
   buttonText,
   onButtonClick,
   ButtonComponent,
+  ...containerProps
 }: ContentItemDuoCommonProps) => {
   const componentClassName = useMemo(() => {
     const classModifiers = [classModifier];
@@ -41,7 +47,7 @@ export const ContentItemDuoCommon = ({
   }, [classModifier, className, isVertical]);
 
   return (
-    <div className={componentClassName}>
+    <div className={componentClassName} {...containerProps}>
       <p className="af-content-item-duo__label">{label}</p>
       {typeof value === "string" ? (
         <p className="af-content-item-duo__value">{value}</p>

--- a/client/apollo/react/src/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/client/apollo/react/src/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -1,12 +1,30 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import { ContentItemDuoCommon } from "../ContentItemDuoCommon";
 import { Button } from "../../../Button/ButtonApollo";
+import { ContentItemDuoCommon } from "../ContentItemDuoCommon";
+
+const ContentItemDuoCommonLabel = "Label";
+const ContentItemDuoCommonValue = "Value";
 
 describe("ContentItemDuoCommon", () => {
-  const ContentItemDuoCommonLabel = "Label";
-  const ContentItemDuoCommonValue = "Value";
+  it("should apply containerProps to the parent div", () => {
+    render(
+      <ContentItemDuoCommon
+        label={ContentItemDuoCommonLabel}
+        value={ContentItemDuoCommonValue}
+        ButtonComponent={Button}
+        id="custom-id"
+        title="custom-title"
+        className="custom-class"
+      />,
+    );
+
+    const container = document.querySelector(".custom-class");
+    expect(container).toHaveAttribute("id", "custom-id");
+    expect(container).toHaveAttribute("title", "custom-title");
+    expect(container).toHaveClass("af-content-item-duo");
+  });
 
   it("should render label and value correctly", () => {
     render(


### PR DESCRIPTION
### Title
Allow passing additional props to ContentItemDuo parent container

### Description
This PR enables the ability to pass extra props to the ContentItemDuo component, which are then forwarded to the parent div element.

### Main Changes
- Extended `ContentItemDuoProps` to include all standard div props using `ComponentProps<"div">`
- Spread additional props (`containerProps`) onto the parent `<div>` in `ContentItemDuoCommon`
- Added a unit test to verify that custom props (e.g., `id`, `title`, `className`) are correctly applied to the parent div

### Impacts
- Increases flexibility for consumers of `ContentItemDuo` by allowing custom HTML attributes and event handlers on the container
- No breaking changes expected; existing usages remain compatible

### Linked Issue
_No linked issue or ticket_

### Screenshots
_N/A_