### PR TITLE
Update CI publish workflow to implement Trusted publishing for npm packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,23 +56,22 @@ jobs:
       - name: Build packages
         run: npm run build
 
+      - name: Config npm
+        run: |
+          npm config set access=public
+          npm config set provenance=true
+
       - name: Publish latest packages
         if: steps.gitversion.outputs.preReleaseTag == ''
-        run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --access public --tag latest;
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --tag latest;
 
       - name: Publish rc packages
         if: contains(steps.gitversion.outputs.fullSemVer, 'RC')
-        run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --access public --tag rc;
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --tag rc;
 
       - name: Publish next packages
         if: steps.gitversion.outputs.preReleaseTag != '' && !contains(steps.gitversion.outputs.fullSemVer, 'RC')
-        run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --access public --tag next;
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --tag next;
 
       - name: Create artifact folders
         uses: ./.github/action/create-storybook-artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,11 +88,14 @@ jobs:
       matrix:
         storybook:
           - name: slash react
-            destination_dir: slash/react
+            publish_dir: slash/react
+            destination_dir: distributeur/react
           - name: apollo react
-            destination_dir: apollo/react
+            publish_dir: apollo/react
+            destination_dir: prospect/react
           - name: look-and-feel react
-            destination_dir: look-and-feel/react
+            publish_dir: look-and-feel/react
+            destination_dir: client/react
       max-parallel: 1
 
     steps:
@@ -105,7 +108,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./${{ matrix.storybook.destination_dir }}
+          publish_dir: ./${{ matrix.storybook.publish_dir }}
           destination_dir: ${{ matrix.storybook.destination_dir }}/next
 
       - name: Upload the ${{ matrix.storybook.name }} storybook version latest
@@ -113,7 +116,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./${{ matrix.storybook.destination_dir }}
+          publish_dir: ./${{ matrix.storybook.publish_dir }}
           destination_dir: ${{ matrix.storybook.destination_dir }}/latest
 
       - name: Upload the ${{ matrix.storybook.name }} storybook version ${{ needs.publish.outputs.version }}
@@ -121,5 +124,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./${{ matrix.storybook.destination_dir }}
+          publish_dir: ./${{ matrix.storybook.publish_dir }}
           destination_dir: ${{ matrix.storybook.destination_dir }}/${{ needs.publish.outputs.version }}


### PR DESCRIPTION
### Description
This PR updates the CI configuration for publishing npm packages, enabling Trusted publishing as described in the official npm documentation.

### Main Changes
- Added npm configuration steps to set `access=public` and `provenance=true` before publishing.
- Removed explicit `--access public` and `NODE_AUTH_TOKEN` usage from publish commands.
- Updated matrix configuration for storybook publishing to use new `publish_dir` and destination directories.
- Adjusted the publish step to use the correct directory variables for storybook deployment.

### Impacts
- Improves security and provenance of published npm packages.
- Changes the way authentication and access are handled during publishing.
- May affect compatibility with previous publishing workflows; requires validation in CI.

### Linked Issue
N/A