### PR TITLE
Fix labels in GitHub issue templates (Look&Feel & Apollo)

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-look&feel_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2-look&feel_bug_report.md
@@ -2,7 +2,7 @@
 name: Look&Feel Bug report
 about: Create a report to help us improve Look&Feel Design System
 title: ''
-labels: ['bug', "look'n feel (Espace Client)"]
+labels: ['bug', "[Client] (look'n feel Espace Client)"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/3-apollo_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/3-apollo_bug_report.md
@@ -2,7 +2,7 @@
 name: Apollo Bug report
 about: Create a report to help us improve Apollo Design System
 title: ''
-labels: ['bug', 'Apollo AXA.fr']
+labels: ['bug', '[Prospect] (Apollo AXA.fr)']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/5-look&feel_accessibility_issue.md
+++ b/.github/ISSUE_TEMPLATE/5-look&feel_accessibility_issue.md
@@ -2,7 +2,7 @@
 name: Look&Feel Accessibility report
 about: Create an accessibility report to help us improve Look&Feel Design System
 title: "[a11y] "
-labels: ['bug', 'accessibility', "look'n feel (Espace Client)"]
+labels: ['bug', 'accessibility', "[Client] (look'n feel Espace Client)"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/6-apollo_accessibility_issue.md
+++ b/.github/ISSUE_TEMPLATE/6-apollo_accessibility_issue.md
@@ -2,7 +2,7 @@
 name: Apollo Accessibility report
 about: Create an accessibility report to help us improve Apollo Design System
 title: "[a11y] "
-labels: ['bug', 'accessibility', 'Apollo AXA.fr']
+labels: ['bug', 'accessibility', '[Prospect] (Apollo AXA.fr)']
 assignees: ''
 
 ---


### PR DESCRIPTION
### Description
Standardize and correct labels in several GitHub issue templates to clearly distinguish client vs prospect contexts and improve issue triage.

### Main Changes
- `.github/ISSUE_TEMPLATE/2-look&feel_bug_report.md`
  - Updated `labels` from `['bug', "look'n feel (Espace Client)"]` to `['bug', "[Client] (look'n feel Espace Client)"]`.
- `.github/ISSUE_TEMPLATE/3-apollo_bug_report.md`
  - Updated `labels` from `['bug', 'Apollo AXA.fr']` to `['bug', '[Prospect] (Apollo AXA.fr)']`.
- `.github/ISSUE_TEMPLATE/5-look&feel_accessibility_issue.md`
  - Updated `labels` from `['bug', 'accessibility', "look'n feel (Espace Client)"]` to `['bug', 'accessibility', "[Client] (look'n feel Espace Client)"]`.
- `.github/ISSUE_TEMPLATE/6-apollo_accessibility_issue.md`
  - Updated `labels` from `['bug', 'accessibility', 'Apollo AXA.fr']` to `['bug', 'accessibility', '[Prospect] (Apollo AXA.fr)']`.

### Impacts
- Improves clarity when filing issues by explicitly marking templates for Client vs Prospect contexts.
- May require updating any automation, saved filters, project boards, or GitHub Actions that referenced the previous label names.
- No runtime or performance impact on the codebase.

### Linked Issue
N/A

### Screenshots
N/A