### PR TITLE
chore(canopee): upgrade dev scripts to support React and CSS in watch build

### DIFF
--- a/apps/apollo-stories/turbo.json
+++ b/apps/apollo-stories/turbo.json
@@ -4,6 +4,14 @@
         "//"
     ],
     "tasks": {
+        "dev": {
+            "with": [
+                "@axa-fr/canopee-css#dev:prospect",
+                "@axa-fr/canopee-react#dev"
+            ],
+            "persistent": true,
+            "cache": false
+        },
         "lint": {
             "dependsOn": [
                 "eslint",

--- a/apps/look-and-feel-stories/turbo.json
+++ b/apps/look-and-feel-stories/turbo.json
@@ -4,6 +4,14 @@
         "//"
     ],
     "tasks": {
+        "dev": {
+            "with": [
+                "@axa-fr/canopee-css#dev:client",
+                "@axa-fr/canopee-react#dev"
+            ],
+            "persistent": true,
+            "cache": false
+        },
         "lint": {
             "dependsOn": [
                 "eslint",

--- a/apps/slash-stories/turbo.json
+++ b/apps/slash-stories/turbo.json
@@ -6,7 +6,8 @@
     "tasks": {
         "dev": {
             "with": [
-                "@axa-fr/design-system-slash-css#dev"
+                "@axa-fr/canopee-css#dev:distributeur",
+                "@axa-fr/canopee-react#dev"
             ],
             "persistent": true,
             "cache": false

--- a/packages/canopee-css/turbo.json
+++ b/packages/canopee-css/turbo.json
@@ -4,6 +4,15 @@
         "//"
     ],
     "tasks": {
+        "dev:client": {
+            "cache": false
+        },
+        "dev:prospect": {
+            "cache": false
+        },
+        "dev:distributeur": {
+            "cache": false
+        },
         "lint": {
             "dependsOn": [
                 "stylelint"

--- a/packages/canopee-react/package.json
+++ b/packages/canopee-react/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
     "build": "tsc -p tsconfig.build.json",
     "eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "eslint:fix": "eslint src --ext js,jsx,ts,tsx --fix",


### PR DESCRIPTION
This pull request improves the development workflow for our Storybook apps and related packages.

**Key changes:**

- Added new `dev` tasks in the `turbo.json` files for the Storybook apps (`apollo-stories`, `look-and-feel-stories`, `slash-stories`). These tasks let you run development environments for specific client types (`prospect`, `client`, `distributeur`) and include the shared `canopee-react` package.
- Added targeted development tasks (`dev:client`, `dev:prospect`, `dev:distributeur`) in `packages/canopee-css/turbo.json` for more flexible builds.
- Added a `dev` script to `packages/canopee-react/package.json` to enable TypeScript watch mode for easier local development.

These changes make it easier and faster to work on different parts of the project.