### PR TITLE
fix(look&feel,apollo): ensure overflow is hidden in progress bar styles

### DIFF
--- a/apps/look-and-feel-stories/src/Stepper/Stepper.mdx
+++ b/apps/look-and-feel-stories/src/Stepper/Stepper.mdx
@@ -8,7 +8,7 @@ import * as StepperStories from "./Stepper.stories";
 To use the header import it like that:
 
 ```tsx
-import { Stepper } from "@axa-fr/design-system-look-and-feel-react";
+import { Stepper } from "@axa-fr/design-system-apollo-react/lf";
 
 const MyComponent = () => <Stepper />;
 ```

--- a/apps/look-and-feel-stories/src/Stepper/Stepper.stories.tsx
+++ b/apps/look-and-feel-stories/src/Stepper/Stepper.stories.tsx
@@ -1,4 +1,4 @@
-import { Stepper } from "@axa-fr/design-system-look-and-feel-react";
+import { Stepper } from "@axa-fr/design-system-apollo-react/lf";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
 
@@ -31,6 +31,6 @@ export const Playground: Story = {
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
   argTypes: {
-    messageType: { control: 'select', options: ['error', 'success'] },
-  }
+    messageType: { control: "select", options: ["error", "success"] },
+  },
 };

--- a/client/apollo/css/src/ProgressBar/ProgressBarCommon.css
+++ b/client/apollo/css/src/ProgressBar/ProgressBarCommon.css
@@ -15,12 +15,14 @@
 
   /* For WebKit browsers */
   &::-webkit-progress-value {
+    border-radius: var(--progress-bar-radius);
     background-color: var(--progress-bar-appearance);
     transition: width 0.75s ease;
   }
 
   /* For Firefox */
   &::-moz-progress-bar {
+    border-radius: var(--progress-bar-radius);
     background-color: var(--progress-bar-appearance);
 
     /* transition doesn't work in Firefox for native progress bars */

--- a/client/apollo/css/src/ProgressBar/ProgressBarCommon.css
+++ b/client/apollo/css/src/ProgressBar/ProgressBarCommon.css
@@ -4,6 +4,7 @@
   height: calc(6 / var(--font-size-base) * 1rem);
   border: none;
   border-radius: var(--progress-bar-radius);
+  overflow: hidden;
   background-color: var(--progress-bar-background-color);
   appearance: var(--progress-bar-appearance);
 


### PR DESCRIPTION
### Title
Fix ProgressBar border radius and update Stepper import paths in the story

### Description
This PR fixes the invisible border radius on the ProgressBar and updates the import paths for the Stepper component in the look-and-feel stories to use the correct package.

### Main Changes
- Added `overflow: hidden;` to the ProgressBar CSS to ensure the border radius is visible.
- Applied `border-radius` to WebKit and Firefox progress bar pseudo-elements for consistent appearance.
- Updated Stepper import paths in `Stepper.mdx` and `Stepper.stories.tsx` to use `@axa-fr/design-system-apollo-react/lf` instead of `@axa-fr/design-system-look-and-feel-react`.

### Impacts
- Visual improvement for the ProgressBar component.
- Ensures correct usage and documentation of the Stepper component in look-and-feel stories.
- No breaking changes or new dependencies.

### Linked Issue
Closes #1508

### Screenshots

<img width="955" height="171" alt="image" src="https://github.com/user-attachments/assets/354bfcff-ba94-414e-bd8d-eabc5cbedb0b" />
