### PR TITLE
fix(apollo,look&feel): hide marker for ios

### DIFF
--- a/client/apollo/css/src/AccordionCore/AccordionCoreCommon.css
+++ b/client/apollo/css/src/AccordionCore/AccordionCoreCommon.css
@@ -21,6 +21,10 @@
   line-height: var(--accordion-title-line-height);
   cursor: pointer;
 
+  &::-webkit-details-marker {
+    display: none;
+  }
+
   p {
     margin: 0;
   }


### PR DESCRIPTION
Bug on IOS :

the native marker still displayed

<img width="373" height="743" alt="image" src="https://github.com/user-attachments/assets/9a2d8dcd-0d66-446e-940d-3f579edec88b" />
