### PR TITLE
feat(apollo,look&feel)!: tabbar migration

### DIFF
--- a/apps/apollo-stories/src/components/ItemTabBar/ItemTabBar.stories.tsx
+++ b/apps/apollo-stories/src/components/ItemTabBar/ItemTabBar.stories.tsx
@@ -1,7 +1,4 @@
-import {
-  ItemTabBar,
-  itemTabBarVariants,
-} from "@axa-fr/design-system-apollo-react";
+import { ItemTabBar } from "@axa-fr/design-system-apollo-react";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof ItemTabBar> = {
@@ -21,10 +18,6 @@ export const Default: Story = {
     title: "Mes contrats",
   },
   argTypes: {
-    variant: {
-      options: Object.values(itemTabBarVariants),
-      control: { type: "select" },
-    },
     isActive: {
       control: { type: "boolean" },
     },

--- a/apps/apollo-stories/src/components/TabBar/TabBar.mdx
+++ b/apps/apollo-stories/src/components/TabBar/TabBar.mdx
@@ -40,6 +40,23 @@ const MyComponent = () => (
 );
 ```
 
+You can also customize the alignment of the tabs with the `direction` prop.
+
+```tsx
+import { TabBar, tabBarDirection } from "@axa-fr/design-system-apollo-react";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      { title: "Tab 1", content: "Content 1" },
+      { title: "Tab 2", content: "Content 2" },
+      { title: "Tab 3", content: "Content 3" },
+    ]}
+    direction={tabBarDirection.center}
+  />
+);
+```
+
 ## With text content
 
 <Canvas of={TabBarStories.TabBarStory} />

--- a/apps/apollo-stories/src/components/TabBar/TabBar.mdx
+++ b/apps/apollo-stories/src/components/TabBar/TabBar.mdx
@@ -1,0 +1,53 @@
+import { Canvas, Controls, Meta } from "@storybook/blocks";
+import * as TabBarStories from "./TabBar.stories";
+
+<Meta of={TabBarStories} name="TabBar" />
+
+# TabBar
+
+## How to use
+
+To use the tabbar component import it like that:
+
+```tsx
+import { TabBar } from "@axa-fr/design-system-apollo-react";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      { title: "Tab 1", content: "Content 1" },
+      { title: "Tab 2", content: "Content 2" },
+      { title: "Tab 3", content: "Content 3" },
+    ]}
+  />
+);
+```
+
+You can define the default selected tab with the `preSelectedTabIndex` prop.
+
+```tsx
+import { TabBar } from "@axa-fr/design-system-apollo-react";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      { title: "Tab 1", content: "Content 1" },
+      { title: "Tab 2", content: "Content 2" },
+      { title: "Tab 3", content: "Content 3" },
+    ]}
+    preSelectedTabIndex={1}
+  />
+);
+```
+
+## With text content
+
+<Canvas of={TabBarStories.TabBarStory} />
+
+<Controls of={TabBarStories.TabBarStory} />
+
+## With ReactNode content
+
+<Canvas of={TabBarStories.TabBarWithReactNodeStory} />
+
+<Controls of={TabBarStories.TabBarWithReactNodeStory} />

--- a/apps/apollo-stories/src/components/TabBar/TabBar.stories.tsx
+++ b/apps/apollo-stories/src/components/TabBar/TabBar.stories.tsx
@@ -1,0 +1,82 @@
+import {
+  TabBar,
+  tabBarDirection,
+  type TabBarProps,
+} from "@axa-fr/design-system-apollo-react";
+import { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps } from "react";
+
+const meta: Meta<typeof TabBar> = {
+  component: TabBar,
+  title: "Components/TabBar",
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type StoryProps = ComponentProps<typeof TabBar>;
+
+export const TabBarStory: StoryObj<StoryProps> = {
+  name: "TabBar",
+  render: (args) => <TabBar {...args} />,
+  args: {
+    items: [
+      { title: "Mes contrats", content: "Mon numéro de contrat, lorem ipsum " },
+      { title: "Mes informations", content: "Mes informations, lorem ipsum" },
+      { title: "Mes paramètres", content: "Mes paramètres, lorem ipsum" },
+    ],
+    preSelectedTabIndex: 0,
+  },
+  argTypes: {
+    items: {
+      control: { type: "object" },
+    },
+    preSelectedTabIndex: {
+      control: { type: "number" },
+    },
+    direction: {
+      control: "select",
+      options: ["default", "center"],
+    },
+  },
+};
+
+export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
+  name: "TabBarWithReactNode",
+  render: (args) => <TabBar {...args} />,
+  args: {
+    items: [
+      {
+        title: "ReactNode tab 1",
+        content: (
+          <>
+            <h2>Titre 1</h2>
+            <p>Content 1</p>
+          </>
+        ) as TabBarProps["items"][0]["content"],
+      },
+      {
+        title: "ReactNode tab 2",
+        content: (
+          <>
+            <h2>Titre 2</h2>
+            <p>Content 2</p>
+          </>
+        ) as TabBarProps["items"][0]["content"],
+      },
+      {
+        title: "ReactNode tab 3",
+        content: (
+          <>
+            <h2>Titre 3</h2>
+            <p>Content 3</p>
+          </>
+        ) as TabBarProps["items"][0]["content"],
+      },
+    ],
+    direction: tabBarDirection.center,
+    preSelectedTabIndex: 0,
+  },
+};

--- a/apps/apollo-stories/src/components/TabBar/TabBar.stories.tsx
+++ b/apps/apollo-stories/src/components/TabBar/TabBar.stories.tsx
@@ -1,8 +1,4 @@
-import {
-  TabBar,
-  tabBarDirection,
-  type TabBarProps,
-} from "@axa-fr/design-system-apollo-react";
+import { TabBar, tabBarDirection } from "@axa-fr/design-system-apollo-react";
 import { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
 
@@ -55,7 +51,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
             <h2>Titre 1</h2>
             <p>Content 1</p>
           </>
-        ) as TabBarProps["items"][0]["content"],
+        ),
       },
       {
         title: "ReactNode tab 2",
@@ -64,7 +60,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
             <h2>Titre 2</h2>
             <p>Content 2</p>
           </>
-        ) as TabBarProps["items"][0]["content"],
+        ),
       },
       {
         title: "ReactNode tab 3",
@@ -73,7 +69,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
             <h2>Titre 3</h2>
             <p>Content 3</p>
           </>
-        ) as TabBarProps["items"][0]["content"],
+        ),
       },
     ],
     direction: tabBarDirection.center,

--- a/apps/look-and-feel-stories/src/ItemTabBar.stories.tsx
+++ b/apps/look-and-feel-stories/src/ItemTabBar.stories.tsx
@@ -1,7 +1,4 @@
-import {
-  ItemTabBar,
-  itemTabBarVariants,
-} from "@axa-fr/design-system-apollo-react/lf";
+import { ItemTabBar } from "@axa-fr/design-system-apollo-react/lf";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof ItemTabBar> = {
@@ -21,10 +18,6 @@ export const Default: Story = {
     title: "Mes contrats",
   },
   argTypes: {
-    variant: {
-      options: Object.values(itemTabBarVariants),
-      control: { type: "select" },
-    },
     isActive: {
       control: { type: "boolean" },
     },

--- a/apps/look-and-feel-stories/src/TabBar/TabBar.mdx
+++ b/apps/look-and-feel-stories/src/TabBar/TabBar.mdx
@@ -1,0 +1,53 @@
+import { Canvas, Controls, Meta } from "@storybook/blocks";
+import * as TabBarStories from "./TabBar.stories";
+
+<Meta of={TabBarStories} name="TabBar" />
+
+# TabBar
+
+## How to use
+
+To use the tabbar component import it like that:
+
+```tsx
+import { TabBar } from "@axa-fr/design-system-apollo-react/lf";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      { title: "Tab 1", content: "Content 1" },
+      { title: "Tab 2", content: "Content 2" },
+      { title: "Tab 3", content: "Content 3" },
+    ]}
+  />
+);
+```
+
+You can define the default selected tab with the `preSelectedTabIndex` prop.
+
+```tsx
+import { TabBar } from "@axa-fr/design-system-apollo-react/lf";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      { title: "Tab 1", content: "Content 1" },
+      { title: "Tab 2", content: "Content 2" },
+      { title: "Tab 3", content: "Content 3" },
+    ]}
+    preSelectedTabIndex={1}
+  />
+);
+```
+
+## With text content
+
+<Canvas of={TabBarStories.TabBarStory} />
+
+<Controls of={TabBarStories.TabBarStory} />
+
+## With ReactNode content
+
+<Canvas of={TabBarStories.TabBarWithReactNodeStory} />
+
+<Controls of={TabBarStories.TabBarWithReactNodeStory} />

--- a/apps/look-and-feel-stories/src/TabBar/TabBar.mdx
+++ b/apps/look-and-feel-stories/src/TabBar/TabBar.mdx
@@ -40,6 +40,23 @@ const MyComponent = () => (
 );
 ```
 
+You can also customize the alignment of the tabs with the `direction` prop.
+
+```tsx
+import { TabBar, tabBarDirection } from "@axa-fr/design-system-apollo-react/lf";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      { title: "Tab 1", content: "Content 1" },
+      { title: "Tab 2", content: "Content 2" },
+      { title: "Tab 3", content: "Content 3" },
+    ]}
+    direction={tabBarDirection.center}
+  />
+);
+```
+
 ## With text content
 
 <Canvas of={TabBarStories.TabBarStory} />

--- a/apps/look-and-feel-stories/src/TabBar/TabBar.stories.tsx
+++ b/apps/look-and-feel-stories/src/TabBar/TabBar.stories.tsx
@@ -1,0 +1,82 @@
+import {
+  TabBar,
+  tabBarDirection,
+  TabBarProps,
+} from "@axa-fr/design-system-apollo-react";
+import { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps } from "react";
+
+const meta: Meta<typeof TabBar> = {
+  component: TabBar,
+  title: "Components/TabBar",
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type StoryProps = ComponentProps<typeof TabBar>;
+
+export const TabBarStory: StoryObj<StoryProps> = {
+  name: "TabBar",
+  render: (args) => <TabBar {...args} />,
+  args: {
+    items: [
+      { title: "Mes contrats", content: "Mon numéro de contrat, lorem ipsum " },
+      { title: "Mes informations", content: "Mes informations, lorem ipsum" },
+      { title: "Mes paramètres", content: "Mes paramètres, lorem ipsum" },
+    ],
+    preSelectedTabIndex: 0,
+  },
+  argTypes: {
+    items: {
+      control: { type: "object" },
+    },
+    preSelectedTabIndex: {
+      control: { type: "number" },
+    },
+    direction: {
+      control: "select",
+      options: ["default", "center"],
+    },
+  },
+};
+
+export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
+  name: "TabBarWithReactNode",
+  render: (args) => <TabBar {...args} />,
+  args: {
+    items: [
+      {
+        title: "ReactNode tab 1",
+        content: (
+          <>
+            <h2>Titre 1</h2>
+            <p>Content 1</p>
+          </>
+        ) as TabBarProps["items"][0]["content"],
+      },
+      {
+        title: "ReactNode tab 2",
+        content: (
+          <>
+            <h2>Titre 2</h2>
+            <p>Content 2</p>
+          </>
+        ) as TabBarProps["items"][0]["content"],
+      },
+      {
+        title: "ReactNode tab 3",
+        content: (
+          <>
+            <h2>Titre 3</h2>
+            <p>Content 3</p>
+          </>
+        ) as TabBarProps["items"][0]["content"],
+      },
+    ],
+    direction: tabBarDirection.center,
+    preSelectedTabIndex: 0,
+  },
+};

--- a/apps/look-and-feel-stories/src/Tabs.mdx
+++ b/apps/look-and-feel-stories/src/Tabs.mdx
@@ -5,7 +5,7 @@ import * as TabsStories from "./Tabs.stories";
 
 # Tabs
 
-Alert component is **deprecated** and will be removed in the next major version. Please use the TabBar component instead.
+Tabs component is **deprecated** and will be removed in the next major version. Please use the TabBar component instead.
 
 More info here : [Apollo documentation](https://axafrance.github.io/design-system/apollo)
 

--- a/apps/look-and-feel-stories/src/Tabs.mdx
+++ b/apps/look-and-feel-stories/src/Tabs.mdx
@@ -5,6 +5,10 @@ import * as TabsStories from "./Tabs.stories";
 
 # Tabs
 
+Alert component is **deprecated** and will be removed in the next major version. Please use the TabBar component instead.
+
+More info here : [Apollo documentation](https://axafrance.github.io/design-system/apollo)
+
 ## How to use
 
 To use the tabs component import it like that:

--- a/client/apollo/css/src/ItemTabBar/ItemTabBarApollo.css
+++ b/client/apollo/css/src/ItemTabBar/ItemTabBarApollo.css
@@ -2,25 +2,16 @@
 
 .af-item-tab-bar {
   --item-tab-bar-font-color: var(--axa-blue-100);
-  --item-tab-bar-font-size: calc(16 / var(--font-size-base) * 1rem);
-  --item-tab-bar-vertical-padding: var(--spacing-10);
-  --item-tab-bar-horizontal-padding: var(--spacing-8);
-  --item-tab-bar-border-color: var(--axa-blue-20);
+  --item-tab-bar-padding: calc(10 / var(--font-size-base) * 1rem)
+    calc(8 / var(--font-size-base) * 1rem);
+  --item-tab-bar-box-shadow-color: var(--axa-blue-20);
+  --item-tab-bar-outline-color: var(--axa-blue-100);
 
-  &:focus-visible {
-    --item-tab-bar-outline-color: var(--axa-blue-100);
+  &[aria-selected="true"] {
+    --item-tab-bar-box-shadow-color: var(--axa-blue-100);
   }
 
   @media (--desktop-small) {
-    --item-tab-bar-vertical-padding: var(--spacing-16);
-    --item-tab-bar-horizontal-padding: var(--spacing-16);
+    --item-tab-bar-padding: calc(16 / var(--font-size-base) * 1rem);
   }
-}
-
-.af-item-tab-bar--tabBar[aria-selected="true"] {
-  --item-tab-bar-border-color: var(--axa-blue-100);
-}
-
-.af-item-tab-bar--header[aria-selected="true"] {
-  --item-tab-bar-border-color: var(--axa-red-digital-100);
 }

--- a/client/apollo/css/src/ItemTabBar/ItemTabBarCommon.css
+++ b/client/apollo/css/src/ItemTabBar/ItemTabBarCommon.css
@@ -1,28 +1,26 @@
 .af-item-tab-bar {
-  padding: var(--item-tab-bar-vertical-padding, 16px)
-    var(--item-tab-bar-horizontal-padding, 16px);
+  padding: var(--item-tab-bar-padding, 1rem);
   border: none;
-  font-family: var(--font-family-base);
-  font-size: var(--item-tab-bar-font-size);
+  font-size: calc(16 / var(--font-size-base) * 1rem);
   font-weight: var(--item-tab-bar-font-weight, 400);
   line-height: 125%;
   color: var(--item-tab-bar-font-color);
   background-color: transparent;
-  box-shadow: inset 0 var(--item-tab-bar-border-width, -1px) 0 0
-    var(--item-tab-bar-border-color);
+  box-shadow: inset 0 var(--item-tab-bar-box-shadow-width, -1px) 0 0
+    var(--item-tab-bar-box-shadow-color);
+  outline: none;
 
-  &:hover {
-    --item-tab-bar-border-width: -4px;
+  &:hover,
+  &[aria-selected="true"] {
+    --item-tab-bar-box-shadow-width: -4px;
   }
 
   &:focus-visible {
     outline: 2px solid var(--item-tab-bar-outline-color);
     outline-offset: 2px;
   }
-}
 
-.af-item-tab-bar--tabBar[aria-selected="true"],
-.af-item-tab-bar--header[aria-selected="true"] {
-  --item-tab-bar-border-width: -4px;
-  --item-tab-bar-font-weight: 600;
+  &[aria-selected="true"] {
+    --item-tab-bar-font-weight: 600;
+  }
 }

--- a/client/apollo/css/src/ItemTabBar/ItemTabBarLF.css
+++ b/client/apollo/css/src/ItemTabBar/ItemTabBarLF.css
@@ -2,31 +2,15 @@
 
 .af-item-tab-bar {
   --item-tab-bar-font-color: var(--color-gray-900);
-  --item-tab-bar-font-size: calc(18 / var(--font-size-base) * 1rem);
-  --item-tab-bar-border-color: var(--color-blue-400);
+  --item-tab-bar-box-shadow-color: var(--color-blue-400);
+  --item-tab-bar-outline-color: var(--color-axa);
 
-  &:focus {
-    outline: none;
-  }
-
-  &:focus-visible {
-    --item-tab-bar-outline-color: var(--color-blue-3);
-
-    outline: 2px solid var(--item-tab-bar-outline-color);
-    outline-offset: 2px;
+  &[aria-selected="true"] {
+    --item-tab-bar-font-color: var(--color-axa);
+    --item-tab-bar-box-shadow-color: var(--color-axa);
   }
 
   @media (--desktop-small) {
     --item-tab-bar-font-size: calc(20 / var(--font-size-base) * 1rem);
   }
-}
-
-.af-item-tab-bar--tabBar[aria-selected="true"] {
-  --item-tab-bar-font-color: var(--color-axa);
-  --item-tab-bar-border-color: var(--color-axa);
-}
-
-.af-item-tab-bar--header[aria-selected="true"] {
-  --item-tab-bar-font-color: var(--color-axa);
-  --item-tab-bar-border-color: var(--color-red);
 }

--- a/client/apollo/css/src/TabBar/TabBarApollo.css
+++ b/client/apollo/css/src/TabBar/TabBarApollo.css
@@ -1,0 +1,1 @@
+@import "./TabBarCommon.css";

--- a/client/apollo/css/src/TabBar/TabBarCommon.css
+++ b/client/apollo/css/src/TabBar/TabBarCommon.css
@@ -1,0 +1,24 @@
+.af-tabbar {
+  display: flex;
+  flex-direction: column;
+
+  & > [role="tablist"] {
+    display: flex;
+    width: 100%;
+    box-shadow: inset 0 -2px 0 0 var(--tab-bar-box-shadow-color);
+  }
+
+  & > [role="tabpanel"][aria-hidden="true"] {
+    display: none;
+  }
+}
+
+.af-tabbar.af-tabbar--center {
+  & > [role="tablist"] {
+    justify-content: center;
+
+    & > [role="tab"] {
+      flex-grow: 1;
+    }
+  }
+}

--- a/client/apollo/css/src/TabBar/TabBarLF.css
+++ b/client/apollo/css/src/TabBar/TabBarLF.css
@@ -1,0 +1,5 @@
+@import "./TabBarCommon.css";
+
+.af-tab-bar {
+  --tab-bar-box-shadow-color: var(--color-blue-400);
+}

--- a/client/apollo/react/src/ItemTabBar/ItemTabBarApollo.tsx
+++ b/client/apollo/react/src/ItemTabBar/ItemTabBarApollo.tsx
@@ -1,7 +1,3 @@
 import "@axa-fr/design-system-apollo-css/dist/ItemTabBar/ItemTabBarApollo.css";
 
-export {
-  ItemTabBar,
-  itemTabBarVariants,
-  type ItemTabBarVariants,
-} from "./ItemTabBarCommon";
+export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBarCommon";

--- a/client/apollo/react/src/ItemTabBar/ItemTabBarCommon.tsx
+++ b/client/apollo/react/src/ItemTabBar/ItemTabBarCommon.tsx
@@ -1,29 +1,14 @@
-import { ComponentPropsWithRef, forwardRef, ReactNode } from "react";
+import { ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../utilities/getComponentClassName";
 
-export const itemTabBarVariants = {
-  tabBar: "tabBar",
-  header: "header",
-} as const;
-export type ItemTabBarVariants = keyof typeof itemTabBarVariants;
-
-type ItemTabBarProps = ComponentPropsWithRef<"button"> & {
-  variant?: ItemTabBarVariants;
+export type ItemTabBarProps = ComponentPropsWithRef<"button"> & {
   isActive?: boolean;
-  icon?: ReactNode;
   title: string;
 };
 
 export const ItemTabBar = forwardRef<HTMLButtonElement, ItemTabBarProps>(
-  (
-    { variant = "tabBar", isActive = false, icon, title, className, ...props },
-    ref,
-  ) => {
-    const classNames = getComponentClassName(
-      "af-item-tab-bar",
-      className,
-      variant,
-    );
+  ({ isActive = false, title, className, ...props }, ref) => {
+    const classNames = getComponentClassName("af-item-tab-bar", className);
 
     return (
       <button
@@ -34,7 +19,6 @@ export const ItemTabBar = forwardRef<HTMLButtonElement, ItemTabBarProps>(
         className={classNames}
         {...props}
       >
-        {icon}
         {title}
       </button>
     );

--- a/client/apollo/react/src/ItemTabBar/ItemTabBarLF.tsx
+++ b/client/apollo/react/src/ItemTabBar/ItemTabBarLF.tsx
@@ -1,7 +1,3 @@
 import "@axa-fr/design-system-apollo-css/dist/ItemTabBar/ItemTabBarLF.css";
 
-export {
-  ItemTabBar,
-  itemTabBarVariants,
-  type ItemTabBarVariants,
-} from "./ItemTabBarCommon";
+export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBarCommon";

--- a/client/apollo/react/src/ItemTabBar/__test__/ItemTabBar.test.tsx
+++ b/client/apollo/react/src/ItemTabBar/__test__/ItemTabBar.test.tsx
@@ -1,29 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { axe } from "jest-axe";
-import {
-  ItemTabBar,
-  ItemTabBarVariants,
-  itemTabBarVariants,
-} from "../ItemTabBarCommon";
+import { ItemTabBar } from "../ItemTabBarCommon";
 
 describe("ItemTabBar component", () => {
-  it.each(Object.keys(itemTabBarVariants))(
-    "should render correctly with variant %s",
-    (variant) => {
-      render(
-        <ItemTabBar
-          variant={variant as ItemTabBarVariants}
-          aria-label="test"
-          title="This is title"
-        />,
-      );
-      const container = screen.getByLabelText("test");
-      expect(container).toHaveClass(
-        `af-item-tab-bar af-item-tab-bar--${variant}`,
-      );
-    },
-  );
+  it("should render correctly", () => {
+    render(<ItemTabBar aria-label="test" title="This is title" />);
+    const container = screen.getByLabelText("test");
+    expect(container).toHaveClass("af-item-tab-bar");
+  });
 
   describe("A11Y", () => {
     it("shouldn't have an accessibility violation <ItemTabBar />", async () => {

--- a/client/apollo/react/src/ItemTabBar/__test__/ItemTabBar.test.tsx
+++ b/client/apollo/react/src/ItemTabBar/__test__/ItemTabBar.test.tsx
@@ -8,6 +8,16 @@ describe("ItemTabBar component", () => {
     render(<ItemTabBar aria-label="test" title="This is title" />);
     const container = screen.getByLabelText("test");
     expect(container).toHaveClass("af-item-tab-bar");
+    expect(screen.getByRole("tab")).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByText("This is title")).toBeInTheDocument();
+  });
+
+  it("should render correctly with isActive true", () => {
+    render(<ItemTabBar aria-label="test" title="This is title" isActive />);
+    const container = screen.getByLabelText("test");
+    expect(container).toHaveClass("af-item-tab-bar");
+    expect(screen.getByRole("tab")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("This is title")).toBeInTheDocument();
   });
 
   describe("A11Y", () => {

--- a/client/apollo/react/src/TabBar/TabBarApollo.tsx
+++ b/client/apollo/react/src/TabBar/TabBarApollo.tsx
@@ -1,0 +1,13 @@
+import "@axa-fr/design-system-apollo-css/dist/TabBar/TabBarApollo.css";
+import { ItemTabBar } from "../ItemTabBar/ItemTabBarApollo";
+import { TabBarCommon, type TabBarProps } from "./TabBarCommon";
+
+export {
+  tabBarDirection,
+  type TabBarProps,
+  type TabBarDirection,
+} from "./TabBarCommon";
+
+export const TabBar = (props: TabBarProps) => (
+  <TabBarCommon {...props} ItemTabBarComponent={ItemTabBar} />
+);

--- a/client/apollo/react/src/TabBar/TabBarCommon.tsx
+++ b/client/apollo/react/src/TabBar/TabBarCommon.tsx
@@ -1,25 +1,42 @@
-import "@axa-fr/design-system-look-and-feel-css/dist/Tabs/Tabs.scss";
+import {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  ComponentType,
+  ReactNode,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import classNames from "classnames";
-import { ReactNode, useCallback, useRef, useState } from "react";
+import { ItemTabBar } from "../ItemTabBar/ItemTabBarCommon";
 
-export enum Direction {
-  center = "center",
-}
+export const tabBarDirection = {
+  center: "center",
+  left: "left",
+} as const;
 
-type TabsProps = {
-  items: { title: string; content: string | ReactNode; icon?: ReactNode }[];
+export type TabBarDirection = keyof typeof tabBarDirection;
+
+export type TabBarProps = {
+  items: (ComponentPropsWithoutRef<typeof ItemTabBar> & {
+    content: ReactNode;
+  })[];
   preSelectedTabIndex?: number;
-  direction?: Direction;
+  direction?: TabBarDirection;
 };
 
-/**
- * @deprecated Use `TabBar` instead.
- * */
-export const TabsClient = ({
+type TabBarPropsCommon = TabBarProps & {
+  ItemTabBarComponent: ComponentType<ComponentProps<typeof ItemTabBar>>;
+};
+
+const CLASS_NAME = "af-tabbar";
+
+export const TabBarCommon = ({
   items,
   preSelectedTabIndex,
-  direction,
-}: TabsProps) => {
+  direction = "left",
+  ItemTabBarComponent,
+}: TabBarPropsCommon) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(
     preSelectedTabIndex || 0,
   );
@@ -72,15 +89,14 @@ export const TabsClient = ({
   return (
     <div
       className={classNames(
-        "af-tabs-client",
-        direction === Direction.center ? `af-tabs-client--center` : "",
+        CLASS_NAME,
+        direction === tabBarDirection.center ? `${CLASS_NAME}--center` : "",
       )}
     >
       <div role="tablist" ref={tablistRef}>
-        {items.map((item, index) => (
-          <button
-            key={`tab-${item.title}`}
-            role="tab"
+        {items.map(({ title }, index) => (
+          <ItemTabBarComponent
+            key={`tab-${title}`}
             id={`tab-${index}`}
             aria-selected={isActive(index)}
             aria-controls={`tabpanel-${index}`}
@@ -89,12 +105,9 @@ export const TabsClient = ({
             ref={(element: HTMLButtonElement) => {
               buttonRefs.current[index] = element;
             }}
-            type="button"
             tabIndex={isActive(index) ? 0 : -1}
-          >
-            {item.icon}
-            <span>{item.title}</span>
-          </button>
+            title={title}
+          />
         ))}
       </div>
 

--- a/client/apollo/react/src/TabBar/TabBarCommon.tsx
+++ b/client/apollo/react/src/TabBar/TabBarCommon.tsx
@@ -1,6 +1,5 @@
 import {
   ComponentProps,
-  ComponentPropsWithoutRef,
   ComponentType,
   ReactNode,
   useCallback,
@@ -8,7 +7,10 @@ import {
   useState,
 } from "react";
 import classNames from "classnames";
-import { ItemTabBar } from "../ItemTabBar/ItemTabBarCommon";
+import {
+  ItemTabBar,
+  type ItemTabBarProps,
+} from "../ItemTabBar/ItemTabBarCommon";
 
 export const tabBarDirection = {
   center: "center",
@@ -18,9 +20,9 @@ export const tabBarDirection = {
 export type TabBarDirection = keyof typeof tabBarDirection;
 
 export type TabBarProps = {
-  items: (ComponentPropsWithoutRef<typeof ItemTabBar> & {
+  items: ({
     content: ReactNode;
-  })[];
+  } & Omit<ItemTabBarProps, "content">)[];
   preSelectedTabIndex?: number;
   direction?: TabBarDirection;
 };

--- a/client/apollo/react/src/TabBar/TabBarLF.tsx
+++ b/client/apollo/react/src/TabBar/TabBarLF.tsx
@@ -1,0 +1,13 @@
+import "@axa-fr/design-system-apollo-css/dist/TabBar/TabBarLF.css";
+import { ItemTabBar } from "../ItemTabBar/ItemTabBarLF";
+import { TabBarCommon, type TabBarProps } from "./TabBarCommon";
+
+export {
+  tabBarDirection,
+  type TabBarProps,
+  type TabBarDirection,
+} from "./TabBarCommon";
+
+export const TabBar = (props: TabBarProps) => (
+  <TabBarCommon {...props} ItemTabBarComponent={ItemTabBar} />
+);

--- a/client/apollo/react/src/TabBar/__test__/TabBar.test.tsx
+++ b/client/apollo/react/src/TabBar/__test__/TabBar.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
+import { ItemTabBar } from "../../ItemTabBar/ItemTabBarCommon";
+import {
+  TabBarCommon as TabBar,
+  tabBarDirection,
+  type TabBarDirection,
+} from "../TabBarCommon";
+
+const tabs = [
+  { title: "Tab 1", content: "Content 1" },
+  { title: "Tab 2", content: "Content 2" },
+  { title: "Tab 3", content: "Content 3" },
+];
+
+describe("TabBar", () => {
+  it("should render the component", () => {
+    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+  });
+
+  it("should render the component with the second tab pre-selected", () => {
+    render(
+      <TabBar
+        items={tabs}
+        ItemTabBarComponent={ItemTabBar}
+        preSelectedTabIndex={1}
+      />,
+    );
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 2")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[1]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should render the component with centered tabs", () => {
+    render(
+      <TabBar
+        items={tabs}
+        ItemTabBarComponent={ItemTabBar}
+        direction={tabBarDirection.center as TabBarDirection}
+      />,
+    );
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    expect(screen.getByRole("tablist").parentElement).toHaveClass(
+      "af-tabbar af-tabbar--center",
+    );
+  });
+
+  it("should change tab on click", async () => {
+    const user = userEvent.setup();
+    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    await user.click(screen.getAllByRole("tab")[1]);
+    expect(screen.getByText("Content 2")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[1]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should change tab on arrow right key press", async () => {
+    const user = userEvent.setup();
+    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    screen.getAllByRole("tab")[0].focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByText("Content 2")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[1]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should change tab on arrow left key press", async () => {
+    const user = userEvent.setup();
+    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    screen.getAllByRole("tab")[0].focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByText("Content 3")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[2]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should have no accessibility violations", async () => {
+    const { container } = render(
+      <TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/client/apollo/react/src/TabBar/__test__/TabBar.test.tsx
+++ b/client/apollo/react/src/TabBar/__test__/TabBar.test.tsx
@@ -15,12 +15,33 @@ const tabs = [
   { title: "Tab 3", content: "Content 3" },
 ];
 
+const tabs2 = [
+  { title: "Tab 1", content: <p>Content 1</p> },
+  { title: "Tab 2", content: <p>Content 2</p> },
+  { title: "Tab 3", content: <p>Content 3</p> },
+];
+
 describe("TabBar", () => {
   it("should render the component", () => {
     render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
     expect(screen.getByRole("tablist")).toBeInTheDocument();
     expect(screen.getAllByRole("tab")).toHaveLength(3);
     expect(screen.getByText("Content 1")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[0]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should render the component with content Element", () => {
+    render(<TabBar items={tabs2} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[0]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("should render the component with the second tab pre-selected", () => {

--- a/client/apollo/react/src/index.ts
+++ b/client/apollo/react/src/index.ts
@@ -60,9 +60,14 @@ export {
 } from "./Icon/IconApollo";
 export {
   ItemTabBar,
-  itemTabBarVariants,
-  type ItemTabBarVariants,
+  type ItemTabBarProps,
 } from "./ItemTabBar/ItemTabBarApollo";
+export {
+  TabBar,
+  type TabBarProps,
+  tabBarDirection,
+  type TabBarDirection,
+} from "./TabBar/TabBarApollo";
 export { Footer, type FooterProps } from "./Layout/Footer/FooterApollo";
 export { Link, linkVariants, type LinkVariants } from "./Link/LinkApollo";
 export {

--- a/client/apollo/react/src/indexLF.ts
+++ b/client/apollo/react/src/indexLF.ts
@@ -62,11 +62,13 @@ export {
   type IconSizeVariants,
   type IconVariants,
 } from "./Icon/IconLF";
+export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBar/ItemTabBarLF";
 export {
-  ItemTabBar,
-  itemTabBarVariants,
-  type ItemTabBarVariants,
-} from "./ItemTabBar/ItemTabBarLF";
+  TabBar,
+  type TabBarProps,
+  tabBarDirection,
+  type TabBarDirection,
+} from "./TabBar/TabBarLF";
 export { Footer, type FooterProps } from "./Layout/Footer/FooterLF";
 export { Link, linkVariants, type LinkVariants } from "./Link/LinkLF";
 export {

--- a/client/look-and-feel/react/src/ItemTabBar/ItemTabBar.tsx
+++ b/client/look-and-feel/react/src/ItemTabBar/ItemTabBar.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 export {
   ItemTabBar,
-  itemTabBarVariants,
-  type ItemTabBarVariants,
+  type ItemTabBarProps,
 } from "@axa-fr/design-system-apollo-react/lf";

--- a/client/look-and-feel/react/src/TabBar/TabBar.tsx
+++ b/client/look-and-feel/react/src/TabBar/TabBar.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
+export {
+  TabBar,
+  type TabBarProps,
+  tabBarDirection,
+  type TabBarDirection,
+} from "@axa-fr/design-system-apollo-react/lf";

--- a/client/look-and-feel/react/src/index.ts
+++ b/client/look-and-feel/react/src/index.ts
@@ -59,11 +59,13 @@ export {
   type IconVariants,
 } from "./Icon/Icon";
 export { IconBg } from "./IconBg";
+export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBar/ItemTabBar";
 export {
-  ItemTabBar,
-  itemTabBarVariants,
-  type ItemTabBarVariants,
-} from "./ItemTabBar/ItemTabBar";
+  TabBar,
+  type TabBarProps,
+  tabBarDirection,
+  type TabBarDirection,
+} from "./TabBar/TabBar";
 export { Footer } from "./Layout/Footer/Footer";
 export { BurgerMenu, Header, NavBar, PreviousLink } from "./Layout/Header";
 export { Link } from "./Link/Link";


### PR DESCRIPTION
Migration du composant ItemTabBar et TabBar vers le dossier Apollo 
Utilisation de l'atome ItemTabBar dans TabBar
Ajout des tests
suppression des variants sur l'ItemTabBar car les Items de menu seront faits à part.
Suppression des icons sur les l'ItemTabBar

https://github.com/AxaFrance/design-system/issues/887
https://github.com/AxaFrance/design-system/issues/866

<img width="819" height="480" alt="image" src="https://github.com/user-attachments/assets/13ce9f1e-d14b-4b22-aa66-53e40e1f754a" />

