### PR TITLE
chore(design-system): update action.yaml for improved node setup

### DIFF
--- a/.github/action/setup-node/action.yaml
+++ b/.github/action/setup-node/action.yaml
@@ -20,6 +20,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
       with:
+        registry-url: "https://registry.npmjs.org"
         node-version: ${{ env.NODE_VERSION || 'lts/*' }}
 
     - name: Setup npm version


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for setting up Node.js. The change ensures that the npm registry URL is explicitly set during the Node.js setup step, which can help avoid issues with package installations.

* Explicitly sets the `registry-url` to `"https://registry.npmjs.org"` in the `actions/setup-node` step in `.github/action/setup-node/action.yaml`.