### PR TITLE
fix(slash): placeholder in `Select` (`default` mode)

### DIFF
--- a/slash/react/src/Form/Select/SelectDefault.tsx
+++ b/slash/react/src/Form/Select/SelectDefault.tsx
@@ -16,6 +16,8 @@ const SelectDefault = forwardRef<HTMLSelectElement, Props>(
       onChange,
       forceDisplayPlaceholder = false,
       value,
+      defaultValue,
+      required,
       placeholder = "- Select -",
       id,
       children,
@@ -29,7 +31,7 @@ const SelectDefault = forwardRef<HTMLSelectElement, Props>(
 
     const childrenWithDefault = (
       <>
-        {!(hasHandleChangeOnce || otherProps.defaultValue !== undefined) && (
+        {(!required || !(hasHandleChangeOnce || defaultValue || value)) && (
           <option value="">{placeholder}</option>
         )}
         {children}
@@ -41,6 +43,8 @@ const SelectDefault = forwardRef<HTMLSelectElement, Props>(
         {...otherProps}
         id={inputId}
         value={value}
+        defaultValue={defaultValue}
+        required={required}
         onChange={(e) => {
           if (onChange) {
             onChange(e);

--- a/slash/react/src/Form/Select/SelectDefaultWithOptions.tsx
+++ b/slash/react/src/Form/Select/SelectDefaultWithOptions.tsx
@@ -33,6 +33,8 @@ export const SelectDefaultWithOptions = forwardRef<HTMLSelectElement, Props>(
       onChange,
       forceDisplayPlaceholder = false,
       value,
+      defaultValue,
+      required,
       placeholder = "- Select -",
       options,
       id,
@@ -43,12 +45,20 @@ export const SelectDefaultWithOptions = forwardRef<HTMLSelectElement, Props>(
     const [hasHandleChangeOnce, setHasHandleChangeOnce] = useState(false);
     const generatedId = useId();
     const inputId = id ?? generatedId;
+
     const newOptions = useMemo(
       () =>
-        hasHandleChangeOnce || otherProps.defaultValue !== undefined
+        (hasHandleChangeOnce || defaultValue || value) && required
           ? options
           : [{ value: "", label: placeholder }, ...options],
-      [hasHandleChangeOnce, options, otherProps.defaultValue, placeholder],
+      [
+        hasHandleChangeOnce,
+        options,
+        defaultValue,
+        value,
+        required,
+        placeholder,
+      ],
     );
 
     return (
@@ -56,6 +66,7 @@ export const SelectDefaultWithOptions = forwardRef<HTMLSelectElement, Props>(
         {...otherProps}
         id={inputId}
         value={value}
+        defaultValue={defaultValue}
         options={newOptions}
         onChange={(e) => {
           if (onChange) {

--- a/slash/react/src/Form/Select/__tests__/Select.test.tsx
+++ b/slash/react/src/Form/Select/__tests__/Select.test.tsx
@@ -244,5 +244,92 @@ describe("Select", () => {
 
       expect(await axe(container)).toHaveNoViolations();
     });
+
+    it.each([
+      [false, "fun", undefined],
+      [false, "", undefined],
+      [false, undefined, "fun"],
+      [false, undefined, ""],
+      [true, undefined, undefined],
+    ])(
+      "should display placeholder at component render when required=%s, value=%s, defaultValue=%s",
+      async (required, value, defaultValue) => {
+        render(
+          <Select
+            mode="default"
+            onChange={() => {}}
+            value={value}
+            defaultValue={defaultValue}
+            placeholder="sélectionner une option"
+            required={required}
+          >
+            <option value="fun">for fun</option>
+            <option value="work">for work</option>
+            <option value="drink">for drink</option>
+          </Select>,
+        );
+
+        // Assert
+        const placeholder = screen.queryByRole("option", {
+          name: /sélectionner une option/i,
+        });
+
+        expect(placeholder).toBeInTheDocument();
+      },
+    );
+
+    it.each([
+      [true, "fun", undefined],
+      [true, undefined, "fun"],
+    ])(
+      "shouldn't display placeholder at component render when required=%s, value=%s, defaultValue=%s",
+      async (required, value, defaultValue) => {
+        render(
+          <Select
+            mode="default"
+            onChange={() => {}}
+            value={value}
+            defaultValue={defaultValue}
+            placeholder="sélectionner une option"
+            required={required}
+          >
+            <option value="fun">for fun</option>
+            <option value="work">for work</option>
+            <option value="drink">for drink</option>
+          </Select>,
+        );
+
+        // Assert
+        const placeholder = screen.queryByRole("option", {
+          name: /sélectionner une option/i,
+        });
+
+        expect(placeholder).not.toBeInTheDocument();
+      },
+    );
+
+    it("shouldn't display placeholder when value is required and modified", async () => {
+      render(
+        <Select
+          mode="default"
+          onChange={() => {}}
+          placeholder="sélectionner une option"
+          required
+        >
+          <option value="fun">for fun</option>
+          <option value="work">for work</option>
+          <option value="drink">for drink</option>
+        </Select>,
+      );
+
+      // Act
+      await userEvent.selectOptions(screen.getByRole("combobox"), "fun");
+
+      // Assert
+      const placeholder = screen.queryByRole("option", {
+        name: /sélectionner une option/i,
+      });
+      expect(placeholder).not.toBeInTheDocument();
+    });
   });
 });

--- a/slash/react/src/Form/Select/__tests__/SelectInput.test.tsx
+++ b/slash/react/src/Form/Select/__tests__/SelectInput.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
 import { SelectInput } from "../SelectInput";
 
 const options = [
@@ -40,5 +41,86 @@ describe("SelectInput", () => {
 
     // Assert
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it.each([
+    [false, "fun", undefined],
+    [false, "", undefined],
+    [false, undefined, "fun"],
+    [false, undefined, ""],
+    [true, undefined, undefined],
+  ])(
+    "should display placeholder at component render when required=%s, value=%s, defaultValue=%s",
+    async (required, value, defaultValue) => {
+      render(
+        <SelectInput
+          mode="default"
+          label="label select input"
+          onChange={() => {}}
+          value={value}
+          defaultValue={defaultValue}
+          options={options}
+          placeholder="sélectionner une option"
+          required={required}
+        />,
+      );
+
+      // Assert
+      const placeholder = screen.queryByRole("option", {
+        name: /sélectionner une option/i,
+      });
+
+      expect(placeholder).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    [true, "fun", undefined],
+    [true, undefined, "fun"],
+  ])(
+    "shouldn't display placeholder at component render when required=%s, value=%s, defaultValue=%s",
+    async (required, value, defaultValue) => {
+      render(
+        <SelectInput
+          mode="default"
+          label="label select input"
+          onChange={() => {}}
+          value={value}
+          defaultValue={defaultValue}
+          options={options}
+          placeholder="sélectionner une option"
+          required={required}
+        />,
+      );
+
+      // Assert
+      const placeholder = screen.queryByRole("option", {
+        name: /sélectionner une option/i,
+      });
+
+      expect(placeholder).not.toBeInTheDocument();
+    },
+  );
+
+  it("shouldn't display placeholder when value is required and modified", async () => {
+    render(
+      <SelectInput
+        mode="default"
+        label="label select input"
+        onChange={() => {}}
+        options={options}
+        placeholder="sélectionner une option"
+        required
+      />,
+    );
+
+    // Act
+    await userEvent.selectOptions(screen.getByRole("combobox"), "fun");
+
+    // Assert
+    const placeholder = screen.queryByRole("option", {
+      name: /sélectionner une option/i,
+    });
+    expect(placeholder).not.toBeInTheDocument();
   });
 });

--- a/slash/react/src/Form/core/Field.tsx
+++ b/slash/react/src/Form/core/Field.tsx
@@ -189,6 +189,7 @@ export const Field = ({
             errorId,
             disabled,
             ariaInvalid: isInvalid,
+            required,
             ...otherProps,
           })}
         </div>


### PR DESCRIPTION
Nous avons actuellement deux problèmes sur le `Select` (en `default` mode seulement car le `base` ne rajoute pas de placeholder):

- Si le champ n'est PAS `required`, une fois que l'utilisateur à sélectionné un choix, il n'a plus la possibilité de re-sélectionner le placeholder avec la valeur vide. 
- Si le composant initialisé au chargement de la page avec déjà une valeur sélectionnée, le composant affiche le placeholder (qui est sélectionnable), meme si le champ EST `required`.

Cette PR corrige ces deux problèmes