### PR TITLE
fix(slash): remove default on Field MessageType

### DIFF
--- a/slash/react/src/Form/core/Field.tsx
+++ b/slash/react/src/Form/core/Field.tsx
@@ -104,7 +104,7 @@ export const Field = ({
   label,
   forceDisplayMessage,
   message,
-  messageType = MessageTypes.error,
+  messageType,
   required,
   classModifier = "",
   disabled = false,


### PR DESCRIPTION
Remove default for MessageType , error modifier is always applied if forcedisplaymessage is set.
