### PR TITLE
fix(slash): change use of children on RadioItem

### DIFF
--- a/slash/react/src/Form/Radio/Radio.tsx
+++ b/slash/react/src/Form/Radio/Radio.tsx
@@ -61,25 +61,26 @@ const Radio = forwardRef<HTMLInputElement, Props>(
     }
 
     return (
-      <div
-        className={classNames("af-form__radio-group", [
-          { "af-form__radio-group-classic": mode === RadioModes.classic },
-        ])}
-      >
-        {options.map((option: Option) => (
-          <RadioItem
-            {...onlyNecessaryProps}
-            key={option.value}
-            isChecked={option.value === value}
-            disabled={option.disabled || disabled}
-            className={classNameMode}
-            ref={inputRef}
-            {...option}
-          >
-            {children}
-          </RadioItem>
-        ))}
-      </div>
+      <>
+        <div
+          className={classNames("af-form__radio-group", [
+            { "af-form__radio-group-classic": mode === RadioModes.classic },
+          ])}
+        >
+          {options.map((option: Option) => (
+            <RadioItem
+              {...onlyNecessaryProps}
+              key={option.value}
+              isChecked={option.value === value}
+              disabled={option.disabled || disabled}
+              className={classNameMode}
+              ref={inputRef}
+              {...option}
+            />
+          ))}
+        </div>
+        {children}
+      </>
     );
   },
 );

--- a/slash/react/src/Form/Radio/RadioItem.tsx
+++ b/slash/react/src/Form/Radio/RadioItem.tsx
@@ -15,7 +15,6 @@ const RadioItem = forwardRef<HTMLInputElement, Props>(
       value = "",
       id,
       isChecked,
-      children,
       label,
       classModifier = "",
       className = "",
@@ -30,7 +29,6 @@ const RadioItem = forwardRef<HTMLInputElement, Props>(
       "af-form__radio",
       disabled,
     );
-    const newLabel = children || label;
     const generatedId = useId();
     const newId = id ?? generatedId;
 
@@ -47,7 +45,7 @@ const RadioItem = forwardRef<HTMLInputElement, Props>(
           disabled={disabled}
         />
         <label className="af-form__label" htmlFor={newId}>
-          <span className="af-form__description">{newLabel}</span>
+          <span className="af-form__description">{label}</span>
         </label>
       </div>
     );


### PR DESCRIPTION
Bug when passing a children to RadioInput with mode different than cardRadio
<img width="511" height="86" alt="image" src="https://github.com/user-attachments/assets/3e9c782e-33a8-459f-b153-168b4b41fe91" />
