### PR TITLE
feat(slash): add FormHelper and ItemFormHelper

### DIFF
--- a/apps/slash-stories/src/FormHelper/FormHelper.mdx
+++ b/apps/slash-stories/src/FormHelper/FormHelper.mdx
@@ -1,0 +1,112 @@
+
+import { Canvas, Controls, Description, Meta } from "@storybook/blocks";
+import * as Stories from "./FormHelper.stories";
+
+<Meta of={Stories} />
+
+# FormHelper
+
+The `FormHelper` component displays one or more sections, each with an optional title and a list of steps. Each step is rendered using `ItemFormHelper`.
+
+## Import
+
+```javascript
+import { FormHelper } from "@axa-fr/design-system-slash-react";
+```
+
+## Usage: with title
+
+<Canvas of={Stories.WithTitle} />
+
+## Usage: without title
+
+<Canvas of={Stories.WithoutTitle} />
+
+## Example
+
+```jsx
+// One section with title
+<FormHelper
+    formTitle="Assistant de saisie"
+    sections={[
+      {
+        title: "Mon formulaire",
+        items: [
+          { label: "En cours", mode: "edited" },
+          { label: "A compléter", mode: "locked" },
+          { label: "Validé", mode: "validated" },
+          { label: "Désactivé", mode: "disabled" },
+        ]
+      }
+    ]}
+/>
+
+// Multiple sections
+<FormHelper
+    formTitle="Assistant de saisie"
+    sections={[
+      {
+          title: "Mon formulaire",
+          items: [
+            { label: "Configuration", mode: "validated" },
+            { label: "Souscription", mode: "validated" },
+            { label: "Payement", mode: "edited" },
+          ],
+        },
+        {
+          title: "Deuxième section avec ancres",
+          items: [
+            { label: "Préférences", mode: "locked", anchor: "preferences" },
+            { label: "Souscription", mode: "locked", anchor: "souscription" },
+            { label: "Retractation", mode: "locked", anchor: "retractation" },
+          ],
+        },
+      ]}
+/>
+
+// Section without title
+<FormHelper
+    formTitle="Assistant de saisie"
+    sections={[
+      {
+        items: [
+          { label: "En cours", mode: "edited" },
+          { label: "A compléter", mode: "locked" },
+          { label: "Validé", mode: "validated" },
+          { label: "Désactivé", mode: "disabled" },
+        ]
+      }
+    ]}
+/>
+```
+
+## Accessibility
+
+- The form title is rendered as an `<h2>` for better screen reader support.
+- The sections title are rendered as `<h3>` for better screen reader support.
+- The component uses semantic HTML (`<ul>`, `<li>`, `<h2>`, `<h3>`) for proper list and navigation structure.
+
+---
+
+## Properties
+
+### formTitle
+
+- **Type:** `string` (required)
+- **Description:** Title of the form, rendered as an `<h2>` for accessibility.
+
+### sections
+
+
+- **Type:** `Array<{ title?: string; items: Array<{ label: string; mode: string; ancre?: string }> }>` (required)
+
+- **Description:**
+  - Each section object can have:
+    - `title`: **string** (optional) — The section title, rendered as an `<h3>` above the list of steps.
+    - `items`: **Array** — The list of step objects for this section.
+      - Each item object can have:
+        - `label`: **string** — The label for the step, displayed in the list.
+        - `mode`: **string** — The visual state of the step (`locked`, `edited`, `validated`, etc.).
+        - `ancre`: **string** (optional) — If provided, the label is rendered as a link to the anchor.
+
+For more advanced usage, see the Storybook controls and playground below.

--- a/apps/slash-stories/src/FormHelper/FormHelper.stories.tsx
+++ b/apps/slash-stories/src/FormHelper/FormHelper.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FormHelper } from "@axa-fr/design-system-slash-react";
+
+const meta: Meta<typeof FormHelper> = {
+  component: FormHelper,
+  title: "Components/FormHelper/FormHelper",
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithTitle: Story = {
+  render: () => (
+    <FormHelper
+      formTitle="Assistant de saisie"
+      sections={[
+        {
+          title: "Mon formulaire",
+          items: [
+            { label: "Configuration", mode: "validated" },
+            { label: "Souscription", mode: "validated" },
+            { label: "Payement", mode: "edited" },
+          ],
+        },
+        {
+          title: "Deuxième section avec ancres",
+          items: [
+            { label: "Préférences", mode: "locked", anchor: "preferences" },
+            { label: "Souscription", mode: "locked", anchor: "subscription" },
+            { label: "Retractation", mode: "locked", anchor: "retraction" },
+          ],
+        },
+      ]}
+    />
+  ),
+};
+
+export const WithoutTitle: Story = {
+  render: () => (
+    <FormHelper
+      formTitle="Assistant de saisie"
+      sections={[
+        {
+          items: [
+            { label: "En cours", mode: "edited" },
+            { label: "A compléter", mode: "locked" },
+            { label: "Validé", mode: "validated" },
+            { label: "Désactivé", mode: "disabled" },
+          ],
+        },
+      ]}
+    />
+  ),
+};

--- a/apps/slash-stories/src/FormHelper/ItemFormHelper.mdx
+++ b/apps/slash-stories/src/FormHelper/ItemFormHelper.mdx
@@ -1,0 +1,67 @@
+
+import { Canvas, Controls, Description, Meta } from "@storybook/blocks";
+import * as Stories from "./ItemFormHelper.stories";
+
+<Meta of={Stories} />
+
+# ItemFormHelper
+
+The `ItemFormHelper` component displays a single step in a form helper or stepper, with different visual states depending on its `mode` prop. It can optionally render as a link if the `ancre` prop is provided.
+
+## Import
+
+```javascript
+import { ItemFormHelper } from "@axa-fr/design-system-slash-react";
+```
+
+## Usage without anchor
+
+<Canvas of={Stories.Default} />
+
+## Usage with anchor
+
+If the `ancre` prop is provided, the label is rendered as a link to the corresponding anchor in the page.
+
+
+<Canvas of={Stories.Anchor} />
+
+## Modes
+
+The `mode` prop controls the visual state of the step:
+
+- `locked`: The step is locked and not accessible. The label is shown as plain text and styled as blocked.
+- `edited`: The step is currently being edited. The label is styled as active.
+- `validated`: The step is completed and validated. The label is styled as validated.
+- `disabled`: The step is disabled and not accessible.
+
+## Example
+
+```jsx
+<ItemFormHelper label="Locked" mode="locked" />
+<ItemFormHelper label="Edited" mode="edited" ancre="etape2" />
+<ItemFormHelper label="Validated" mode="validated" ancre="etape3" />
+<ItemFormHelper label="Disabled" mode="disabled" />
+```
+
+## Accessibility
+
+- The anchor (`<a>`) includes an `aria-label` for better screen reader support.
+- The component uses semantic HTML (`<li>`, `<a>`, `<span>`) for proper list and navigation structure.
+
+---
+
+## Properties
+
+**label**  
+Type: `string` (required)  
+The text displayed for the step. Identifies the step to the user.
+
+**mode**  
+Type: `string` (required)  
+Controls the visual state of the step. Possible values are `locked`, `edited`, `validated`, or `disabled`.
+
+**ancre**  
+Type: `string` (optional)  
+If provided, renders the label as a link to the specified anchor on the page.
+
+For more advanced usage, see the Storybook controls and playground below.

--- a/apps/slash-stories/src/FormHelper/ItemFormHelper.stories.tsx
+++ b/apps/slash-stories/src/FormHelper/ItemFormHelper.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ItemFormHelper } from "@axa-fr/design-system-slash-react";
+
+const meta: Meta<typeof ItemFormHelper> = {
+  component: ItemFormHelper,
+  title: "Components/FormHelper/ItemFormHelper",
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <>
+      <ItemFormHelper label="En cours" mode="edited" ancre="" />
+      <ItemFormHelper label="A compléter" mode="locked" ancre="" />
+      <ItemFormHelper label="Validé" mode="validated" ancre="" />
+      <ItemFormHelper label="Désactivé" mode="disabled" ancre="" />
+    </>
+  ),
+};
+
+export const Anchor: Story = {
+  render: () => (
+    <>
+      <ItemFormHelper label="En cours" mode="edited" ancre="versEnCours" />
+      <ItemFormHelper label="A compléter" mode="locked" ancre="versLocked" />
+      <ItemFormHelper label="Validé" mode="validated" ancre="VersValider" />
+    </>
+  ),
+};

--- a/slash/css/src/FormHelper/FormHelper.css
+++ b/slash/css/src/FormHelper/FormHelper.css
@@ -1,0 +1,36 @@
+.af-form-helper__legend {
+  padding: 0;
+  border-bottom: 1px solid var(--gray20);
+  font-size: 1rem;
+  background-color: var(--white);
+
+  & ul {
+    width: 100%;
+    margin: 0.5rem;
+    padding: 0;
+    columns: 3;
+    list-style: none;
+
+    & li {
+      padding-left: 0.75rem;
+    }
+  }
+}
+
+.af-form-helper__main-content {
+  padding: 1rem 1.25rem;
+  background-color: var(--gray10);
+
+  & ul {
+    margin-bottom: 1rem;
+    padding: 0;
+  }
+
+  & ul:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.af-form-helper__section-title {
+  font-size: 1.125rem;
+}

--- a/slash/css/src/FormHelper/ItemFormHelper.css
+++ b/slash/css/src/FormHelper/ItemFormHelper.css
@@ -1,0 +1,60 @@
+:root {
+  --step-background-color: transparent;
+  --link-color: var(--gray80);
+}
+
+.af-item-form-helper {
+  line-height: 1.5rem;
+  list-style: none;
+
+  a {
+    color: var(--link-color);
+  }
+
+  &::before {
+    display: inline-block;
+    width: 0.6rem;
+    height: 0.6rem;
+    margin-right: 8px;
+    margin-left: 2px;
+    border-radius: 0.3rem;
+    background: var(--step-background-color);
+    content: "";
+  }
+}
+
+.af-item-form-helper__validated {
+  --link-color: var(--green40);
+
+  color: var(--green40);
+}
+
+.af-item-form-helper__validated::before {
+  display: none;
+}
+
+.af-item-form-helper__greenTick {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 4px;
+  vertical-align: middle;
+  color: var(--green40);
+  fill: var(--green40);
+}
+
+.af-item-form-helper__edited {
+  --step-background-color: var(--axablue80);
+}
+
+.af-item-form-helper__disabled::before {
+  border: 1px solid var(--gray50);
+}
+
+.af-item-form-helper__locked::before {
+  border: 1px solid var(--axablue80);
+}
+
+.af-item-form-helper__disabled {
+  color: var(--gray50);
+}

--- a/slash/react/src/FormHelper/FormHelper/FormHelper.tsx
+++ b/slash/react/src/FormHelper/FormHelper/FormHelper.tsx
@@ -1,0 +1,58 @@
+import classNames from "classnames";
+import {
+  ArticleRestitution,
+  HeaderRestitution,
+  SectionRestitution,
+} from "../../Restitution";
+import { ItemFormHelper } from "../ItemFormHelper/ItemFormHelper";
+import "@axa-fr/design-system-slash-css/dist/FormHelper/FormHelper.css";
+
+type ItemFormHelperProps = {
+  label: string;
+  mode: string;
+  anchor?: string;
+};
+
+type Section = {
+  title?: string;
+  items: ItemFormHelperProps[];
+};
+
+type FormHelperProps = {
+  formTitle: string;
+  sections: Section[];
+};
+
+export const FormHelper = ({ formTitle, sections }: FormHelperProps) => (
+  <ArticleRestitution>
+    <HeaderRestitution title={formTitle} />
+    <SectionRestitution className="af-form-helper__legend">
+      <ul>
+        <ItemFormHelper label="à compléter" mode="locked" />
+        <ItemFormHelper label="en cours" mode="edited" />
+        <ItemFormHelper label="validé" mode="validated" />
+      </ul>
+    </SectionRestitution>
+    <SectionRestitution
+      className={classNames("af-restitution", "af-form-helper__main-content")}
+    >
+      {sections.map((section, idx) => (
+        <ul key={section.title || idx}>
+          {section.title ? (
+            <h3 className={classNames("af-form-helper__section-title")}>
+              {section.title}
+            </h3>
+          ) : null}
+          {section.items.map((item) => (
+            // eslint-disable-next-line react/jsx-key
+            <ItemFormHelper
+              label={item.label}
+              mode={item.mode}
+              anchor={item.anchor}
+            />
+          ))}
+        </ul>
+      ))}
+    </SectionRestitution>
+  </ArticleRestitution>
+);

--- a/slash/react/src/FormHelper/ItemFormHelper/ItemFormHelper.tsx
+++ b/slash/react/src/FormHelper/ItemFormHelper/ItemFormHelper.tsx
@@ -1,0 +1,44 @@
+import classNames from "classnames";
+import greenTick from "@material-symbols/svg-400/outlined/check-fill.svg";
+import "@axa-fr/design-system-slash-css/dist/FormHelper/ItemFormHelper.css";
+import { Svg } from "../../Svg";
+
+type ItemFormHelperProps = {
+  label: string;
+  mode: string;
+  anchor?: string;
+};
+
+export const ItemFormHelper = ({
+  label,
+  mode,
+  anchor,
+}: ItemFormHelperProps) => {
+  const className = `af-item-form-helper__${mode}`;
+  const showTick = mode === "validated";
+  return (
+    <li
+      className={classNames("af-item-form-helper", className)}
+      key={`etape_${label}`}
+    >
+      {showTick ? (
+        <Svg
+          src={greenTick}
+          className={classNames("af-item-form-helper__greenTick")}
+        />
+      ) : null}
+      {anchor ? (
+        <a
+          href={`#${anchor}`}
+          aria-label={`Accéder à l'étape ${label} depuis l'assistant de saisie`}
+        >
+          {label}
+        </a>
+      ) : (
+        <span className={mode === "locked" ? "lockedStep" : undefined}>
+          {label}
+        </span>
+      )}
+    </li>
+  );
+};

--- a/slash/react/src/FormHelper/__tests__/FormHelper.spec.tsx
+++ b/slash/react/src/FormHelper/__tests__/FormHelper.spec.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { FormHelper } from "../FormHelper/FormHelper";
+
+describe("Form Helper", () => {
+  it("show links without anchor", async () => {
+    render(
+      <FormHelper
+        formTitle="Assistant de saisie"
+        sections={[
+          {
+            title: "Mon formulaire",
+            items: [
+              { label: "Configuration", mode: "validated" },
+              { label: "Souscription", mode: "validated" },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    await screen.findByText(/Assistant de saisie/i);
+    await screen.findByText(/Configuration/i);
+    await screen.findByText(/Souscription/i);
+  });
+
+  it("show links with anchor but without section title", async () => {
+    render(
+      <FormHelper
+        formTitle="Assistant de saisie"
+        sections={[
+          {
+            items: [
+              { label: "Configuration", mode: "validated", anchor: "config" },
+              { label: "Souscripteur", mode: "locked" },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    await screen.findByText(/Assistant de saisie/i);
+    await screen.findByRole("link", { name: /Configuration/i });
+    await screen.findByText(/Souscripteur/i);
+  });
+
+  it("show form helper with form subtitle", async () => {
+    render(
+      <FormHelper
+        formTitle="Assistant de saisie"
+        sections={[
+          {
+            title: "Mon formulaire",
+            items: [
+              { label: "Configuration", mode: "validated" },
+              { label: "Souscription", mode: "validated" },
+            ],
+          },
+        ]}
+      />,
+    );
+    await screen.findByText(/Assistant de saisie/i);
+    await screen.findByText(/Mon formulaire/i);
+  });
+});

--- a/slash/react/src/FormHelper/index.tsx
+++ b/slash/react/src/FormHelper/index.tsx
@@ -1,0 +1,2 @@
+export { ItemFormHelper } from "./ItemFormHelper/ItemFormHelper";
+export { FormHelper } from "./FormHelper/FormHelper";

--- a/slash/react/src/index.ts
+++ b/slash/react/src/index.ts
@@ -107,3 +107,5 @@ export { Loader } from "./Loader/Loader";
 
 export { CardData } from "./CardData/CardData";
 export type { CardDataVariant } from "./CardData/CardData";
+export { ItemFormHelper } from "./FormHelper/ItemFormHelper/ItemFormHelper";
+export { FormHelper } from "./FormHelper/FormHelper/FormHelper";


### PR DESCRIPTION
Issue: #1336 

Pair test: **OK**

Added **FormHelper** and its inner component **ItemFormHelper**

<img width="1070" height="705" alt="image" src="https://github.com/user-attachments/assets/ba1f111b-9430-4be1-88c4-67783adfafa6" />

<img width="1334" height="552" alt="image" src="https://github.com/user-attachments/assets/1b1693a2-d6df-4452-849b-b52989a5416e" />
