### PR TITLE
fix(prospect,client): manage deprecated props from item label

### DIFF
--- a/packages/canopee-react/src/prospect-client/Form/Dropdown/DropdownCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Dropdown/DropdownCommon.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import {
   type ComponentProps,
   type ComponentPropsWithRef,
@@ -5,7 +6,6 @@ import {
   forwardRef,
   useId,
 } from "react";
-import classNames from "classnames";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -18,7 +18,7 @@ import {
 export type DropdownProps = ComponentPropsWithRef<"select"> & {
   id?: string;
   classModifier?: string;
-  label?: ItemLabelProps["label"];
+  label?: ItemLabelProps["children"];
   /**
    * @deprecated Use `message` and messageType instead.
    */
@@ -28,10 +28,18 @@ export type DropdownProps = ComponentPropsWithRef<"select"> & {
    */
   success?: string;
   placeholder?: string;
-  buttonLabel?: string;
   description?: string;
   helper?: string;
-} & Partial<ItemLabelProps & ItemMessageProps>;
+} & Pick<
+    ItemLabelProps,
+    | "buttonLabel"
+    | "moreButtonLabel"
+    | "onButtonClick"
+    | "onMoreButtonClick"
+    | "sideButtonLabel"
+    | "onSideButtonClick"
+  > &
+  Pick<ItemMessageProps, "message" | "messageType">;
 
 type DropdownCommonProps = DropdownProps & {
   ItemLabelComponent: ComponentType<
@@ -55,7 +63,9 @@ const DropdownCommon = forwardRef<HTMLSelectElement, DropdownCommonProps>(
       messageType,
       description,
       buttonLabel,
+      moreButtonLabel,
       onButtonClick,
+      onMoreButtonClick,
       sideButtonLabel,
       onSideButtonClick,
       ItemLabelComponent,
@@ -79,15 +89,16 @@ const DropdownCommon = forwardRef<HTMLSelectElement, DropdownCommonProps>(
     return (
       <div className="af-form__dropdown-container">
         <ItemLabelComponent
-          label={label}
           description={description}
-          buttonLabel={buttonLabel}
-          onButtonClick={onButtonClick}
+          moreButtonLabel={moreButtonLabel ?? buttonLabel}
+          onMoreButtonClick={onMoreButtonClick ?? onButtonClick}
           sideButtonLabel={sideButtonLabel}
           onSideButtonClick={onSideButtonClick}
           required={required}
-          inputId={inputId}
-        />
+          htmlFor={inputId}
+        >
+          {label}
+        </ItemLabelComponent>
         <select
           className={classname}
           {...otherProps}

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDate.helper.ts
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDate.helper.ts
@@ -1,4 +1,4 @@
-export const formatInputDateValue = (value?: Date | string) =>
+export const formatInputDateValue = (value?: Date | string | number) =>
   value instanceof Date ? value.toISOString().split("T")[0] : value;
 
 export const isValidDayDecimal = (char: string, index: number): boolean =>

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateAtom.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateAtom.tsx
@@ -1,4 +1,8 @@
-import { type ComponentPropsWithRef, forwardRef } from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithRef,
+  forwardRef,
+} from "react";
 import { formatInputDateValue } from "./InputDate.helper";
 
 export type InputDateAtomProps = Omit<
@@ -7,8 +11,8 @@ export type InputDateAtomProps = Omit<
 > & {
   defaultValue?: Date | string;
   value?: Date | string;
-  min?: Date | string;
-  max?: Date | string;
+  min?: ComponentProps<"input">["min"] | Date;
+  max?: ComponentProps<"input">["max"] | Date;
 };
 
 const InputDateAtom = forwardRef<HTMLInputElement, InputDateAtomProps>(

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
@@ -14,7 +14,7 @@ import {
   ItemMessage,
   type ItemMessageProps,
 } from "../ItemMessage/ItemMessageCommon";
-import { InputDateAtom } from "./InputDateAtom";
+import { InputDateAtom, type InputDateAtomProps } from "./InputDateAtom";
 import { InputDateTextAtom } from "./InputDateTextAtom";
 
 export type InputDateProps = Omit<
@@ -24,8 +24,8 @@ export type InputDateProps = Omit<
   classModifier?: string;
   defaultValue?: Date | string;
   value?: Date | string;
-  min?: Date | string;
-  max?: Date | string;
+  min?: InputDateAtomProps["min"];
+  max?: InputDateAtomProps["max"];
   helper?: string;
   /**
    * @deprecated Use `message` and messageType instead.

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
@@ -114,8 +114,8 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
       <div className="af-form__input-container">
         <ItemLabelComponent
           description={description}
-          moreButtonLabel={buttonLabel || moreButtonLabel}
-          onMoreButtonClick={onButtonClick || onMoreButtonClick}
+          moreButtonLabel={moreButtonLabel ?? buttonLabel}
+          onMoreButtonClick={onMoreButtonClick ?? onButtonClick}
           required={required}
           htmlFor={inputId}
         >

--- a/packages/canopee-react/src/prospect-client/Form/InputPhone/InputPhoneCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputPhone/InputPhoneCommon.tsx
@@ -7,6 +7,8 @@ import {
   useId,
 } from "react";
 import { SingleValue } from "react-select";
+import { Icon } from "../../Icon/IconCommon";
+import { InputTextAtom } from "../InputTextAtom/InputTextAtomCommon";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -15,10 +17,8 @@ import {
   ItemMessage,
   type ItemMessageProps,
 } from "../ItemMessage/ItemMessageCommon";
-import { InputTextAtom } from "../InputTextAtom/InputTextAtomCommon";
-import { Icon } from "../../Icon/IconCommon";
-import { type OptionType } from "./InputPhone.types";
 import { CountryCodeSelect } from "./CountryCodeSelect";
+import { type OptionType } from "./InputPhone.types";
 import { maskFrenchPhoneNumber } from "./maskFrenchPhoneNumber";
 
 export type InputPhoneProps = ComponentPropsWithRef<"input"> & {
@@ -39,8 +39,18 @@ export type InputPhoneProps = ComponentPropsWithRef<"input"> & {
   onChangeSelect?: (value: SingleValue<OptionType>) => void;
   onChangeInput?: (value: string) => void;
   mask?: (value: string) => string;
-  label: ItemLabelProps["label"];
-} & Partial<ItemLabelProps & ItemMessageProps>;
+  label: ItemLabelProps["children"];
+} & Pick<
+    ItemLabelProps,
+    | "description"
+    | "moreButtonLabel"
+    | "buttonLabel"
+    | "onMoreButtonClick"
+    | "onButtonClick"
+    | "sideButtonLabel"
+    | "onSideButtonClick"
+  > &
+  Pick<ItemMessageProps, "message" | "messageType">;
 
 type InputPhoneCommonProps = InputPhoneProps & {
   ItemLabelComponent: ComponentType<
@@ -67,7 +77,9 @@ const InputPhoneCommon = forwardRef<HTMLInputElement, InputPhoneCommonProps>(
       label,
       description,
       buttonLabel,
+      moreButtonLabel,
       onButtonClick,
+      onMoreButtonClick,
       required,
       sideButtonLabel,
       onSideButtonClick,
@@ -116,15 +128,16 @@ const InputPhoneCommon = forwardRef<HTMLInputElement, InputPhoneCommonProps>(
     return (
       <div className="af-form__input-phone-container">
         <ItemLabelComponent
-          label={label}
           description={description}
-          buttonLabel={buttonLabel}
-          onButtonClick={onButtonClick}
+          moreButtonLabel={moreButtonLabel ?? buttonLabel}
+          onMoreButtonClick={onMoreButtonClick ?? onButtonClick}
           sideButtonLabel={sideButtonLabel}
           onSideButtonClick={onSideButtonClick}
           required={required}
-          inputId={inputId}
-        />
+          htmlFor={inputId}
+        >
+          {label}
+        </ItemLabelComponent>
 
         <div className="af-form__input-phone-fields">
           {showSelect ? (

--- a/packages/canopee-react/src/prospect-client/Form/InputText/InputTextCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputText/InputTextCommon.tsx
@@ -19,6 +19,7 @@ import {
 export type InputTextProps = ComponentPropsWithRef<"input"> & {
   unit?: ReactNode;
   classModifier?: string;
+  label?: ItemLabelProps["children"];
   helper?: string;
   /**
    * @deprecated Use `message` and messageType instead.
@@ -28,7 +29,17 @@ export type InputTextProps = ComponentPropsWithRef<"input"> & {
    * @deprecated Use `message` and messageType instead.
    */
   success?: string;
-} & Partial<ItemLabelProps & ItemMessageProps>;
+} & Pick<
+    ItemLabelProps,
+    | "description"
+    | "moreButtonLabel"
+    | "buttonLabel"
+    | "onMoreButtonClick"
+    | "onButtonClick"
+    | "sideButtonLabel"
+    | "onSideButtonClick"
+  > &
+  Pick<ItemMessageProps, "message" | "messageType">;
 
 type InputTextCommonProps = InputTextProps & {
   ItemLabelComponent: ComponentType<
@@ -52,7 +63,9 @@ const InputTextCommon = forwardRef<HTMLInputElement, InputTextCommonProps>(
       label,
       description,
       buttonLabel,
+      moreButtonLabel,
       onButtonClick,
+      onMoreButtonClick,
       required,
       sideButtonLabel,
       onSideButtonClick,
@@ -75,15 +88,16 @@ const InputTextCommon = forwardRef<HTMLInputElement, InputTextCommonProps>(
     return (
       <div className="af-form__input-container">
         <ItemLabelComponent
-          label={label}
           description={description}
-          buttonLabel={buttonLabel}
-          onButtonClick={onButtonClick}
+          moreButtonLabel={moreButtonLabel ?? buttonLabel}
+          onMoreButtonClick={onMoreButtonClick ?? onButtonClick}
           sideButtonLabel={sideButtonLabel}
           onSideButtonClick={onSideButtonClick}
           required={required}
-          inputId={inputId}
-        />
+          htmlFor={inputId}
+        >
+          {label}
+        </ItemLabelComponent>
 
         <InputTextAtomComponent
           id={inputId}

--- a/packages/canopee-react/src/prospect-client/Form/TextArea/TextAreaCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/TextArea/TextAreaCommon.tsx
@@ -3,7 +3,6 @@ import {
   ComponentPropsWithRef,
   type ComponentType,
   forwardRef,
-  MouseEventHandler,
   useId,
 } from "react";
 import {
@@ -16,13 +15,23 @@ import {
 } from "../ItemMessage/ItemMessageCommon";
 
 export type TextAreaProps = ComponentPropsWithRef<"textarea"> & {
+  label?: ItemLabelProps["children"];
   helper?: string;
   /**
    * @deprecated Use `message` and messageType instead.
    */
   error?: string;
-  onButtonClick?: MouseEventHandler<HTMLButtonElement>;
-} & Partial<ItemMessageProps & ItemLabelProps>;
+} & Pick<
+    ItemLabelProps,
+    | "description"
+    | "moreButtonLabel"
+    | "buttonLabel"
+    | "onMoreButtonClick"
+    | "onButtonClick"
+    | "sideButtonLabel"
+    | "onSideButtonClick"
+  > &
+  Pick<ItemMessageProps, "message" | "messageType">;
 
 type TextAreaCommonProps = TextAreaProps & {
   ItemLabelComponent: ComponentType<
@@ -43,7 +52,9 @@ const TextAreaCommon = forwardRef<HTMLTextAreaElement, TextAreaCommonProps>(
       message,
       messageType,
       buttonLabel,
+      moreButtonLabel,
       onButtonClick,
+      onMoreButtonClick,
       required,
       sideButtonLabel,
       ItemLabelComponent,
@@ -69,15 +80,16 @@ const TextAreaCommon = forwardRef<HTMLTextAreaElement, TextAreaCommonProps>(
           .join(" ")}
       >
         <ItemLabelComponent
-          label={label}
           description={description}
-          buttonLabel={buttonLabel}
-          onButtonClick={onButtonClick}
+          moreButtonLabel={moreButtonLabel ?? buttonLabel}
+          onMoreButtonClick={onMoreButtonClick ?? onButtonClick}
           sideButtonLabel={sideButtonLabel}
           onSideButtonClick={onSideButtonClick}
           required={required}
-          inputId={inputId}
-        />
+          htmlFor={inputId}
+        >
+          {label}
+        </ItemLabelComponent>
 
         <textarea
           id={inputId}


### PR DESCRIPTION
## Summary

This pull request refactors several form components in `packages/canopee-react/src/prospect-client/Form` to improve type safety, clarify prop usage, and better handle deprecated props from `ItemLabelCommon`.

### Key Changes

- **Type Improvements:**  
  - Updated `label` prop to use `ItemLabelProps["children"]` instead of the deprecated `label` prop, ensuring consistency and future-proofing.
  - Refactored prop types for `Dropdown`, `InputPhone`, `InputText`, and `TextArea` to use `Pick` for relevant label and message props, making types more explicit and reducing reliance on `Partial<ItemLabelProps & ItemMessageProps>`.

- **InputDate Compatibility Fix:**  
  - Fixed `InputDate` to support `number` types and allow `min`/`max` as either native values or `Date` objects.  
  - This resolves issues with React Hook Form's `register`, which requires `min` and `max` types to closely match native input types.

- **Deprecated Prop Handling:**  
  - Improved management of deprecated props, especially those inherited from `ItemLabelCommon`, to reduce confusion and encourage use of the new pattern.

- **Button Label Extensibility:**  
  - Added support for new button-related label props (`moreButtonLabel`, `onMoreButtonClick`, etc.) and updated logic to prefer `moreButtonLabel` over `buttonLabel` where relevant.

- **Consistent Label Rendering:**  
  - All labels are now rendered using the `children` prop and wrapped in `ItemLabelComponent` for consistent display and accessibility.

- **Code Cleanup:**  
  - Reordered and cleaned up imports, removing unused ones.