### PR TITLE
Fix pre-publish script to stop updating an obsolete peerDependency for apollo/react

### DIFF
--- a/scripts/pre-publish.js
+++ b/scripts/pre-publish.js
@@ -48,9 +48,6 @@ packages.forEach((packageType) => {
   if (packageType === 'look-and-feel/react') {
     packageJson.peerDependencies['@axa-fr/design-system-apollo-react'] = packageJson.version;
   }
-  if (packageType === 'apollo/react') {
-    packageJson.peerDependencies['@axa-fr/design-system-look-and-feel-css'] = packageJson.version
-  }
 
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), { encoding: 'utf-8' });
 });


### PR DESCRIPTION
### Description
Update the pre-publish script so it no longer updates a peerDependency that is no longer required for the `apollo/react` package. This prevents an unnecessary modification of package manifests during the pre-publish step.

### Main Changes
- scripts/pre-publish.js
  - Removed the block that set `packageJson.peerDependencies['@axa-fr/design-system-look-and-feel-css'] = packageJson.version` for `packageType === 'apollo/react'`.
  - Preserved existing behavior for other package types (e.g., `look-and-feel/react`).
  - The script still writes the updated package.json to disk via `writeFileSync`.

### Impacts
- Publishing: prevents accidental addition/updates of the `@axa-fr/design-system-look-and-feel-css` peer dependency for `apollo/react` during pre-publish.
- Compatibility: reduces unintended coupling between packages; should not affect runtime behavior of published packages.
- Risk: low — change is limited to the pre-publish script. Recommend running a publish dry-run to confirm package.json contents before releasing.
- No performance impact.

### Linked Issue
N/A
