### PR TITLE
Fix CSS tokens for Card Checkbox/Radio options in Apollo and LF themes

### DIFF
--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css
@@ -6,6 +6,7 @@
   --checkbox-option-color-subtitle: var(--neutral-80);
   --checkbox-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --checkbox-option-border-radius: var(--radius-8);
+  --checkbox-option-background-color: var(--white);
 
   &:hover,
   &:focus-visible,

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.css
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionCommon.css
@@ -1,6 +1,5 @@
 .af-card-checkbox-option {
   --checkbox-option-border-width: 1px;
-  --checkbox-option-background-color: var(--white);
 
   position: relative;
   display: flex;

--- a/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.css
+++ b/client/apollo/css/src/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.css
@@ -6,6 +6,7 @@
   --checkbox-option-color-subtitle: var(--color-gray-700);
   --checkbox-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --checkbox-option-border-radius: var(--radius-4);
+  --checkbox-option-background-color: var(--color-white);
 
   &:hover,
   &:focus-visible,

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionApollo.css
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionApollo.css
@@ -6,6 +6,7 @@
   --radio-option-color-subtitle: var(--neutral-80);
   --radio-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --radio-option-border-radius: var(--radius-8);
+  --radio-option-background-color: var(--white);
 
   &:hover,
   &:focus-visible,

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.css
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionCommon.css
@@ -1,6 +1,5 @@
 .af-card-radio-option {
   --radio-option-border-width: 1px;
-  --radio-option-background-color: var(--white);
 
   position: relative;
   display: flex;

--- a/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionLF.css
+++ b/client/apollo/css/src/Form/Radio/CardRadioOption/CardRadioOptionLF.css
@@ -6,6 +6,7 @@
   --radio-option-color-subtitle: var(--color-gray-700);
   --radio-option-gap: calc(8 / var(--font-size-base) * 1rem);
   --radio-option-border-radius: var(--radius-4);
+  --radio-option-background-color: var(--color-white);
 
   &:hover,
   &:focus-visible,


### PR DESCRIPTION
### Description
Adjust CSS custom properties so background color tokens for card-style checkbox and radio options are defined in theme-specific files (Apollo and LF) and removed from the common files to avoid unintended overrides across themes.

### Main Changes
- Move background color CSS custom properties from common files into theme-specific files for both checkbox and radio card options.

### Impacts
- Visual: Background colors for card-style checkbox and radio options will now be driven by theme-specific variables; visuals may change slightly where the common token previously applied.
- Compatibility: No API changes; CSS behavior is adjusted. Ensure themes have the expected `--white` / `--color-white` variables available to avoid unexpected transparent backgrounds.

### Linked Issue
N/A

### Screenshots
N/A
