### PR TITLE
Fix deprecated components not displayed due to removed comments at build

### DIFF
--- a/client/look-and-feel/react/eslint.config.mjs
+++ b/client/look-and-feel/react/eslint.config.mjs
@@ -1,3 +1,15 @@
 import config from "@axa-fr/eslint-config-design-system";
 
-export default config;
+export default [
+  ...config,
+  {
+    rules: {
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          devDependencies: true,
+        },
+      ],
+    },
+  },
+];

--- a/client/look-and-feel/react/src/Accordion/Accordion.tsx
+++ b/client/look-and-feel/react/src/Accordion/Accordion.tsx
@@ -16,6 +16,9 @@ type AccordionProps = {
 } & ComponentProps<typeof AccordionTagDateContainer> &
   Partial<ComponentProps<typeof AccordionCore>>;
 
+/**
+ * @deprecated Use `Accordion` from `@axa-fr/design-system-apollo-react/lf` package instead.
+ */
 export const Accordion = ({
   title,
   children,

--- a/client/look-and-feel/react/src/AccordionCore/AccordionCore.tsx
+++ b/client/look-and-feel/react/src/AccordionCore/AccordionCore.tsx
@@ -17,6 +17,9 @@ type AccordionProps = {
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 } & Partial<ComponentProps<"details">>;
 
+/**
+ * @deprecated Use `AccordionCore` from `@axa-fr/design-system-apollo-react/lf` package instead.
+ */
 export const AccordionCore = ({
   summary,
   children,

--- a/client/look-and-feel/react/src/Alert/Alert.tsx
+++ b/client/look-and-feel/react/src/Alert/Alert.tsx
@@ -44,7 +44,7 @@ const getIconFromType = (type: AlertType) =>
   })[type] || wbIncandescentOutlined;
 
 /**
- * @deprecated Use Message instead
+ * @deprecated Use `Message` from `@axa-fr/design-system-apollo-react/lf` instead.
  */
 export const Alert = ({
   type = alertTypes.information,

--- a/client/look-and-feel/react/src/BasePicture/BasePicture.tsx
+++ b/client/look-and-feel/react/src/BasePicture/BasePicture.tsx
@@ -1,1 +1,6 @@
-export { BasePicture } from "@axa-fr/design-system-apollo-react/lf";
+import { BasePicture as ApolloBasePicture } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `BasePicture` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const BasePicture = ApolloBasePicture;

--- a/client/look-and-feel/react/src/Button/Button.tsx
+++ b/client/look-and-feel/react/src/Button/Button.tsx
@@ -1,3 +1,18 @@
-export { Button, buttonVariants } from "@axa-fr/design-system-apollo-react/lf";
+import {
+  Button as ApolloButton,
+  buttonVariants as ApolloButtonVariants,
+  type ButtonVariants as ApolloButtonVariantsType,
+} from "@axa-fr/design-system-apollo-react/lf";
 
-export type { ButtonVariants } from "@axa-fr/design-system-apollo-react/lf";
+/**
+ * @deprecated Use `Button` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Button: typeof ApolloButton = ApolloButton;
+/**
+ * @deprecated Use `buttonVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const buttonVariants = ApolloButtonVariants;
+/**
+ * @deprecated Use `ButtonVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type ButtonVariants = ApolloButtonVariantsType;

--- a/client/look-and-feel/react/src/CardMessage/CardMessage.tsx
+++ b/client/look-and-feel/react/src/CardMessage/CardMessage.tsx
@@ -1,5 +1,18 @@
-export {
-  CardMessage,
-  cardMessageVariants,
-  type CardMessageVariants,
+import {
+  CardMessage as ApolloCardMessage,
+  cardMessageVariants as ApolloCardMessageVariants,
+  type CardMessageVariants as ApolloCardMessageVariantsType,
 } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `CardMessage` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const CardMessage: typeof ApolloCardMessage = ApolloCardMessage;
+/**
+ * @deprecated Use `cardMessageVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const cardMessageVariants = ApolloCardMessageVariants;
+/**
+ * @deprecated Use `CardMessageVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type CardMessageVariants = ApolloCardMessageVariantsType;

--- a/client/look-and-feel/react/src/ClickIcon/ClickIcon.tsx
+++ b/client/look-and-feel/react/src/ClickIcon/ClickIcon.tsx
@@ -1,1 +1,6 @@
-export { ClickIcon } from "@axa-fr/design-system-apollo-react/lf";
+import { ClickIcon as ApolloClickIcon } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ClickIcon` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ClickIcon: typeof ApolloClickIcon = ApolloClickIcon;

--- a/client/look-and-feel/react/src/ContentItemMono/ContentItemMono.tsx
+++ b/client/look-and-feel/react/src/ContentItemMono/ContentItemMono.tsx
@@ -1,1 +1,7 @@
-export { ContentItemMono } from "@axa-fr/design-system-apollo-react/lf";
+import { ContentItemMono as ApolloContentItemMono } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ContentItemMono` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ContentItemMono: typeof ApolloContentItemMono =
+  ApolloContentItemMono;

--- a/client/look-and-feel/react/src/Divider/Divider.tsx
+++ b/client/look-and-feel/react/src/Divider/Divider.tsx
@@ -1,1 +1,6 @@
-export { Divider } from "@axa-fr/design-system-apollo-react/lf";
+import { Divider as ApolloDivider } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Divider` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Divider = ApolloDivider;

--- a/client/look-and-feel/react/src/Form/Checkbox/CardCheckbox.tsx
+++ b/client/look-and-feel/react/src/Form/Checkbox/CardCheckbox.tsx
@@ -19,6 +19,9 @@ export type CardCheckboxProps = Partial<TCardCheckboxItem> & {
   error?: string;
 };
 
+/**
+ * @deprecated Use `CardCheckbox` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const CardCheckbox = ({
   className,
   labelGroup,
@@ -80,3 +83,8 @@ export const CardCheckbox = ({
 };
 
 CardCheckbox.displayName = "CardCheckbox";
+
+/**
+ * @deprecated Use `CardCheckbox` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const CheckboxCard = CardCheckbox;

--- a/client/look-and-feel/react/src/Form/Checkbox/Checkbox.tsx
+++ b/client/look-and-feel/react/src/Form/Checkbox/Checkbox.tsx
@@ -1,1 +1,6 @@
-export { Checkbox } from "@axa-fr/design-system-apollo-react/lf";
+import { Checkbox as ApolloCheckbox } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Checkbox` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Checkbox: typeof ApolloCheckbox = ApolloCheckbox;

--- a/client/look-and-feel/react/src/Form/Checkbox/CheckboxText.tsx
+++ b/client/look-and-feel/react/src/Form/Checkbox/CheckboxText.tsx
@@ -1,1 +1,6 @@
-export { CheckboxText } from "@axa-fr/design-system-apollo-react/lf";
+import { CheckboxText as ApolloCheckboxText } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `CheckboxText` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const CheckboxText: typeof ApolloCheckboxText = ApolloCheckboxText;

--- a/client/look-and-feel/react/src/Form/Dropdown/Dropdown.tsx
+++ b/client/look-and-feel/react/src/Form/Dropdown/Dropdown.tsx
@@ -1,1 +1,11 @@
-export { Dropdown } from "@axa-fr/design-system-apollo-react/lf";
+import { Dropdown as ApolloDropdown } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Dropdown` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Dropdown: typeof ApolloDropdown = ApolloDropdown;
+
+/**
+ * @deprecated Use `Dropdown` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Select: typeof ApolloDropdown = ApolloDropdown;

--- a/client/look-and-feel/react/src/Form/InputDate/InputDate.tsx
+++ b/client/look-and-feel/react/src/Form/InputDate/InputDate.tsx
@@ -1,1 +1,11 @@
-export { InputDate } from "@axa-fr/design-system-apollo-react/lf";
+import { InputDate as ApolloInputDate } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `InputDate` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const InputDate: typeof ApolloInputDate = ApolloInputDate;
+
+/**
+ * @deprecated Use `InputDate` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const DateInput: typeof ApolloInputDate = ApolloInputDate;

--- a/client/look-and-feel/react/src/Form/InputError/InputError.tsx
+++ b/client/look-and-feel/react/src/Form/InputError/InputError.tsx
@@ -8,7 +8,7 @@ type InputErrorProps = {
 };
 
 /**
- * @deprecated Use ItemMessage instead
+ * @deprecated Use `ItemMessage` from `@axa-fr/design-system-apollo-react/lf` instead.
  */
 export const InputError = ({ message, id }: InputErrorProps) => (
   <div className="af-input-error">

--- a/client/look-and-feel/react/src/Form/InputText/InputText.tsx
+++ b/client/look-and-feel/react/src/Form/InputText/InputText.tsx
@@ -1,1 +1,11 @@
-export { TextInput } from "@axa-fr/design-system-apollo-react/lf";
+import { InputText as ApolloInputText } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `TextInput` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const TextInput: typeof ApolloInputText = ApolloInputText;
+
+/**
+ * @deprecated Use `TextInput` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const InputText: typeof ApolloInputText = ApolloInputText;

--- a/client/look-and-feel/react/src/Form/ItemFile/ItemFile.tsx
+++ b/client/look-and-feel/react/src/Form/ItemFile/ItemFile.tsx
@@ -1,1 +1,6 @@
-export { ItemFile } from "@axa-fr/design-system-apollo-react/lf";
+import { ItemFile as ApolloItemFile } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ItemFile` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ItemFile: typeof ApolloItemFile = ApolloItemFile;

--- a/client/look-and-feel/react/src/Form/ItemLabel/ItemLabel.tsx
+++ b/client/look-and-feel/react/src/Form/ItemLabel/ItemLabel.tsx
@@ -1,1 +1,6 @@
-export { ItemLabel } from "@axa-fr/design-system-apollo-react/lf";
+import { ItemLabel as ApolloItemLabel } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ItemLabel` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ItemLabel: typeof ApolloItemLabel = ApolloItemLabel;

--- a/client/look-and-feel/react/src/Form/ItemMessage/ItemMessage.tsx
+++ b/client/look-and-feel/react/src/Form/ItemMessage/ItemMessage.tsx
@@ -1,1 +1,6 @@
-export { ItemMessage } from "@axa-fr/design-system-apollo-react/lf";
+import { ItemMessage as ApolloItemMessage } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ItemMessage` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ItemMessage: typeof ApolloItemMessage = ApolloItemMessage;

--- a/client/look-and-feel/react/src/Form/Radio/Radio.tsx
+++ b/client/look-and-feel/react/src/Form/Radio/Radio.tsx
@@ -1,1 +1,6 @@
-export { Radio } from "@axa-fr/design-system-apollo-react/lf";
+import { Radio as ApolloRadio } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Radio` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Radio: typeof ApolloRadio = ApolloRadio;

--- a/client/look-and-feel/react/src/Form/Radio/RadioCard.tsx
+++ b/client/look-and-feel/react/src/Form/Radio/RadioCard.tsx
@@ -21,6 +21,9 @@ export type CardRadioProps = Omit<ComponentProps<typeof Radio>, "size"> & {
   error?: string;
 };
 
+/**
+ * @deprecated Use `CardRadio` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const RadioCard = ({
   className,
   labelGroup,
@@ -94,3 +97,8 @@ export const RadioCard = ({
 };
 
 RadioCard.displayName = "RadioCard";
+
+/**
+ * @deprecated Use `CardRadio` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const CardRadio = RadioCard;

--- a/client/look-and-feel/react/src/Form/TextArea/TextArea.tsx
+++ b/client/look-and-feel/react/src/Form/TextArea/TextArea.tsx
@@ -1,1 +1,6 @@
-export { TextArea } from "@axa-fr/design-system-apollo-react/lf";
+import { TextArea as ApolloTextArea } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `TextArea` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const TextArea: typeof ApolloTextArea = ApolloTextArea;

--- a/client/look-and-feel/react/src/Grid/DebugGrid.tsx
+++ b/client/look-and-feel/react/src/Grid/DebugGrid.tsx
@@ -1,1 +1,6 @@
-export { DebugGrid } from "@axa-fr/design-system-apollo-react/lf";
+import { DebugGrid as ApolloDebugGrid } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `DebugGrid` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const DebugGrid: typeof ApolloDebugGrid = ApolloDebugGrid;

--- a/client/look-and-feel/react/src/Heading/Heading.ts
+++ b/client/look-and-feel/react/src/Heading/Heading.ts
@@ -1,4 +1,14 @@
-export {
-  Heading,
-  type HeadingLevel,
+import {
+  Heading as ApolloHeading,
+  type HeadingLevel as ApolloHeadingLevel,
 } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Heading` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Heading: typeof ApolloHeading = ApolloHeading;
+
+/**
+ * @deprecated Use `HeadingLevel` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type HeadingLevel = ApolloHeadingLevel;

--- a/client/look-and-feel/react/src/Icon/Icon.tsx
+++ b/client/look-and-feel/react/src/Icon/Icon.tsx
@@ -1,7 +1,32 @@
-export {
-  Icon,
-  iconVariants,
-  type IconVariants,
-  iconSizeVariants,
-  type IconSizeVariants,
+import {
+  Icon as ApolloIcon,
+  iconVariants as apolloIconVariants,
+  type IconVariants as ApolloIconVariants,
+  iconSizeVariants as ApolloIconSizeVariants,
+  type IconSizeVariants as apolloIconSizeVariants,
 } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Icon` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Icon: typeof ApolloIcon = ApolloIcon;
+
+/**
+ * @deprecated Use `iconVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const iconVariants = apolloIconVariants;
+
+/**
+ * @deprecated Use `IconVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type IconVariants = ApolloIconVariants;
+
+/**
+ * @deprecated Use `iconSizeVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const iconSizeVariants = ApolloIconSizeVariants;
+
+/**
+ * @deprecated Use `IconSizeVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type IconSizeVariants = apolloIconSizeVariants;

--- a/client/look-and-feel/react/src/IconBg/IconBg.tsx
+++ b/client/look-and-feel/react/src/IconBg/IconBg.tsx
@@ -9,7 +9,7 @@ type IconBgProps = {
 };
 
 /**
- * @deprecated Use Icon instead
+ * @deprecated Use `Icon` from `@axa-fr/design-system-apollo-react/lf` instead.
  */
 export const IconBg = ({
   children,

--- a/client/look-and-feel/react/src/ItemTabBar/ItemTabBar.tsx
+++ b/client/look-and-feel/react/src/ItemTabBar/ItemTabBar.tsx
@@ -1,4 +1,14 @@
-export {
-  ItemTabBar,
-  type ItemTabBarProps,
+import {
+  ItemTabBar as ApolloItemTabBar,
+  type ItemTabBarProps as ApolloItemTabBarProps,
 } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ItemTabBar` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ItemTabBar: typeof ApolloItemTabBar = ApolloItemTabBar;
+
+/**
+ * @deprecated Use `ItemTabBarProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type ItemTabBarProps = ApolloItemTabBarProps;

--- a/client/look-and-feel/react/src/Layout/Footer/Footer.tsx
+++ b/client/look-and-feel/react/src/Layout/Footer/Footer.tsx
@@ -1,3 +1,14 @@
-export { Footer } from "@axa-fr/design-system-apollo-react/lf";
+import {
+  Footer as ApolloFooter,
+  type FooterProps as ApolloFooterProps,
+} from "@axa-fr/design-system-apollo-react/lf";
 
-export type { FooterProps } from "@axa-fr/design-system-apollo-react/lf";
+/**
+ * @deprecated Use `Footer` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Footer: typeof ApolloFooter = ApolloFooter;
+
+/**
+ * @deprecated Use `FooterProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type FooterProps = ApolloFooterProps;

--- a/client/look-and-feel/react/src/Link/Link.tsx
+++ b/client/look-and-feel/react/src/Link/Link.tsx
@@ -1,1 +1,6 @@
-export { Link } from "@axa-fr/design-system-apollo-react/lf";
+import { Link as ApolloLink } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Link` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Link: typeof ApolloLink = ApolloLink;

--- a/client/look-and-feel/react/src/List/ClickItem/ClickItem.helpers.tsx
+++ b/client/look-and-feel/react/src/List/ClickItem/ClickItem.helpers.tsx
@@ -1,6 +1,9 @@
 import type { ComponentProps, ComponentType, ElementType } from "react";
 import type { TParentClickComponentProps } from "./types";
 
+/**
+ * @deprecated Use `ClickItem` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const createClickItemParent = <TComponent extends ElementType>(
   Wrapper: ComponentType<TComponent> | TComponent,
   wrapperProps: ComponentProps<TComponent>,

--- a/client/look-and-feel/react/src/List/ClickItem/ClickItem.tsx
+++ b/client/look-and-feel/react/src/List/ClickItem/ClickItem.tsx
@@ -4,6 +4,9 @@ import { Svg } from "../../Svg";
 import { getComponentClassName } from "../../utilities";
 import type { TClickItem } from "./types";
 
+/**
+ * @deprecated Use `ClickItem` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const ClickItem = ({
   children,
   icon,

--- a/client/look-and-feel/react/src/List/ContentItemDuo/ContentItemDuo.tsx
+++ b/client/look-and-feel/react/src/List/ContentItemDuo/ContentItemDuo.tsx
@@ -1,1 +1,6 @@
-export { ContentItemDuo } from "@axa-fr/design-system-apollo-react/lf";
+import { ContentItemDuo as ApolloContentItemDuo } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ContentItemDuo` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ContentItemDuo: typeof ApolloContentItemDuo = ApolloContentItemDuo;

--- a/client/look-and-feel/react/src/Message/Message.tsx
+++ b/client/look-and-feel/react/src/Message/Message.tsx
@@ -1,6 +1,18 @@
-export {
-  Message,
-  messageVariants,
+import {
+  Message as ApolloMessage,
+  messageVariants as ApolloMessageVariants,
+  type MessageVariants as ApolloMessageVariantsType,
 } from "@axa-fr/design-system-apollo-react/lf";
 
-export type { MessageVariants } from "@axa-fr/design-system-apollo-react/lf";
+/**
+ * @deprecated Use `Message` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Message: typeof ApolloMessage = ApolloMessage;
+/**
+ * @deprecated Use `messageVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const messageVariants = ApolloMessageVariants;
+/**
+ * @deprecated Use `MessageVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type MessageVariants = ApolloMessageVariantsType;

--- a/client/look-and-feel/react/src/Modal/Modal.tsx
+++ b/client/look-and-feel/react/src/Modal/Modal.tsx
@@ -8,6 +8,9 @@ import {
 import { ModalCoreBody } from "./components/ModalCoreBody";
 import { ModalCoreFooter } from "./components/ModalCoreFooter";
 
+/**
+ * @deprecated Use `ModalProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export type ModalProps = Omit<ModalCoreProps, "onOutsideTap" | "title"> &
   ModalCoreHeaderProps & {
     onSubmit?: (event: React.MouseEvent | React.KeyboardEvent) => void;
@@ -17,7 +20,9 @@ export type ModalProps = Omit<ModalCoreProps, "onOutsideTap" | "title"> &
     cancelDisabled?: boolean;
   };
 
-/** @deprecated Use Modal from \@axa-fr/design-system-apollo-react/lf instead */
+/**
+ * @deprecated Use `Modal` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 const Modal = forwardRef<HTMLDialogElement, ModalProps>(
   (
     {

--- a/client/look-and-feel/react/src/Modal/ModalCore.tsx
+++ b/client/look-and-feel/react/src/Modal/ModalCore.tsx
@@ -1,6 +1,9 @@
 import { forwardRef, type ReactNode } from "react";
 import "@axa-fr/design-system-look-and-feel-css/dist/Modal/Modal.scss";
 
+/**
+ * @deprecated Use `ModalCoreProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export type ModalCoreProps = React.DetailedHTMLProps<
   React.DialogHTMLAttributes<HTMLDialogElement>,
   HTMLDialogElement
@@ -12,7 +15,9 @@ export type ModalCoreProps = React.DetailedHTMLProps<
   ref?: React.Ref<HTMLDialogElement>;
 };
 
-/** @deprecated Use ModalCore from \@axa-fr/design-system-apollo-react/lf instead */
+/**
+ * @deprecated Use `ModalCore` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 const ModalCore = forwardRef<HTMLDialogElement, ModalCoreProps>(
   (
     { className, title = "", onOutsideTap, children, ...props }: ModalCoreProps,

--- a/client/look-and-feel/react/src/Modal/components/ModalCoreBody.tsx
+++ b/client/look-and-feel/react/src/Modal/components/ModalCoreBody.tsx
@@ -1,6 +1,11 @@
+/**
+ * @deprecated Use `ModalCoreBodyProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export type ModalCoreBodyProps = React.HTMLAttributes<HTMLDivElement>;
 
-/** @deprecated Use ModalCoreBody from \@axa-fr/design-system-apollo-react/lf instead */
+/**
+ * @deprecated Use `ModalCoreBody` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const ModalCoreBody = ({
   children,
   className,

--- a/client/look-and-feel/react/src/Modal/components/ModalCoreFooter.tsx
+++ b/client/look-and-feel/react/src/Modal/components/ModalCoreFooter.tsx
@@ -1,6 +1,11 @@
+/**
+ * @deprecated Use `ModalCoreFooterProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export type ModalCoreFooterProps = React.HTMLAttributes<HTMLDivElement>;
 
-/** @deprecated Use ModalCoreFooter from \@axa-fr/design-system-apollo-react/lf instead */
+/**
+ * @deprecated Use `ModalCoreFooter` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const ModalCoreFooter = ({
   className,
   ...rest

--- a/client/look-and-feel/react/src/Modal/components/ModalCoreHeader.tsx
+++ b/client/look-and-feel/react/src/Modal/components/ModalCoreHeader.tsx
@@ -4,6 +4,9 @@ import { Button } from "../../Button/Button";
 import { Svg } from "../../Svg";
 import type { TitleLevel } from "../../Title";
 
+/**
+ * @deprecated Use `ModalCoreHeaderProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export type ModalCoreHeaderProps = HTMLAttributes<HTMLDivElement> & {
   className?: string;
   title: string;
@@ -14,7 +17,9 @@ export type ModalCoreHeaderProps = HTMLAttributes<HTMLDivElement> & {
   closeButtonAriaLabel?: string;
 };
 
-/** @deprecated Use ModalCoreHeader from \@axa-fr/design-system-apollo-react/lf instead */
+/**
+ * @deprecated Use `ModalCoreHeader` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const ModalCoreHeader = ({
   className,
   title,

--- a/client/look-and-feel/react/src/ProgressBar/ProgressBar.tsx
+++ b/client/look-and-feel/react/src/ProgressBar/ProgressBar.tsx
@@ -1,1 +1,6 @@
-export { ProgressBar } from "@axa-fr/design-system-apollo-react/lf";
+import { ProgressBar as ApolloProgressBar } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `ProgressBar` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ProgressBar: typeof ApolloProgressBar = ApolloProgressBar;

--- a/client/look-and-feel/react/src/ProgressBarGroup/ProgressBarGroup.tsx
+++ b/client/look-and-feel/react/src/ProgressBarGroup/ProgressBarGroup.tsx
@@ -1,1 +1,7 @@
-export { ProgressBarGroup } from "@axa-fr/design-system-apollo-react/lf";
+import { ProgressBarGroup as ApolloProgressBarGroup } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Message` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const ProgressBarGroup: typeof ApolloProgressBarGroup =
+  ApolloProgressBarGroup;

--- a/client/look-and-feel/react/src/Spinner/Spinner.tsx
+++ b/client/look-and-feel/react/src/Spinner/Spinner.tsx
@@ -1,6 +1,20 @@
-export {
-  Spinner,
-  spinnerVariants,
+import {
+  Spinner as ApolloSpinner,
+  spinnerVariants as apolloSpinnerVariants,
+  type SpinnerVariants as ApolloSpinnerVariants,
 } from "@axa-fr/design-system-apollo-react/lf";
 
-export type { SpinnerVariants } from "@axa-fr/design-system-apollo-react/lf";
+/**
+ * @deprecated Use `Spinner` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Spinner: typeof ApolloSpinner = ApolloSpinner;
+
+/**
+ * @deprecated Use `spinnerVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const spinnerVariants = apolloSpinnerVariants;
+
+/**
+ * @deprecated Use `SpinnerVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type SpinnerVariants = ApolloSpinnerVariants;

--- a/client/look-and-feel/react/src/Stepper/Stepper.tsx
+++ b/client/look-and-feel/react/src/Stepper/Stepper.tsx
@@ -1,1 +1,6 @@
-export { Stepper } from "@axa-fr/design-system-apollo-react/lf";
+import { Stepper as ApolloStepper } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Stepper` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Stepper: typeof ApolloStepper = ApolloStepper;

--- a/client/look-and-feel/react/src/Svg/Svg.tsx
+++ b/client/look-and-feel/react/src/Svg/Svg.tsx
@@ -22,6 +22,9 @@ const cloneAttributes = (
   });
 };
 
+/**
+ * @deprecated Use `Svg` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const Svg = ({
   src,
   alt,

--- a/client/look-and-feel/react/src/TabBar/TabBar.tsx
+++ b/client/look-and-feel/react/src/TabBar/TabBar.tsx
@@ -1,6 +1,26 @@
-export {
-  TabBar,
-  type TabBarProps,
-  tabBarDirection,
-  type TabBarDirection,
+import {
+  TabBar as ApolloTabBar,
+  type TabBarProps as ApolloTabBarProps,
+  tabBarDirection as apolloTabBarDirection,
+  type TabBarDirection as ApolloTabBarDirection,
 } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `TabBar` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const TabBar: typeof ApolloTabBar = ApolloTabBar;
+
+/**
+ * @deprecated Use `TabBarProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type TabBarProps = ApolloTabBarProps;
+
+/**
+ * @deprecated Use `tabBarDirection` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const tabBarDirection = apolloTabBarDirection;
+
+/**
+ * @deprecated Use `TabBarDirection` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type TabBarDirection = ApolloTabBarDirection;

--- a/client/look-and-feel/react/src/Tabs/Tabs.tsx
+++ b/client/look-and-feel/react/src/Tabs/Tabs.tsx
@@ -2,10 +2,16 @@ import "@axa-fr/design-system-look-and-feel-css/dist/Tabs/Tabs.scss";
 import classNames from "classnames";
 import { ReactNode, useCallback, useRef, useState } from "react";
 
+/**
+ * @deprecated Use `tabBarDirection` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export enum Direction {
   center = "center",
 }
 
+/**
+ * @deprecated Use `TabBarProps` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 type TabsProps = {
   items: { title: string; content: string | ReactNode; icon?: ReactNode }[];
   preSelectedTabIndex?: number;
@@ -13,8 +19,8 @@ type TabsProps = {
 };
 
 /**
- * @deprecated Use `TabBar` instead.
- * */
+ * @deprecated Use `TabBar` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export const TabsClient = ({
   items,
   preSelectedTabIndex,

--- a/client/look-and-feel/react/src/Tag/Tag.ts
+++ b/client/look-and-feel/react/src/Tag/Tag.ts
@@ -1,3 +1,20 @@
-export { Tag, tagVariants } from "@axa-fr/design-system-apollo-react/lf";
+import {
+  Tag as ApolloTag,
+  tagVariants as apolloTagVariants,
+  type TagVariants as ApolloTagVariants,
+} from "@axa-fr/design-system-apollo-react/lf";
 
-export type { TagVariants } from "@axa-fr/design-system-apollo-react/lf";
+/**
+ * @deprecated Use `Tag` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Tag: typeof ApolloTag = ApolloTag;
+
+/**
+ * @deprecated Use `tagVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const tagVariants = apolloTagVariants;
+
+/**
+ * @deprecated Use `TagVariants` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export type TagVariants = ApolloTagVariants;

--- a/client/look-and-feel/react/src/TimelineVertical/TimelineVertical.ts
+++ b/client/look-and-feel/react/src/TimelineVertical/TimelineVertical.ts
@@ -1,1 +1,7 @@
-export { TimelineVertical } from "@axa-fr/design-system-apollo-react/lf";
+import { TimelineVertical as ApolloTimelineVertical } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `TimelineVertical` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const TimelineVertical: typeof ApolloTimelineVertical =
+  ApolloTimelineVertical;

--- a/client/look-and-feel/react/src/Title/Title.tsx
+++ b/client/look-and-feel/react/src/Title/Title.tsx
@@ -21,7 +21,7 @@ type TitleProps = {
 };
 
 /**
- * @deprecated Use Heading instead
+ * @deprecated Use `Heading` from `@axa-fr/design-system-apollo-react/lf` instead.
  */
 export const Title = ({
   children: title,

--- a/client/look-and-feel/react/src/Title/constants.ts
+++ b/client/look-and-feel/react/src/Title/constants.ts
@@ -1,6 +1,12 @@
+/**
+ * @deprecated Use `Heading` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export enum TitleSize {
   XL = "xl",
   L = "l",
 }
 
+/**
+ * @deprecated Use `Heading` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
 export type TitleLevel = 1 | 2 | 3 | 4 | 5 | 6;

--- a/client/look-and-feel/react/src/Toggle/Toggle.ts
+++ b/client/look-and-feel/react/src/Toggle/Toggle.ts
@@ -1,1 +1,6 @@
-export { Toggle } from "@axa-fr/design-system-apollo-react/lf";
+import { Toggle as ApolloToggle } from "@axa-fr/design-system-apollo-react/lf";
+
+/**
+ * @deprecated Use `Toggle` from `@axa-fr/design-system-apollo-react/lf` instead.
+ */
+export const Toggle: typeof ApolloToggle = ApolloToggle;

--- a/client/look-and-feel/react/src/index.ts
+++ b/client/look-and-feel/react/src/index.ts
@@ -1,17 +1,14 @@
 import "@axa-fr/design-system-look-and-feel-css/dist/common/tokens.scss";
 import "@fontsource/source-sans-pro";
 
+// Alias From Apollo/LF
 export {
-  /** @deprecated Use `Accordion` from apollo/lf package instead. */ Accordion,
-} from "./Accordion";
-export {
-  /** @deprecated Use `AccordionCore` from apollo/lf package instead. */ AccordionCore,
-} from "./AccordionCore";
-export { /** @deprecated Use `Message` instead. */ Alert } from "./Alert/Alert";
-export type { AlertType } from "./Alert/Alert";
+  Message,
+  messageVariants,
+  type MessageVariants,
+} from "./Message/Message";
 export { BasePicture } from "./BasePicture/BasePicture";
 export { Button, buttonVariants, type ButtonVariants } from "./Button/Button";
-export { Card } from "./Card";
 export {
   CardMessage,
   cardMessageVariants,
@@ -20,34 +17,14 @@ export {
 export { ClickIcon } from "./ClickIcon/ClickIcon";
 export { ContentItemMono } from "./ContentItemMono/ContentItemMono";
 export { Divider } from "./Divider/Divider";
-export {
-  CardCheckbox,
-  Checkbox,
-  /** @deprecated Use `CardCheckbox` instead. */
-  CardCheckbox as CheckboxCard,
-  CheckboxText,
-} from "./Form/Checkbox";
-export {
-  Dropdown,
-  /** @deprecated Use `Dropdown` instead. */ Dropdown as Select,
-} from "./Form/Dropdown/Dropdown";
-export { FileUpload } from "./Form/FileUpload";
-export {
-  /** @deprecated Use `InputDate` instead. */ InputDate as DateInput,
-  InputDate,
-} from "./Form/InputDate/InputDate";
-export { InputError } from "./Form/InputError";
-export {
-  /** @deprecated Use `TextInput` instead. */ TextInput as InputText,
-  TextInput,
-} from "./Form/InputText/InputText";
+export { Checkbox, CheckboxText } from "./Form/Checkbox";
+export { Dropdown, Select } from "./Form/Dropdown/Dropdown";
+export { DateInput, InputDate } from "./Form/InputDate/InputDate";
+export { ItemMessage } from "./Form/ItemMessage/ItemMessage";
+export { InputText, TextInput } from "./Form/InputText/InputText";
 export { ItemFile } from "./Form/ItemFile/ItemFile";
 export { ItemLabel } from "./Form/ItemLabel/ItemLabel";
-export { ItemMessage } from "./Form/ItemMessage/ItemMessage";
-export {
-  /** @deprecated Use `Radio` from apollo/lf package instead. */ Radio,
-  /** @deprecated Use `RadioCard` from apollo/lf package instead. */ RadioCard,
-} from "./Form/Radio";
+export { Radio } from "./Form/Radio";
 export { TextArea } from "./Form/TextArea/TextArea";
 export { DebugGrid } from "./Grid/DebugGrid";
 export { Heading, type HeadingLevel } from "./Heading/Heading";
@@ -58,7 +35,6 @@ export {
   type IconSizeVariants,
   type IconVariants,
 } from "./Icon/Icon";
-export { IconBg } from "./IconBg";
 export { ItemTabBar, type ItemTabBarProps } from "./ItemTabBar/ItemTabBar";
 export {
   TabBar,
@@ -67,50 +43,53 @@ export {
   type TabBarDirection,
 } from "./TabBar/TabBar";
 export { Footer } from "./Layout/Footer/Footer";
-export { BurgerMenu, Header, NavBar, PreviousLink } from "./Layout/Header";
 export { Link } from "./Link/Link";
-export { List } from "./List";
-export {
-  /** @deprecated Use `ClickItem` from apollo/lf package instead. */ ClickItem,
-  createClickItemParent,
-} from "./List/ClickItem";
 export { ContentItemDuo } from "./List/ContentItemDuo/ContentItemDuo";
-export { ContentTabItem, ContentTabList } from "./List/ContentTabList";
-export {
-  Message,
-  messageVariants,
-  type MessageVariants,
-} from "./Message/Message";
 export {
   Modal,
   ModalCore,
   ModalCoreBody,
   ModalCoreFooter,
   ModalCoreHeader,
+  type ModalCoreBodyProps,
+  type ModalCoreFooterProps,
+  type ModalCoreHeaderProps,
+  type ModalCoreProps,
+  type ModalProps,
 } from "./Modal";
-export type {
-  ModalCoreBodyProps,
-  ModalCoreFooterProps,
-  ModalCoreHeaderProps,
-  ModalCoreProps,
-  ModalProps,
-} from "./Modal";
-export { Pagination } from "./Pagination/Pagination";
-export {
-  /** @deprecated Use `ProgressBar` from apollo/lf package instead. */ ProgressBar,
-} from "./ProgressBar/ProgressBar";
+export { Stepper } from "./Stepper/Stepper";
+export { ProgressBar } from "./ProgressBar/ProgressBar";
 export { ProgressBarGroup } from "./ProgressBarGroup/ProgressBarGroup";
-export { Skeleton } from "./Skeleton/Skeleton";
-export { SkeletonList } from "./SkeletonList/SkeletonList";
 export {
   Spinner,
   spinnerVariants,
   type SpinnerVariants,
 } from "./Spinner/Spinner";
-export { Stepper } from "./Stepper/Stepper";
-export { Svg } from "./Svg";
-export { TabsClient as Tabs, Direction as TabsDirection } from "./Tabs/Tabs";
 export { Tag, tagVariants, type TagVariants } from "./Tag/Tag";
 export { TimelineVertical } from "./TimelineVertical/TimelineVertical";
-export { Title, TitleSize, type TitleLevel } from "./Title";
 export { Toggle } from "./Toggle/Toggle";
+
+// deprecated because moved to Apollo/LF
+export { Accordion } from "./Accordion";
+export { AccordionCore } from "./AccordionCore";
+export { CardCheckbox, CheckboxCard } from "./Form/Checkbox/CardCheckbox";
+export { RadioCard, CardRadio } from "./Form/Radio/RadioCard";
+export { ClickItem, createClickItemParent } from "./List/ClickItem";
+export { TabsClient as Tabs, Direction as TabsDirection } from "./Tabs/Tabs";
+export { Svg } from "./Svg";
+export { FileUpload } from "./Form/FileUpload";
+
+// LF deprecated because renamed
+export { Alert, type AlertType } from "./Alert/Alert";
+export { InputError } from "./Form/InputError";
+export { IconBg } from "./IconBg";
+export { Title, TitleSize, type TitleLevel } from "./Title";
+
+// TODO: move to Apollo/LF or deprecated usage
+export { Card } from "./Card";
+export { BurgerMenu, Header, NavBar, PreviousLink } from "./Layout/Header";
+export { List } from "./List";
+export { ContentTabItem, ContentTabList } from "./List/ContentTabList";
+export { Pagination } from "./Pagination/Pagination";
+export { Skeleton } from "./Skeleton/Skeleton";
+export { SkeletonList } from "./SkeletonList/SkeletonList";

--- a/client/look-and-feel/react/tsconfig.json
+++ b/client/look-and-feel/react/tsconfig.json
@@ -65,7 +65,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    "removeComments": true /* Disable emitting comments. */,
+    "removeComments": false /* Disable emitting comments. */,
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */


### PR DESCRIPTION
### Description
This PR ensures that deprecated components are properly marked and visible by preserving their deprecation comments, which were previously removed during the build process.

### Main Changes
- Added explicit `@deprecated` JSDoc comments to all deprecated components in the `client/look-and-feel/react` package.
- Refactored exports to use named imports and re-exports for deprecated components, ensuring deprecation comments are retained.
- Updated `tsconfig.json` to set `"removeComments": false`, so comments (including deprecation notices) are preserved in the build output.
- Improved consistency of deprecation messaging across all affected files.

### Impacts
- Deprecated components are now clearly marked in the build output, aiding maintainers and consumers.
- No breaking changes to component APIs.
- Slightly larger build output due to preserved comments.
- No impact on runtime performance or compatibility.

### Linked Issue
N/A

