### PR TITLE
fix(apollo,look&feel): fix default error style of CardRadio and CardCheckbox

### DIFF
--- a/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
@@ -58,7 +58,7 @@ export const CardCheckboxCommon = ({
   CardCheckboxItemComponent,
   ItemMessageComponent,
   message,
-  messageType,
+  messageType = "error",
   ...inputProps
 }: CardCheckboxCommonProps) => {
   const generatedId = useId();
@@ -135,7 +135,7 @@ export const CardCheckboxCommon = ({
       <ItemMessageComponent
         id={messageId}
         message={message || error}
-        messageType={messageType || "error"}
+        messageType={messageType}
       />
     </fieldset>
   );

--- a/client/apollo/react/src/Form/Checkbox/CardCheckbox/__tests__/CardCheckbox.test.tsx
+++ b/client/apollo/react/src/Form/Checkbox/CardCheckbox/__tests__/CardCheckbox.test.tsx
@@ -102,7 +102,7 @@ describe("CardCheckbox", () => {
 
     expect(screen.getByText("Quelle ville ?")).toContainHTML("*");
     expect(screen.getByRole("checkbox", { name: /Paris/ })).toBeRequired();
-    expect(screen.getByRole("checkbox", { name: /Londre/ })).toBeRequired();
+    expect(screen.getByRole("checkbox", { name: /Londres/ })).toBeRequired();
   });
 
   it("should remove required when one of checkbox is checked", async () => {
@@ -112,12 +112,14 @@ describe("CardCheckbox", () => {
     await user.click(screen.getByRole("checkbox", { name: /Paris/ }));
 
     expect(screen.getByRole("checkbox", { name: /Paris/ })).not.toBeRequired();
-    expect(screen.getByRole("checkbox", { name: /Londre/ })).not.toBeRequired();
+    expect(
+      screen.getByRole("checkbox", { name: /Londres/ }),
+    ).not.toBeRequired();
 
     await user.click(screen.getByRole("checkbox", { name: /Paris/ }));
 
     expect(screen.getByRole("checkbox", { name: /Paris/ })).toBeRequired();
-    expect(screen.getByRole("checkbox", { name: /Londre/ })).toBeRequired();
+    expect(screen.getByRole("checkbox", { name: /Londres/ })).toBeRequired();
   });
 
   it("should not set checkboxes as required when required is false", async () => {
@@ -127,11 +129,26 @@ describe("CardCheckbox", () => {
     await user.click(screen.getByRole("checkbox", { name: /Paris/ }));
 
     expect(screen.getByRole("checkbox", { name: /Paris/ })).not.toBeRequired();
-    expect(screen.getByRole("checkbox", { name: /Londre/ })).not.toBeRequired();
+    expect(
+      screen.getByRole("checkbox", { name: /Londres/ }),
+    ).not.toBeRequired();
 
     await user.click(screen.getByRole("checkbox", { name: /Paris/ }));
 
     expect(screen.getByRole("checkbox", { name: /Paris/ })).not.toBeRequired();
-    expect(screen.getByRole("checkbox", { name: /Londre/ })).not.toBeRequired();
+    expect(
+      screen.getByRole("checkbox", { name: /Londres/ }),
+    ).not.toBeRequired();
+  });
+
+  it("should display message with error type by default", () => {
+    render(<CardCheckbox {...defaultArgs} message="Error message" />);
+
+    expect(
+      screen.getByRole("checkbox", { name: /Paris/ }),
+    ).toHaveAccessibleErrorMessage("Error message");
+    expect(
+      screen.getByRole("checkbox", { name: /Londres/ }),
+    ).toHaveAccessibleErrorMessage("Error message");
   });
 });

--- a/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -70,7 +70,7 @@ const CardRadioCommon = ({
   type = "vertical",
   error,
   message,
-  messageType,
+  messageType = "error",
   name,
   value,
   id,

--- a/client/apollo/react/src/Form/Radio/CardRadio/__tests__/CardRadio.test.tsx
+++ b/client/apollo/react/src/Form/Radio/CardRadio/__tests__/CardRadio.test.tsx
@@ -129,4 +129,20 @@ describe("Radio card Component", () => {
     expect(radiogroup).toContainHTML("*");
     expect(radiogroup).toBeRequired();
   });
+
+  it("should display message with error type by default", () => {
+    render(
+      <CardRadio
+        label="Choose a city"
+        options={radioOptions}
+        message="Error message"
+      />,
+    );
+    const radiogroup = screen.getByRole("radiogroup", {
+      name: "Choose a city",
+    });
+
+    expect(radiogroup).not.toBeValid();
+    expect(radiogroup).toHaveAccessibleErrorMessage("Error message");
+  });
 });


### PR DESCRIPTION
# Description

Défini le `messageType` par défaut sur `error` directement dans les props de `CardRadioCommon` et `CardCheckboxCommon`.
Avant le fix, il fallait toujours préciser `messageType` pour avoir le style des cards alors qu'il est par défaut en `error` dans `ItemMessageComponent`.

---

# Rendu sans préciser `messageType`

## CardCheckbox

### Avant fix

<img width="1011" height="346" alt="image" src="https://github.com/user-attachments/assets/a318fc2b-62c1-4d88-8f00-a128a40a8441" />

### Après fix

<img width="1010" height="348" alt="image" src="https://github.com/user-attachments/assets/d5bfe1e4-4250-4a4c-979f-1f4681641d73" />

## CardRadio

### Avant fix

<img width="1008" height="336" alt="image" src="https://github.com/user-attachments/assets/57e155f9-4691-45f1-9de7-247470053a5c" />

### Après fix

<img width="1009" height="346" alt="image" src="https://github.com/user-attachments/assets/148d3ead-8c07-4494-a39c-1f5c5cc7a319" />
