### PR TITLE
feat(canopee): update sample to use canopee packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21172,6 +21172,11 @@
       "name": "sample-vite",
       "version": "0.0.0",
       "dependencies": {
+        "@axa-fr/canopee-css": "*",
+        "@axa-fr/canopee-react": "*",
+        "@axa-fr/design-system-apollo-css": "*",
+        "@axa-fr/design-system-apollo-react": "*",
+        "@axa-fr/design-system-look-and-feel-css": "*",
         "@axa-fr/design-system-look-and-feel-react": "*",
         "@axa-fr/design-system-slash-css": "*",
         "@axa-fr/design-system-slash-react": "*",

--- a/samples/vite/package.json
+++ b/samples/vite/package.json
@@ -11,7 +11,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@axa-fr/canopee-react": "*",
+    "@axa-fr/canopee-css": "*",
+    "@axa-fr/design-system-apollo-react": "*",
+    "@axa-fr/design-system-apollo-css": "*",
     "@axa-fr/design-system-look-and-feel-react": "*",
+    "@axa-fr/design-system-look-and-feel-css": "*",
     "@axa-fr/design-system-slash-react": "*",
     "@axa-fr/design-system-slash-css": "*",
     "@material-symbols/svg-400": "^0.31.2",

--- a/samples/vite/src/Agent.tsx
+++ b/samples/vite/src/Agent.tsx
@@ -1,4 +1,4 @@
-import logoAxa from "@axa-fr/design-system-slash-css/logo-axa.svg";
+import logoAxa from "@axa-fr/canopee-css/logo-axa.svg";
 
 import {
   Action,
@@ -26,7 +26,7 @@ import {
   Title,
   Tr,
   User,
-} from "@axa-fr/design-system-slash-react";
+} from "@axa-fr/canopee-react/distributeur";
 import openInNew from "@material-symbols/svg-400/outlined/open_in_new.svg";
 import { useRef, useState } from "react";
 import { NavLink } from "react-router";

--- a/samples/vite/src/App.tsx
+++ b/samples/vite/src/App.tsx
@@ -1,4 +1,4 @@
-import axalogo from "@axa-fr/design-system-slash-css/logo-axa.svg";
+import axalogo from "@axa-fr/canopee-css/logo-axa.svg";
 import { Navigate, NavLink, Route, Routes } from "react-router";
 import Agent from "./Agent";
 import "./App.css";

--- a/samples/vite/src/Client.tsx
+++ b/samples/vite/src/Client.tsx
@@ -1,12 +1,11 @@
 import {
-  Button as ButtonClient,
-  buttonVariants as ButtonClientVariants,
+  Button,
   CardCheckbox,
-  RadioCard,
-  Select,
-  Svg,
-  TextInput,
-} from "@axa-fr/design-system-look-and-feel-react";
+  CardRadio,
+  Dropdown,
+  Icon,
+  InputText,
+} from "@axa-fr/canopee-react/client";
 import acUnit from "@material-symbols/svg-400/outlined/ac_unit.svg";
 
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -46,24 +45,26 @@ const Client = () => {
           </header>
           <p className="af-test-token-css">Test de token CSS</p>
           <article>
-            <TextInput
+            <InputText
               {...register("exampleTextInput", {
                 required: "This field is required",
               })}
               label="Name"
               description="Description"
-              error={errors.exampleTextInput?.message}
+              message={errors.exampleTextInput?.message}
+              messageType="error"
             />
           </article>
 
           <article>
-            <Select
+            <Dropdown
               label="Name"
               {...register("exampleSelectInput", {
                 required: "This field is required",
               })}
               description="Description"
-              error={errors.exampleSelectInput?.message}
+              message={errors.exampleSelectInput?.message}
+              messageType="error"
             >
               <option disabled value="">
                 Select a country
@@ -71,15 +72,16 @@ const Client = () => {
               <option value="FR">France</option>
               <option value="ES">Espagne</option>
               <option value="JP">Japon</option>
-            </Select>
+            </Dropdown>
           </article>
 
           <article>
-            <RadioCard
-              labelGroup="Card Radio Group"
+            <CardRadio
+              label="Card Radio Group"
               type="vertical"
-              isRequired
-              error={errors.exampleRadioInput?.message}
+              required
+              message={errors.exampleRadioInput?.message}
+              messageType="error"
               options={[
                 {
                   label: "Option 1",
@@ -100,10 +102,11 @@ const Client = () => {
 
           <article>
             <CardCheckbox
-              labelGroup="Card Checkbox Group"
+              label="Card Checkbox Group"
               type="vertical"
-              isRequired
-              error={errors.exampleCheckboxInput?.message}
+              required
+              message={errors.exampleCheckboxInput?.message}
+              messageType="error"
               options={[
                 {
                   label: "Checkbox 1",
@@ -123,14 +126,15 @@ const Client = () => {
           </article>
 
           <article>
-            <ButtonClient
+            <Button
               id="button"
-              variant={ButtonClientVariants.secondary}
+              variant="secondary"
               onClick={() => console.log("click")}
               type="submit"
+              iconRight={<Icon src={acUnit} />}
             >
-              Submit <Svg src={acUnit} />
-            </ButtonClient>
+              Submit
+            </Button>
           </article>
         </section>
       </form>


### PR DESCRIPTION
This pull request updates the Vite sample app to use the new Canopee design system packages instead of the previous Slash and Look-and-Feel packages. The main changes involve switching imports in the React components and updating the usage of several UI components to match the Canopee API. This modernizes the sample app and ensures consistency with the latest design system.

**Migration to Canopee Design System:**

* Updated dependencies in `package.json` to include Canopee React and CSS packages, as well as related Apollo and Look-and-Feel packages.
* Replaced all imports of Slash and Look-and-Feel components in `Agent.tsx`, `App.tsx`, and `Client.tsx` with Canopee equivalents, including SVG assets. [[1]](diffhunk://#diff-0a65034795676be6751ff9d01e5bc20ab3ac43f645b03c47c390f2f014cbeb79L1-R1) [[2]](diffhunk://#diff-0a65034795676be6751ff9d01e5bc20ab3ac43f645b03c47c390f2f014cbeb79L29-R29) [[3]](diffhunk://#diff-7ddd1dfd4926cf35ce1926837a4780d3e976384d45b0e5bfdd90fba8ef380332L1-R1) [[4]](diffhunk://#diff-7d96edc6d4e95474fe1f71adefb271f1b8d4b0ab5b3d696ca07bd680beef10beL2-R8)

**Component API Updates:**

* Refactored form components in `Client.tsx` to use Canopee components (`InputText`, `Dropdown`, `CardRadio`, `CardCheckbox`, `Button`, `Icon`) and updated props to match the new API (e.g., `message`/`messageType` instead of `error`, `label` instead of `labelGroup`, `required` instead of `isRequired`). [[1]](diffhunk://#diff-7d96edc6d4e95474fe1f71adefb271f1b8d4b0ab5b3d696ca07bd680beef10beL49-R84) [[2]](diffhunk://#diff-7d96edc6d4e95474fe1f71adefb271f1b8d4b0ab5b3d696ca07bd680beef10beL103-R109) [[3]](diffhunk://#diff-7d96edc6d4e95474fe1f71adefb271f1b8d4b0ab5b3d696ca07bd680beef10beL126-R137)

These changes collectively ensure the sample app leverages the latest Canopee design system and component APIs, improving maintainability and visual consistency.