### PR TITLE
fix(slash): rework title component for contentLeft 

### DIFF
--- a/slash/css/src/Title/Title.scss
+++ b/slash/css/src/Title/Title.scss
@@ -15,52 +15,47 @@ h4.af-title {
 
 .af-title {
   position: relative;
-  flex: 1;
   overflow: hidden;
   font-weight: 600;
   color: common.$color-texte;
 
-  &--container {
+  &--content {
     display: flex;
+    align-items: center;
+    gap: 1rem;
 
-    > * {
-      display: flex;
-      align-items: center;
+    > af-title {
+      flex: 0 0 auto;
     }
 
+    .content-left,
     .content-right {
-      margin-bottom: 0.5em;
+      display: flex;
+      flex: 0 0 auto;
+      align-items: center;
+
+      > .af-btn {
+        width: auto;
+      }
     }
   }
 
-  &::after {
-    z-index: 1;
-    width: 100%;
-    height: 1px;
-    margin: 0.5rem 1rem;
-    flex: 1;
-    background-color: common.$color-gray-1;
-    content: " ";
+  &--container {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+
+    > .af-title {
+      flex: 0 0 auto;
+    }
+
+    > .af-title--content {
+      min-width: 0;
+      flex: 1 1 auto;
+    }
   }
 
   & + .af-title {
     margin-top: 0;
-  }
-
-  &--content {
-    margin: 2rem 0 3rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid common.$color-silver;
-    font-size: 1.75em;
-    font-weight: 600;
-    color: common.$color-mine-shaft;
-
-    &:nth-child(1) {
-      margin-top: 0;
-    }
-  }
-
-  > :first-child {
-    margin-left: 1.5rem;
   }
 }

--- a/slash/react/src/Title/Title.tsx
+++ b/slash/react/src/Title/Title.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 
 import { getComponentClassName } from "../utilities";
+import { Divider } from "../Divider/Divider";
 
 type Headings = "h2" | "h3" | "h4";
 
@@ -46,11 +47,16 @@ export const Title = forwardRef<
       <div className={`${baseClass}--container`}>
         <Heading ref={ref} className={componentClassName} {...otherProps}>
           {children}
-          {contentLeft}
         </Heading>
-        {contentRight ? (
-          <div className="content-right">{contentRight}</div>
-        ) : null}
+        <div className={`${baseClass}--content`}>
+          {contentLeft ? (
+            <div className="content-left">{contentLeft}</div>
+          ) : null}
+          <Divider mode="horizontal" />
+          {contentRight ? (
+            <div className="content-right">{contentRight}</div>
+          ) : null}
+        </div>
       </div>
     );
   },

--- a/slash/react/src/Title/__tests__/Title.test.tsx
+++ b/slash/react/src/Title/__tests__/Title.test.tsx
@@ -1,133 +1,104 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { Title } from "../Title";
 
 describe("Title", () => {
-  it("should render children", () => {
-    // Act
+  it("renders children with default h2 heading", () => {
     render(<Title>A title</Title>);
-
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).toBeInTheDocument();
   });
 
-  it("should have default class", () => {
-    // Act
+  it("applies default class", () => {
     render(<Title>A title</Title>);
-
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("af-title", {
-      exact: true,
-    });
+    ).toHaveClass("af-title", { exact: true });
   });
 
-  it("should have custom class", () => {
-    // Act
+  it("applies custom class", () => {
     render(<Title className="custom-class">A title</Title>);
-
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("custom-class", {
-      exact: true,
-    });
+    ).toHaveClass("custom-class", { exact: true });
   });
 
-  it("should have custom class with modifier", () => {
-    // Act
+  it("applies custom class with modifier", () => {
     render(
       <Title className="custom-class" classModifier="modifier">
         A title
       </Title>,
     );
-
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("custom-class custom-class--modifier", {
-      exact: true,
-    });
+    ).toHaveClass("custom-class custom-class--modifier", { exact: true });
   });
 
-  it("should not have classModifier attribute", () => {
-    // Act
+  it("does not expose classModifier attribute", () => {
     render(
       <Title className="custom-class" classModifier="modifier">
         A title
       </Title>,
     );
-
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).not.toHaveAttribute("classModifier");
   });
 
-  it("should have correct heading level", () => {
-    // Act
+  it("uses configured heading level", () => {
     render(<Title heading="h3">A title</Title>);
-
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 3 }),
     ).toBeInTheDocument();
   });
 
-  it("shouldn't have an accessibility violation <Title/>", async () => {
-    // Act
+  it("has no accessibility violations", async () => {
     const { container } = render(<Title heading="h3">A title</Title>);
-
-    // Assert
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("should be wrapped in a container", async () => {
-    // Act
+  it("is wrapped in container", () => {
     render(<Title heading="h3">A title</Title>);
-
-    // Assert
     const container = screen.getByRole("heading", {
       name: /A title/,
       level: 3,
-    }).parentElement as HTMLElement;
-    expect(container.getAttribute("class")).toEqual("af-title--container");
-  });
-
-  it("content left should be child of heading", () => {
-    // Act
-    render(
-      <Title heading="h3" contentLeft={<p>Some content</p>}>
-        A title
-      </Title>,
-    );
-
-    // Assert
-    const heading = screen.getByRole("heading", {
-      level: 3,
-    });
-
-    expect(within(heading).getByText("Some content")).toBeInTheDocument();
-  });
-
-  it("content right should be child of content-right div", () => {
-    // Act
-    render(
-      <Title heading="h3" contentRight={<p>Some content</p>}>
-        A title
-      </Title>,
-    );
-
-    // Assert
-    const container = screen.getByRole("heading", {
-      level: 3,
     }).parentElement!;
+    expect(container).toHaveClass("af-title--container");
+  });
 
-    expect(
-      within(container.childNodes[1] as HTMLElement).getByText("Some content"),
-    ).toBeInTheDocument();
+  it("renders contentLeft inside .content-left wrapper", () => {
+    render(
+      <Title heading="h3" contentLeft={<p>Left content</p>}>
+        A title
+      </Title>,
+    );
+    const el = screen.getByText("Left content");
+    expect(el.closest(".content-left")).not.toBeNull();
+  });
+
+  it("renders contentRight inside .content-right wrapper", () => {
+    render(
+      <Title heading="h3" contentRight={<p>Right content</p>}>
+        A title
+      </Title>,
+    );
+    const el = screen.getByText("Right content");
+    expect(el.closest(".content-right")).not.toBeNull();
+  });
+
+  it("renders horizontal divider between optional contents", () => {
+    render(
+      <Title
+        heading="h3"
+        contentLeft={<span>L</span>}
+        contentRight={<span>R</span>}
+      >
+        A title
+      </Title>,
+    );
+    const container = screen.getByRole("heading", { level: 3 }).parentElement!;
+    const contentWrapper = container.querySelector(".af-title--content")!;
+    expect(contentWrapper.children[1]).toBeTruthy();
   });
 });


### PR DESCRIPTION
# fixe #1444

##  🚀 Rework Title Element on Slash
* Use Divider component 
* Remove Element on Heading Html Element
* Rework Css
* Update Unit test


## Html exemple

new structure

```html
<div class="af-title--container">
  <h2 class="af-title">Title with content</h2>
  <div class="af-title--content">
    <div class="content-left">
      <button type="button" class="af-btn">Click me</button>
    </div>
    <hr class="af-divider af-divider--horizontal" />
    <div class="content-right">
      <a class="af-slash-link" href="/">Click me</a>
    </div>
  </div>
</div>
```


## Screens

<img width="907" height="84" alt="image" src="https://github.com/user-attachments/assets/9d113d60-0389-4040-a64a-b38335ae6c85" />
