### PR TITLE
feat(apollo, look&feel): update input date deprectated props

### DIFF
--- a/apps/apollo-stories/src/components/InputDate/InputDate.mdx
+++ b/apps/apollo-stories/src/components/InputDate/InputDate.mdx
@@ -13,7 +13,7 @@ import { InputDate } from "@axa-fr/design-system-apollo-react";
 const MyComponent = () => (
   <>
     <InputDate
-      buttonLabel="En savoir plus"
+      moreButtonLabel="En savoir plus"
       description="Description"
       helper="Informations complémentaires"
       id="uniqueId"

--- a/apps/apollo-stories/src/components/InputDate/InputDate.stories.tsx
+++ b/apps/apollo-stories/src/components/InputDate/InputDate.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof InputDate> = {
     label: "Date de naissance",
     required: true,
     description: "Description",
-    buttonLabel: "En savoir plus",
+    moreButtonLabel: "En savoir plus",
     helper: "Informations complémentaires",
     hidePicker: false,
     message: "",

--- a/apps/look-and-feel-stories/src/InputDate/InputDate.mdx
+++ b/apps/look-and-feel-stories/src/InputDate/InputDate.mdx
@@ -13,7 +13,7 @@ import { InputDate } from "@axa-fr/design-system-apollo-react/lf";
 const MyComponent = () => (
   <>
     <InputDate
-      buttonLabel="En savoir plus"
+      moreButtonLabel="En savoir plus"
       description="Description"
       helper="Informations complémentaires"
       id="uniqueId"

--- a/apps/look-and-feel-stories/src/InputDate/InputDate.stories.tsx
+++ b/apps/look-and-feel-stories/src/InputDate/InputDate.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof InputDate> = {
     label: "Date de naissance",
     required: true,
     description: "Description",
-    buttonLabel: "En savoir plus",
+    moreButtonLabel: "En savoir plus",
     helper: "Informations complémentaires",
     hidePicker: false,
     message: "",

--- a/client/apollo/react/src/Form/InputDate/InputDateCommon.tsx
+++ b/client/apollo/react/src/Form/InputDate/InputDateCommon.tsx
@@ -5,7 +5,7 @@ import {
   forwardRef,
   useId,
 } from "react";
-import { getComponentClassName } from "../../utilities/getComponentClassName";
+import { getClassName } from "../../utilities/getClassName";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -82,11 +82,11 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
     },
     inputRef,
   ) => {
-    const componentClassName = getComponentClassName(
-      "af-form__input-date",
-      className ?? "",
-      classModifier,
-    );
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-date",
+      modifiers: classModifier.split(" "),
+      className,
+    });
 
     let inputId = useId();
     inputId = otherProps.id ?? inputId;

--- a/client/apollo/react/src/Form/InputDate/InputDateCommon.tsx
+++ b/client/apollo/react/src/Form/InputDate/InputDateCommon.tsx
@@ -6,8 +6,6 @@ import {
   useId,
 } from "react";
 import { getComponentClassName } from "../../utilities/getComponentClassName";
-import { InputDateAtom } from "./InputDateAtom";
-import { InputDateTextAtom } from "./InputDateTextAtom";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -16,6 +14,8 @@ import {
   ItemMessage,
   type ItemMessageProps,
 } from "../ItemMessage/ItemMessageCommon";
+import { InputDateAtom } from "./InputDateAtom";
+import { InputDateTextAtom } from "./InputDateTextAtom";
 
 export type InputDateProps = Omit<
   ComponentPropsWithRef<"input">,
@@ -36,8 +36,18 @@ export type InputDateProps = Omit<
    */
   success?: string;
   hidePicker?: boolean;
-  label: ItemLabelProps["label"];
-} & Partial<Omit<ItemLabelProps, "onChange"> & ItemMessageProps>;
+  label: ItemLabelProps["children"];
+} & Partial<
+    Pick<
+      ItemLabelProps,
+      | "description"
+      | "buttonLabel"
+      | "moreButtonLabel"
+      | "onButtonClick"
+      | "onMoreButtonClick"
+    > &
+      ItemMessageProps
+  >;
 
 type InputDateCommonProps = InputDateProps & {
   ItemLabelComponent: ComponentType<
@@ -59,7 +69,9 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
       label,
       description,
       buttonLabel,
+      moreButtonLabel,
       onButtonClick,
+      onMoreButtonClick,
       ItemLabelComponent,
       ItemMessageComponent,
       required,
@@ -101,13 +113,14 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
     return (
       <div className="af-form__input-container">
         <ItemLabelComponent
-          label={label}
           description={description}
-          buttonLabel={buttonLabel}
-          onButtonClick={onButtonClick}
+          moreButtonLabel={buttonLabel || moreButtonLabel}
+          onMoreButtonClick={onButtonClick || onMoreButtonClick}
           required={required}
-          inputId={inputId}
-        />
+          htmlFor={inputId}
+        >
+          {label}
+        </ItemLabelComponent>
         {hidePicker ? (
           <InputDateTextAtom
             {...otherProps}

--- a/client/apollo/react/src/Form/InputDate/__tests__/InputDate.test.tsx
+++ b/client/apollo/react/src/Form/InputDate/__tests__/InputDate.test.tsx
@@ -22,7 +22,7 @@ describe("<InputDate />", () => {
         onChange={() => {}}
         required
         description="description"
-        buttonLabel="buttonLabel"
+        moreButtonLabel="moreButtonLabel"
         helper="helper"
       />,
     );

--- a/client/apollo/react/src/Form/ItemLabel/ItemLabelCommon.tsx
+++ b/client/apollo/react/src/Form/ItemLabel/ItemLabelCommon.tsx
@@ -1,13 +1,13 @@
+import infoIcon from "@material-symbols/svg-400/outlined/info.svg";
 import {
   useId,
+  type ComponentProps,
   type ComponentType,
   type MouseEventHandler,
   type ReactNode,
-  type ComponentProps,
 } from "react";
-import infoIcon from "@material-symbols/svg-400/outlined/info.svg";
-import { Svg } from "../../Svg/Svg";
 import type { ButtonProps } from "../../Button/ButtonCommon";
+import { Svg } from "../../Svg/Svg";
 
 export type ItemLabelProps = ComponentProps<"label"> & {
   /**
@@ -60,7 +60,7 @@ export type ItemLabelProps = ComponentProps<"label"> & {
 
   /**
    * Click handler for the info button
-   * @deprecated use `onInfoButtonClick` instead.
+   * @deprecated use `onMoreButtonClick` instead.
    */
   onButtonClick?: MouseEventHandler<HTMLButtonElement>;
 


### PR DESCRIPTION
What has been done:
- Update deprecated types in `InputDate` previously inherited from `ItemLabel`
- Use Pick instead of Omit to select specific props from `ItemLabel`
- Replace `getComponentClassName` with `getClassName`
