### PR TITLE
feat(slash): add mandatory mention component

### DIFF
--- a/apps/slash-stories/src/MandatoryMention.mdx
+++ b/apps/slash-stories/src/MandatoryMention.mdx
@@ -1,0 +1,41 @@
+import { Meta, Story, Canvas, Controls } from "@storybook/blocks";
+import * as MandatoryMentionStories from "./MandatoryMention.stories.tsx";
+import { MandatoryMention } from "@axa-fr/design-system-slash-react";
+
+<Meta of={MandatoryMentionStories} />
+
+# MandatoryMention
+
+Mandatory Mention item is used to inform the user of the expected completion of a form: either all fields are required, or only some of them
+
+## Import
+
+```tsx
+import { MandatoryMention } from "@axa-fr/design-system-slash-react";
+```
+
+## Use
+
+```tsx
+import { MandatoryMention } from "@axa-fr/design-system-slash-react";
+
+function FormHeader() {
+  return (
+    <>
+      <MandatoryMention variant="one" />
+      <MandatoryMention variant="all" />
+    </>
+  );
+}
+```
+
+## Playground
+
+<Story of={MandatoryMentionStories.Default} />
+
+<Controls of={MandatoryMentionStories.Default} />
+
+### Variants
+
+- variant="one": Champs obligatoires \*
+- variant="all": Tous les champs sont obligatoires

--- a/apps/slash-stories/src/MandatoryMention.stories.tsx
+++ b/apps/slash-stories/src/MandatoryMention.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { MandatoryMention } from "@axa-fr/design-system-slash-react";
+
+const meta: Meta<typeof MandatoryMention> = {
+  title: "Components/MandatoryMention",
+  component: MandatoryMention,
+  argTypes: {
+    variant: {
+      control: "radio",
+      options: ["one", "all"],
+    },
+    id: { control: "text" },
+  },
+} satisfies Meta<typeof MandatoryMention>;
+export default meta;
+
+type Story = StoryObj<typeof MandatoryMention>;
+
+export const Default: Story = {
+  args: {
+    variant: "one",
+  },
+};

--- a/slash/css/src/MandatoryMention/MandatoryMention.css
+++ b/slash/css/src/MandatoryMention/MandatoryMention.css
@@ -1,0 +1,7 @@
+.af-mandatory--one {
+  color: var(--red30);
+}
+
+.af-mandatory--all {
+  color: var(--gray50);
+}

--- a/slash/css/src/slash.scss
+++ b/slash/css/src/slash.scss
@@ -38,3 +38,4 @@
 @use "./Popover/Popover";
 @use "./Loader/Loader";
 @use "./CardData/CardData";
+@use "./MandatoryMention/MandatoryMention";

--- a/slash/react/src/MandatoryMention/MandatoryMention.tsx
+++ b/slash/react/src/MandatoryMention/MandatoryMention.tsx
@@ -1,0 +1,25 @@
+import "@axa-fr/design-system-slash-css/dist/MandatoryMention/MandatoryMention.css";
+
+const variantTexts = {
+  all: "Tous les champs sont obligatoires",
+  one: "Champs obligatoires *",
+} as const;
+
+type MandatoryVariant = keyof typeof variantTexts;
+
+type TMandatoryMentionProps = {
+  variant: MandatoryVariant;
+  id?: string;
+};
+
+const MandatoryMention = ({ variant, id }: TMandatoryMentionProps) => {
+  const text = variantTexts[variant];
+
+  return (
+    <p id={id} className={`af-mandatory--${variant}`}>
+      {text}
+    </p>
+  );
+};
+
+export { MandatoryMention };

--- a/slash/react/src/MandatoryMention/__tests__/MandatoryMention.test.tsx
+++ b/slash/react/src/MandatoryMention/__tests__/MandatoryMention.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MandatoryMention } from "../MandatoryMention";
+
+describe("MandatoryMention", () => {
+  it("renders correct text for variant all", () => {
+    render(<MandatoryMention variant="all" />);
+    const el = screen.getByText("Tous les champs sont obligatoires");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass("af-mandatory--all");
+  });
+
+  it("renders correct text for variant one", () => {
+    render(<MandatoryMention variant="one" />);
+    const el = screen.getByText(/Champs obligatoires \*/);
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass("af-mandatory--one");
+  });
+
+  it("applies provided id prop", () => {
+    render(<MandatoryMention variant="one" id="mention-test" />);
+    const el = screen.getByText(/Champs obligatoires \*/);
+    expect(el).toHaveAttribute("id", "mention-test");
+  });
+});

--- a/slash/react/src/index.ts
+++ b/slash/react/src/index.ts
@@ -107,3 +107,5 @@ export { Loader } from "./Loader/Loader";
 
 export { CardData } from "./CardData/CardData";
 export type { CardDataVariant } from "./CardData/CardData";
+
+export { MandatoryMention } from "./MandatoryMention/MandatoryMention";


### PR DESCRIPTION
# fixe #1504

##  🚀 MandatoryMention
 MandatoryMention component is designed to inform users about the required level of completion in a form. It indicates whether all fields are mandatory or only some.

Two variants are available:

* all: All fields are required
* one: Only some fields are required (marked with *)

## Screens
* <img width="173" height="48" alt="image" src="https://github.com/user-attachments/assets/87541aa6-6aa8-4cb5-a4ca-28f770d3fcf5" />
* <img width="244" height="55" alt="image" src="https://github.com/user-attachments/assets/daea76c2-95e9-4193-aa3d-4b93a0b71aac" />

## Links 
* [Lien ZeroHeight](https://zeroheight.com/4b1e27a45/v/latest/p/982460-item-mandatory-mention/b/4461c0)
* [Lien figma](https://www.figma.com/design/reZserxMfytQ9M82bt20Bi/B2B---Distributeurs---Collaborateurs?node-id=2179-14042&t=7zrHJKnS0lXQkF5o-1)


