### PR TITLE
fix(look&feel,apollo): correction curseur et deprecation

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/InputText/InputTextApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputText/InputTextApollo.css
@@ -5,7 +5,7 @@
 }
 
 .af-form__input-container:has([class*="__sidebutton"]):has(:disabled)
-  .af-form__input-variant {
+  .af-form__input-atom-container {
   --input-border-color: var(--neutral-50);
   --input-text-color: var(--neutral-80);
   --input-bg-color: var(--neutral-5);

--- a/packages/canopee-css/src/prospect-client/Form/InputText/InputTextLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputText/InputTextLF.css
@@ -5,7 +5,7 @@
 }
 
 .af-form__input-container:has([class*="__sidebutton"]):has(:disabled)
-  .af-form__input-variant {
+  .af-form__input-atom-container {
   --input-border-color: var(--color-gray-400);
   --input-text-color: var(--color-gray-700);
   --input-bg-color: var(--color-gray-200);

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomApollo.css
@@ -1,6 +1,6 @@
 @import "./InputTextAtomCommon.css";
 
-.af-form__input-variant {
+.af-form__input-atom-container {
   --input-border-color: var(--axa-blue-65);
   --input-border-radius: var(--radius-8);
   --input-bg-color: var(--white);

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.css
@@ -1,9 +1,8 @@
-.af-form__input-variant {
+.af-form__input-atom-container {
   --input-box-shadow-width: 1px;
 
   display: grid;
   width: 100%;
-  padding: calc(16 / var(--font-size-base) * 1rem);
   border-radius: var(--input-border-radius);
   grid-template-columns: auto min-content;
   align-items: center;
@@ -18,6 +17,7 @@
 
   > input {
     all: unset;
+    padding: calc(16 / var(--font-size-base) * 1rem);
     font-size: calc(16 / var(--font-size-base) * 1rem);
     font-weight: 600;
     line-height: 1.25em;
@@ -29,6 +29,7 @@
     }
 
     & ~ * {
+      margin-right: calc(16 / var(--font-size-base) * 1rem);
       color: var(--input-text-icon-color);
       fill: var(--input-text-icon-color);
     }
@@ -36,6 +37,10 @@
     @media (--desktop-small) {
       font-size: calc(18 / var(--font-size-base) * 1rem);
     }
+  }
+
+  &:has(:nth-child(2)) > input {
+    padding-right: 0;
   }
 
   &:has(> input:disabled),

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomLF.css
@@ -1,6 +1,6 @@
 @import "./InputTextAtomCommon.css";
 
-.af-form__input-variant {
+.af-form__input-atom-container {
   --input-border-color: var(--color-gray-700);
   --input-border-radius: var(--radius-4);
   --input-bg-color: var(--color-white);

--- a/packages/canopee-react/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.tsx
@@ -5,7 +5,7 @@ import {
   useId,
 } from "react";
 
-import { getComponentClassName } from "../../utilities/getComponentClassName";
+import { getClassName } from "../../utilities/getClassName";
 
 type InputTextAtomProps = ComponentPropsWithRef<"input"> & {
   unit?: ReactNode;
@@ -32,17 +32,17 @@ const InputTextAtom = forwardRef<HTMLInputElement, InputTextAtomProps>(
     },
     inputRef,
   ) => {
-    const componentClassName = getComponentClassName(
-      "af-form__input-text",
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-text",
+      modifiers: [classModifier, error || ariaErrormessage ? "error" : ""],
       className,
-      classModifier + (error || ariaErrormessage ? " error" : ""),
-    );
+    });
 
     let inputId = useId();
     inputId = otherProps.id || inputId;
 
     return (
-      <div className="af-form__input-variant">
+      <div className="af-form__input-atom-container">
         <input
           id={inputId}
           className={componentClassName}


### PR DESCRIPTION
Correction d'un souci visuel sur les input Apollo et LF. L'élément html input ne prenait pas toute la taille de la case à cause d'un padding.
Modification d'une fonction deprecated

https://github.com/AxaFrance/design-system/issues/1561