### PR TITLE
feat(client,prospect): refactor ContentItemDuo

### DIFF
--- a/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.mdx
+++ b/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.mdx
@@ -11,13 +11,13 @@ The `ContentItemDuo` component displays a label and a value, optionally with an 
 >
 > `ContentItemDuo` should be used inside a `<dl>` (description list) container to ensure semantically correct HTML structure. Each `ContentItemDuo` renders a `<dt>`/`<dd>` pair, making it suitable for lists of definitions or information.
 
-### Semantic usage example with List component
+### Semantic usage example
 
 ```tsx
-import { ContentItemDuo, List } from "@axa-fr/canopee-react/prospect";
+import { ContentItemDuo } from "@axa-fr/canopee-react/prospect";
 
 const ContentItemDuoList = () => (
-  <List as="dl">
+  <dl>
     <ContentItemDuo label="Name" value="John Doe" />
     <ContentItemDuo label="Age" value="32 years" />
     <ContentItemDuo
@@ -26,7 +26,7 @@ const ContentItemDuoList = () => (
       buttonText="Details"
       onButtonClick={() => console.log("Clicked!")}
     />
-  </List>
+  </dl>
 );
 ```
 
@@ -84,6 +84,16 @@ const ContentItemDuoList = () => (
     </tr>
     <tr>
       <td>
+        <code>isVertical</code>
+      </td>
+      <td>boolean</td>
+      <td>-</td>
+      <td>
+        <strong>DEPRECATED</strong> - Use <code>position</code> instead.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>size</code>
       </td>
       <td>"small" | "large"</td>
@@ -97,6 +107,17 @@ const ContentItemDuoList = () => (
       <td>string</td>
       <td>-</td>
       <td>Custom CSS class for the container.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>classModifier</code>
+      </td>
+      <td>string</td>
+      <td>-</td>
+      <td>
+        <strong>DEPRECATED</strong> - Use <code>size</code> or{" "}
+        <code>className</code> instead.
+      </td>
     </tr>
     <tr>
       <td>

--- a/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 
 const meta: Meta<typeof ContentItemDuo> = {
-  title: "Components/List/ContentItemDuo",
+  title: "Components/ContentItemDuo",
   component: ContentItemDuo,
   args: {
     label: "Label",
@@ -12,12 +12,14 @@ const meta: Meta<typeof ContentItemDuo> = {
   },
   argTypes: {
     className: { control: "text" },
+    classModifier: { control: "text" },
     position: {
       options: ["horizontal", "vertical"],
       control: {
         type: "select",
       },
     },
+    isVertical: { control: "boolean" },
     size: {
       options: ["small", "large"],
       control: {

--- a/apps/apollo-stories/src/components/List/ContentItemDuo/ContentItemDuo.mdx
+++ b/apps/apollo-stories/src/components/List/ContentItemDuo/ContentItemDuo.mdx
@@ -5,41 +5,125 @@ import * as ContentItemDuoStories from "./ContentItemDuo.stories";
 
 # ContentItemDuo
 
-1. [Import](#import)
-2. [Default ContentItemDuo](#default-contentitemduo)
-3. [Large ContentItemDuo](#large-contentitemduo)
-4. [Vertical ContentItemDuo](#vertical-contentitemduo)
+The `ContentItemDuo` component displays a label and a value, optionally with an action button. It supports horizontal and vertical layouts, and two sizes. Use it to present key-value pairs in a clear, accessible way.
 
-## Import
+> **Accessibility & Semantics**
+>
+> `ContentItemDuo` should be used inside a `<dl>` (description list) container to ensure semantically correct HTML structure. Each `ContentItemDuo` renders a `<dt>`/`<dd>` pair, making it suitable for lists of definitions or information.
+
+### Semantic usage example with List component
 
 ```tsx
-import { ContentItemDuo } from "@axa-fr/canopee-react/prospect";
+import { ContentItemDuo, List } from "@axa-fr/canopee-react/prospect";
 
-const MyComponent = () => (
-  <>
-    <ContentItemDuo label="Libelle" value="Reponse">
-      My message
-    </ContentItemDuo>
-  </>
+const ContentItemDuoList = () => (
+  <List as="dl">
+    <ContentItemDuo label="Name" value="John Doe" />
+    <ContentItemDuo label="Age" value="32 years" />
+    <ContentItemDuo
+      label="Status"
+      value="Active"
+      buttonText="Details"
+      onButtonClick={() => console.log("Clicked!")}
+    />
+  </List>
 );
 ```
 
-## Uses
+## Props
 
-### Default Content Item Duo
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Prop</th>
+      <th scope="col">Type</th>
+      <th scope="col">Default</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>label</code>
+      </td>
+      <td>ReactNode</td>
+      <td>-</td>
+      <td>Label displayed on the left (horizontal) or top (vertical).</td>
+    </tr>
+    <tr>
+      <td>
+        <code>value</code>
+      </td>
+      <td>ReactNode</td>
+      <td>-</td>
+      <td>Value displayed on the right (horizontal) or bottom (vertical).</td>
+    </tr>
+    <tr>
+      <td>
+        <code>buttonText</code>
+      </td>
+      <td>string</td>
+      <td>-</td>
+      <td>Text for the optional action button.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>onButtonClick</code>
+      </td>
+      <td>() =&gt; void</td>
+      <td>-</td>
+      <td>Handler called when the button is clicked.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>position</code>
+      </td>
+      <td>"horizontal" | "vertical"</td>
+      <td>"horizontal"</td>
+      <td>Layout direction.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>size</code>
+      </td>
+      <td>"small" | "large"</td>
+      <td>"large"</td>
+      <td>Component size.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>className</code>
+      </td>
+      <td>string</td>
+      <td>-</td>
+      <td>Custom CSS class for the container.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>...divProps</code>
+      </td>
+      <td>
+        All native <code>&lt;div&gt;</code> props
+      </td>
+      <td>-</td>
+      <td>Any other props are forwarded to the container.</td>
+    </tr>
+  </tbody>
+</table>
 
-<Canvas of={ContentItemDuoStories.ContentItemDuoDefault} />
+> Note: The button is only rendered if both `buttonText` and `onButtonClick` are provided.
 
-<Controls of={ContentItemDuoStories.ContentItemDuoDefault} />
+## Playground
 
-### Large Content Item Duo
+### Horizontal (Large)
 
-<Canvas of={ContentItemDuoStories.ContentItemDuoLarge} />
+<Canvas
+  of={ContentItemDuoStories.ContentItemDuoHorizontal}
+  sourceState="shown"
+/>
+<Controls of={ContentItemDuoStories.ContentItemDuoHorizontal} />
 
-<Controls of={ContentItemDuoStories.ContentItemDuoLarge} />
+### Vertical
 
-### Content Item Duo Vertical
-
-<Canvas of={ContentItemDuoStories.ContentItemDuoVertical} />
-
+<Canvas of={ContentItemDuoStories.ContentItemDuoVertical} sourceState="shown" />
 <Controls of={ContentItemDuoStories.ContentItemDuoVertical} />

--- a/apps/apollo-stories/src/components/List/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/apollo-stories/src/components/List/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -1,72 +1,63 @@
+import { ContentItemDuo } from "@axa-fr/canopee-react/prospect";
 import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
-import { ContentItemDuo } from "@axa-fr/canopee-react/prospect";
 
 const meta: Meta<typeof ContentItemDuo> = {
   title: "Components/List/ContentItemDuo",
   component: ContentItemDuo,
+  args: {
+    label: "Label",
+    value: "Value",
+    buttonText: "Learn more",
+  },
+  argTypes: {
+    className: { control: "text" },
+    position: {
+      options: ["horizontal", "vertical"],
+      control: {
+        type: "select",
+      },
+    },
+    size: {
+      options: ["small", "large"],
+      control: {
+        type: "select",
+      },
+    },
+    onButtonClick: { action: "onButtonClick" },
+  },
+  decorators: [
+    (Story) => (
+      <dl>
+        <Story />
+      </dl>
+    ),
+  ],
 };
 
 export default meta;
 
-const defaultArgs = {
-  isVertical: false,
-  label: "Libellé",
-  value: "Réponse",
-  buttonText: "En savoir plus",
-};
-
-const verticalArgs = {
-  isVertical: true,
-  label:
-    "Le choc de véhicules terrestres à moteur, (voiture, trottinette à moteur…) ou la chute d’appareils aériens (avions, hélicoptères…) avec un propriétaire du véhicule adverse identifié ?",
-  value: "Les incendies, explosions, implosions, fumée et foudre",
-  buttonText: "En savoir plus",
-  classModifier: [],
-};
-
-export const ContentItemDuoDefault: StoryObj<
-  Omit<ComponentProps<typeof ContentItemDuo>, "classModifier"> & {
-    classModifier: string[];
-  }
+export const ContentItemDuoHorizontal: StoryObj<
+  ComponentProps<typeof ContentItemDuo>
 > = {
-  render: ({ classModifier, ...args }) => (
-    <ContentItemDuo classModifier={classModifier.join(" ")} {...args} />
-  ),
   args: {
-    ...defaultArgs,
-    classModifier: ["small"],
-  },
-};
-
-export const ContentItemDuoLarge: StoryObj<
-  Omit<ComponentProps<typeof ContentItemDuo>, "classModifier"> & {
-    classModifier: string[];
-  }
-> = {
-  render: ({ classModifier, ...args }) => (
-    <ContentItemDuo classModifier={classModifier.join(" ")} {...args} />
-  ),
-  args: {
-    ...defaultArgs,
-    classModifier: ["large"],
+    position: "horizontal",
+    label: "Label",
+    value: "Value",
+    size: "large",
   },
 };
 
 export const ContentItemDuoVertical: StoryObj<
-  Omit<ComponentProps<typeof ContentItemDuo>, "classModifier"> & {
-    classModifier: string[];
-  }
+  ComponentProps<typeof ContentItemDuo>
 > = {
-  render: ({ classModifier, ...args }) => (
-    <ContentItemDuo classModifier={classModifier.join(" ")} {...args} />
-  ),
-  args: verticalArgs,
+  args: {
+    position: "vertical",
+    label:
+      "Collision of motor vehicles (car, electric scooter, etc.) or crash of aircraft (planes, helicopters, etc.) with an identified owner of the other vehicle?",
+    value: "Fires, explosions, implosions, smoke, and lightning",
+  },
   argTypes: {
-    classModifier: {
-      options: ["large"],
-      control: { type: "multi-select" },
-      defaultValue: [],
-    },
+    size: { control: false },
   },
 };

--- a/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.mdx
+++ b/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.mdx
@@ -5,55 +5,125 @@ import * as ContentItemDuoStories from "./ContentItemDuo.stories";
 
 # ContentItemDuo
 
-1. [Import](#import)
-2. [Default ContentItemDuo](#default-contentitemduo)
-3. [Large ContentItemDuo](#large-contentitemduo)
-4. [Vertical ContentItemDuo](#vertical-contentitemduo)
-5. [Default ContentItemDuo List](#default-contentitemduo-list)
-6. [Vertical ContentItemDuo List](#vertical-contentitemduo-list)
+The `ContentItemDuo` component displays a label and a value, optionally with an action button. It supports horizontal and vertical layouts, and two sizes. Use it to present key-value pairs in a clear, accessible way.
 
-## Import
+> **Accessibility & Semantics**
+>
+> `ContentItemDuo` should be used inside a `<dl>` (description list) container to ensure semantically correct HTML structure. Each `ContentItemDuo` renders a `<dt>`/`<dd>` pair, making it suitable for lists of definitions or information.
+
+### Semantic usage example with List component
 
 ```tsx
-import { ContentItemDuo } from "@axa-fr/canopee-react/client";
+import { ContentItemDuo, List } from "@axa-fr/canopee-react/client";
 
-const MyComponent = () => (
-  <>
-    <ContentItemDuo label="Libelle" value="Reponse">
-      My message
-    </ContentItemDuo>
-  </>
+const ContentItemDuoList = () => (
+  <List as="dl">
+    <ContentItemDuo label="Name" value="John Doe" />
+    <ContentItemDuo label="Age" value="32 years" />
+    <ContentItemDuo
+      label="Status"
+      value="Active"
+      buttonText="Details"
+      onButtonClick={() => console.log("Clicked!")}
+    />
+  </List>
 );
 ```
 
-## Uses
+## Props
 
-### Default Content Item Duo
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Prop</th>
+      <th scope="col">Type</th>
+      <th scope="col">Default</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>label</code>
+      </td>
+      <td>ReactNode</td>
+      <td>-</td>
+      <td>Label displayed on the left (horizontal) or top (vertical).</td>
+    </tr>
+    <tr>
+      <td>
+        <code>value</code>
+      </td>
+      <td>ReactNode</td>
+      <td>-</td>
+      <td>Value displayed on the right (horizontal) or bottom (vertical).</td>
+    </tr>
+    <tr>
+      <td>
+        <code>buttonText</code>
+      </td>
+      <td>string</td>
+      <td>-</td>
+      <td>Text for the optional action button.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>onButtonClick</code>
+      </td>
+      <td>() =&gt; void</td>
+      <td>-</td>
+      <td>Handler called when the button is clicked.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>position</code>
+      </td>
+      <td>"horizontal" | "vertical"</td>
+      <td>"horizontal"</td>
+      <td>Layout direction.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>size</code>
+      </td>
+      <td>"small" | "large"</td>
+      <td>"large"</td>
+      <td>Component size.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>className</code>
+      </td>
+      <td>string</td>
+      <td>-</td>
+      <td>Custom CSS class for the container.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>...divProps</code>
+      </td>
+      <td>
+        All native <code>&lt;div&gt;</code> props
+      </td>
+      <td>-</td>
+      <td>Any other props are forwarded to the container.</td>
+    </tr>
+  </tbody>
+</table>
 
-<Canvas of={ContentItemDuoStories.ContentItemDuoDefault} />
+> Note: The button is only rendered if both `buttonText` and `onButtonClick` are provided.
 
-<Controls of={ContentItemDuoStories.ContentItemDuoDefault} />
+## Playground
 
-### Large Content Item Duo
+### Horizontal (Large)
 
-<Canvas of={ContentItemDuoStories.ContentItemDuoLarge} />
+<Canvas
+  of={ContentItemDuoStories.ContentItemDuoHorizontal}
+  sourceState="shown"
+/>
+<Controls of={ContentItemDuoStories.ContentItemDuoHorizontal} />
 
-<Controls of={ContentItemDuoStories.ContentItemDuoLarge} />
+### Vertical
 
-### Vertical Content Item Duo
-
-<Canvas of={ContentItemDuoStories.ContentItemDuoVertical} />
-
+<Canvas of={ContentItemDuoStories.ContentItemDuoVertical} sourceState="shown" />
 <Controls of={ContentItemDuoStories.ContentItemDuoVertical} />
-
-### Default ContentItemDuo List
-
-<Canvas of={ContentItemDuoStories.DefaultContentItemDuoList} />
-
-<Controls of={ContentItemDuoStories.DefaultContentItemDuoList} />
-
-### Vertical ContentItemDuo List
-
-<Canvas of={ContentItemDuoStories.VerticalContentItemDuoList} />
-
-<Controls of={ContentItemDuoStories.VerticalContentItemDuoList} />

--- a/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.mdx
+++ b/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.mdx
@@ -11,13 +11,13 @@ The `ContentItemDuo` component displays a label and a value, optionally with an 
 >
 > `ContentItemDuo` should be used inside a `<dl>` (description list) container to ensure semantically correct HTML structure. Each `ContentItemDuo` renders a `<dt>`/`<dd>` pair, making it suitable for lists of definitions or information.
 
-### Semantic usage example with List component
+### Semantic usage example
 
 ```tsx
-import { ContentItemDuo, List } from "@axa-fr/canopee-react/client";
+import { ContentItemDuo } from "@axa-fr/canopee-react/prospect";
 
 const ContentItemDuoList = () => (
-  <List as="dl">
+  <dl>
     <ContentItemDuo label="Name" value="John Doe" />
     <ContentItemDuo label="Age" value="32 years" />
     <ContentItemDuo
@@ -26,7 +26,7 @@ const ContentItemDuoList = () => (
       buttonText="Details"
       onButtonClick={() => console.log("Clicked!")}
     />
-  </List>
+  </dl>
 );
 ```
 
@@ -84,6 +84,16 @@ const ContentItemDuoList = () => (
     </tr>
     <tr>
       <td>
+        <code>isVertical</code>
+      </td>
+      <td>boolean</td>
+      <td>-</td>
+      <td>
+        <strong>DEPRECATED</strong> - Use <code>position</code> instead.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>size</code>
       </td>
       <td>"small" | "large"</td>
@@ -97,6 +107,17 @@ const ContentItemDuoList = () => (
       <td>string</td>
       <td>-</td>
       <td>Custom CSS class for the container.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>classModifier</code>
+      </td>
+      <td>string</td>
+      <td>-</td>
+      <td>
+        <strong>DEPRECATED</strong> - Use <code>size</code> or{" "}
+        <code>className</code> instead.
+      </td>
     </tr>
     <tr>
       <td>

--- a/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -5,69 +5,59 @@ import type { ComponentProps } from "react";
 const meta: Meta<typeof ContentItemDuo> = {
   title: "Components/List/ContentItemDuo",
   component: ContentItemDuo,
+  args: {
+    label: "Label",
+    value: "Value",
+    buttonText: "Learn more",
+  },
+  argTypes: {
+    className: { control: "text" },
+    position: {
+      options: ["horizontal", "vertical"],
+      control: {
+        type: "select",
+      },
+    },
+    size: {
+      options: ["small", "large"],
+      control: {
+        type: "select",
+      },
+    },
+    onButtonClick: { action: "onButtonClick" },
+  },
+  decorators: [
+    (Story) => (
+      <dl>
+        <Story />
+      </dl>
+    ),
+  ],
 };
 
 export default meta;
 
-const defaultArgs = {
-  isVertical: false,
-  label: "Libellé",
-  value: "Réponse",
-  buttonText: "En savoir plus",
-  classModifier: [],
-};
-
-const verticalArgs = {
-  isVertical: true,
-  label:
-    "Le choc de véhicules terrestres à moteur, (voiture, trottinette à moteur…) ou la chute d’appareils aériens (avions, hélicoptères…) avec un propriétaire du véhicule adverse identifié ?",
-  value: "Les incendies, explosions, implosions, fumée et foudre",
-  buttonText: "En savoir plus",
-  classModifier: [],
-};
-
-export const ContentItemDuoDefault: StoryObj<
-  Omit<ComponentProps<typeof ContentItemDuo>, "classModifier"> & {
-    classModifier: string[];
-  }
+export const ContentItemDuoHorizontal: StoryObj<
+  ComponentProps<typeof ContentItemDuo>
 > = {
-  render: ({ classModifier, ...args }) => (
-    <ContentItemDuo classModifier={classModifier.join(" ")} {...args} />
-  ),
   args: {
-    ...defaultArgs,
-    classModifier: ["small"],
-  },
-};
-
-export const ContentItemDuoLarge: StoryObj<
-  Omit<ComponentProps<typeof ContentItemDuo>, "classModifier"> & {
-    classModifier: string[];
-  }
-> = {
-  render: ({ classModifier, ...args }) => (
-    <ContentItemDuo classModifier={classModifier.join(" ")} {...args} />
-  ),
-  args: {
-    ...defaultArgs,
-    classModifier: ["large"],
+    position: "horizontal",
+    label: "Label",
+    value: "Value",
+    size: "large",
   },
 };
 
 export const ContentItemDuoVertical: StoryObj<
-  Omit<ComponentProps<typeof ContentItemDuo>, "classModifier"> & {
-    classModifier: string[];
-  }
+  ComponentProps<typeof ContentItemDuo>
 > = {
-  render: ({ classModifier, ...args }) => (
-    <ContentItemDuo classModifier={classModifier.join(" ")} {...args} />
-  ),
-  args: verticalArgs,
+  args: {
+    position: "vertical",
+    label:
+      "Collision of motor vehicles (car, electric scooter, etc.) or crash of aircraft (planes, helicopters, etc.) with an identified owner of the other vehicle?",
+    value: "Fires, explosions, implosions, smoke, and lightning",
+  },
   argTypes: {
-    classModifier: {
-      options: ["large"],
-      control: { type: "multi-select" },
-      defaultValue: [],
-    },
+    size: { control: false },
   },
 };

--- a/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 
 const meta: Meta<typeof ContentItemDuo> = {
-  title: "Components/List/ContentItemDuo",
+  title: "Components/ContentItemDuo",
   component: ContentItemDuo,
   args: {
     label: "Label",
@@ -12,12 +12,14 @@ const meta: Meta<typeof ContentItemDuo> = {
   },
   argTypes: {
     className: { control: "text" },
+    classModifier: { control: "text" },
     position: {
       options: ["horizontal", "vertical"],
       control: {
         type: "select",
       },
     },
+    isVertical: { control: "boolean" },
     size: {
       options: ["small", "large"],
       control: {

--- a/packages/canopee-css/src/prospect-client/Button/ButtonLF.css
+++ b/packages/canopee-css/src/prospect-client/Button/ButtonLF.css
@@ -69,10 +69,7 @@
   --button-text-color: var(--color-axa);
   --button-bg-color: transparent;
   --button-padding: 0;
-
-  @media (--desktop-small) {
-    --button-font-size: calc(16 / var(--font-size-base) * 1rem);
-  }
+  --button-font-size: calc(16 / var(--font-size-base) * 1rem);
 
   &:hover,
   &:focus,

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoApollo.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoApollo.css
@@ -1,9 +1,7 @@
 @import "./ContentItemDuoCommon.css";
 
-.af-content-item-duo__label {
-  --content-duo-label-color: var(--neutral-80);
-}
-
-.af-content-item-duo__value {
-  --content-duo-value-color: var(--neutral-100);
+.af-content-item-duo {
+  --content-item-duo-font-family: var(--font-family-sans-serif);
+  --content-item-duo-label-color: var(--neutral-80);
+  --content-item-duo-value-color: var(--neutral-100);
 }

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoApollo.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoApollo.css
@@ -1,7 +1,6 @@
 @import "./ContentItemDuoCommon.css";
 
 .af-content-item-duo {
-  --content-item-duo-font-family: var(--font-family-sans-serif);
   --content-item-duo-label-color: var(--neutral-80);
   --content-item-duo-value-color: var(--neutral-100);
 }

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
@@ -1,127 +1,77 @@
 .af-content-item-duo {
+  --content-item-duo-column-gap: 16;
+  --content-item-duo-text-font-size: 16;
+  --content-item-duo-value-justify: start;
+  --content-item-duo-button-justify: start;
+
   display: grid;
   width: 100%;
-  grid-template:
-    "icon label value"
-    "icon label button";
-  grid-template-columns: auto 1fr 1fr;
-  row-gap: calc(8 / var(--font-size-base) * 1rem);
-}
-
-.af-content-item-duo__label,
-.af-content-item-duo__value {
-  margin: 0;
-  font-family: var(--font-family-base);
-  font-size: calc(16 / var(--font-size-base) * 1rem);
-  line-height: 125%;
-  overflow-wrap: break-word;
-}
-
-.af-content-item-duo__label {
-  margin-right: calc(16 / var(--font-size-base) * 1rem);
-  grid-area: label;
-  font-weight: 400;
-  color: var(--content-duo-label-color);
-}
-
-.af-content-item-duo__value {
-  grid-area: value;
-  font-weight: 600;
-  text-align: end;
-  color: var(--content-duo-value-color);
-}
-
-.af-content-item-duo__button {
-  grid-area: button;
-  justify-self: end;
-}
-
-.af-content-item-duo--large {
-  :not(:has(.af-content-item-duo__button)) {
-    row-gap: 0;
-  }
-
-  .af-content-item-duo__icon {
-    margin-top: calc(4 / var(--font-size-base) * 1rem);
-  }
-
-  .af-content-item-duo__label,
-  .af-content-item-duo__value {
-    font-size: calc(16 / var(--font-size-base) * 1rem);
-    line-height: 125%;
-  }
+  grid-template: "label value";
+  grid-template-columns: 1fr 1fr;
+  gap: calc(8 / var(--font-size-base) * 1rem)
+    calc(var(--content-item-duo-column-gap) / var(--font-size-base) * 1rem);
 
   .af-content-item-duo__label {
-    margin-right: calc(1 / var(--font-size-base) * 1rem);
-  }
-
-  .af-content-item-duo__value {
-    text-align: end;
-  }
-
-  .af-content-item-duo__button {
-    margin-left: 0;
-    justify-self: end;
-  }
-}
-
-.af-content-item-duo--vertical {
-  grid-template:
-    "icon label button"
-    ". value value";
-  grid-template-columns: auto 1fr auto;
-  gap: calc(6 / var(--font-size-base) * 1rem)
-    calc(12 / var(--font-size-base) * 1rem);
-
-  .af-content-item-duo__icon {
-    margin-top: calc(2 / var(--font-size-base) * 1rem);
-    margin-right: 0;
-  }
-
-  .af-content-item-duo__label,
-  .af-content-item-duo__value {
-    margin-right: 0;
-    font-size: calc(16 / var(--font-size-base) * 1rem);
+    grid-area: label;
+    font-family: var(--content-item-duo-font-family);
+    font-size: calc(
+      var(--content-item-duo-text-font-size) / var(--font-size-base) * 1rem
+    );
+    font-weight: 400;
     line-height: 125%;
-    text-align: start;
+    color: var(--content-item-duo-label-color);
   }
 
   .af-content-item-duo__value {
-    margin: 0;
+    grid-area: value;
+    justify-self: var(--content-item-duo-value-justify);
+    font-family: var(--content-item-duo-font-family);
+    font-size: calc(
+      var(--content-item-duo-text-font-size) / var(--font-size-base) * 1rem
+    );
+    font-weight: 600;
+    line-height: 125%;
+    color: var(--content-item-duo-value-color);
   }
 
   .af-content-item-duo__button {
-    margin-left: 0;
-    justify-self: end;
-  }
-}
-
-@media (--desktop-small) {
-  .af-content-item-duo--large {
-    .af-content-item-duo__label,
-    .af-content-item-duo__value {
-      font-size: calc(18 / var(--font-size-base) * 1rem);
-    }
-
-    .af-content-item-duo__label {
-      margin-right: calc(40 / var(--font-size-base) * 1rem);
-    }
-
-    .af-content-item-duo__value {
-      text-align: start;
-    }
-
-    .af-content-item-duo__button {
-      justify-self: start;
-    }
+    grid-area: button;
+    justify-self: var(--content-item-duo-button-justify);
   }
 
-  .af-content-item-duo--vertical {
-    row-gap: calc(8 / var(--font-size-base) * 1rem);
+  @media (--tablet) {
+    --content-item-duo-column-gap: 40;
+    --content-item-duo-text-font-size: 18;
+  }
 
-    .af-content-item-duo__label,
-    .af-content-item-duo__value {
-      font-size: calc(18 / var(--font-size-base) * 1rem);
-    }
+  &.af-content-item-duo--horizontal:has(.af-content-item-duo__button) {
+    grid-template:
+      "label value"
+      ". button";
+  }
+
+  &.af-content-item-duo--horizontal.af-content-item-duo--small {
+    --content-item-duo-column-gap: 16;
+    --content-item-duo-text-font-size: 16;
+    --content-item-duo-value-justify: end;
+    --content-item-duo-button-justify: end;
+  }
+
+  &.af-content-item-duo--vertical {
+    grid-template:
+      "label"
+      "value";
+    grid-template-columns: 1fr;
+
+    --content-item-duo-column-gap: 12;
+  }
+
+  &.af-content-item-duo--vertical:has(.af-content-item-duo__button) {
+    grid-template:
+      "label button"
+      "value value";
+    grid-template-columns: 1fr auto;
+
+    --content-item-duo-button-justify: end;
   }
 }

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
@@ -13,7 +13,6 @@
 
   .af-content-item-duo__label {
     grid-area: label;
-    font-family: var(--content-item-duo-font-family);
     font-size: calc(
       var(--content-item-duo-text-font-size) / var(--font-size-base) * 1rem
     );
@@ -25,7 +24,6 @@
   .af-content-item-duo__value {
     grid-area: value;
     justify-self: var(--content-item-duo-value-justify);
-    font-family: var(--content-item-duo-font-family);
     font-size: calc(
       var(--content-item-duo-text-font-size) / var(--font-size-base) * 1rem
     );

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
@@ -37,7 +37,7 @@
     justify-self: var(--content-item-duo-button-justify);
   }
 
-  @media (--tablet) {
+  @media (--desktop-small) {
     --content-item-duo-column-gap: 40;
     --content-item-duo-text-font-size: 18;
   }

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoLF.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoLF.css
@@ -1,9 +1,7 @@
 @import "./ContentItemDuoCommon.css";
 
-.af-content-item-duo__label {
-  --content-duo-label-color: var(--color-gray-700);
-}
-
-.af-content-item-duo__value {
-  --content-duo-value-color: var(--color-gray-900);
+.af-content-item-duo {
+  --content-item-duo-font-family: var(--font-family-sans-serif);
+  --content-item-duo-label-color: var(--color-gray-700);
+  --content-item-duo-value-color: var(--color-gray-900);
 }

--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoLF.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoLF.css
@@ -1,7 +1,6 @@
 @import "./ContentItemDuoCommon.css";
 
 .af-content-item-duo {
-  --content-item-duo-font-family: var(--font-family-sans-serif);
   --content-item-duo-label-color: var(--color-gray-700);
   --content-item-duo-value-color: var(--color-gray-900);
 }

--- a/packages/canopee-css/src/prospect-client/common/reboot.css
+++ b/packages/canopee-css/src/prospect-client/common/reboot.css
@@ -41,3 +41,9 @@ fieldset {
 legend {
   padding: 0;
 }
+
+dl,
+dt,
+dd {
+  margin: 0;
+}

--- a/packages/canopee-css/src/prospect-client/common/rebootLF.css
+++ b/packages/canopee-css/src/prospect-client/common/rebootLF.css
@@ -80,7 +80,6 @@ address {
   line-height: inherit;
 }
 
-dl,
 ol,
 ul {
   margin-top: 0;
@@ -94,13 +93,10 @@ ul ul {
   margin-bottom: 0;
 }
 
-dt {
-  font-weight: 700;
-}
-
+dl,
+dt,
 dd {
-  margin-bottom: 0.5rem;
-  margin-left: 0;
+  margin: 0;
 }
 
 blockquote {

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -17,6 +17,10 @@ export type ContentItemDuoProps = {
   value: ReactNode;
   buttonText?: string;
   onButtonClick?: () => void;
+  /** @deprecated Use `position` instead */
+  isVertical?: boolean;
+  /** @deprecated Use `size` or `className` instead */
+  classModifier?: string;
 } & ContentItemDuoPositions &
   ComponentProps<"div">;
 
@@ -30,6 +34,8 @@ export const ContentItemDuoCommon = ({
   position = "horizontal",
   size = "large",
   className,
+  classModifier,
+  isVertical,
   buttonText,
   onButtonClick,
   ButtonComponent,
@@ -38,7 +44,11 @@ export const ContentItemDuoCommon = ({
   const componentClassName = getClassName({
     baseClassName: "af-content-item-duo",
     className,
-    modifiers: [position, size === "small" && size],
+    modifiers: [
+      isVertical ? "vertical" : position,
+      size === "small" && size,
+      classModifier,
+    ],
   });
 
   return (

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -38,7 +38,7 @@ export const ContentItemDuoCommon = ({
   const componentClassName = getClassName({
     baseClassName: "af-content-item-duo",
     className,
-    modifiers: [position, size],
+    modifiers: [position, size === "small" && size],
   });
 
   return (

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -1,21 +1,24 @@
-import {
-  type ComponentProps,
-  type ComponentType,
-  type ReactNode,
-  useMemo,
-} from "react";
+import { type ComponentProps, type ComponentType, type ReactNode } from "react";
 import type { ButtonProps } from "../../Button/ButtonCommon";
-import { getComponentClassName } from "../../utilities/getComponentClassName";
+import { getClassName } from "../../utilities/getClassName";
+
+type ContentItemDuoPositions =
+  | {
+      position?: "horizontal";
+      size?: "small" | "large";
+    }
+  | {
+      size?: "large";
+      position: "vertical";
+    };
 
 export type ContentItemDuoProps = {
-  label: string;
+  label: ReactNode;
   value: ReactNode;
-  isVertical?: boolean;
-  className?: string;
-  classModifier?: string;
   buttonText?: string;
   onButtonClick?: () => void;
-} & ComponentProps<"div">;
+} & ContentItemDuoPositions &
+  ComponentProps<"div">;
 
 type ContentItemDuoCommonProps = ContentItemDuoProps & {
   ButtonComponent: ComponentType<ButtonProps>;
@@ -24,43 +27,33 @@ type ContentItemDuoCommonProps = ContentItemDuoProps & {
 export const ContentItemDuoCommon = ({
   label,
   value,
-  isVertical = false,
+  position = "horizontal",
+  size = "large",
   className,
-  classModifier,
   buttonText,
   onButtonClick,
   ButtonComponent,
   ...containerProps
 }: ContentItemDuoCommonProps) => {
-  const componentClassName = useMemo(() => {
-    const classModifiers = [classModifier];
-
-    if (isVertical) {
-      classModifiers.push("vertical");
-    }
-
-    return getComponentClassName(
-      "af-content-item-duo",
-      className,
-      classModifiers.filter(Boolean).join(" "),
-    );
-  }, [classModifier, className, isVertical]);
+  const componentClassName = getClassName({
+    baseClassName: "af-content-item-duo",
+    className,
+    modifiers: [position, size],
+  });
 
   return (
     <div className={componentClassName} {...containerProps}>
-      <p className="af-content-item-duo__label">{label}</p>
-      {typeof value === "string" ? (
-        <p className="af-content-item-duo__value">{value}</p>
-      ) : (
-        <div className="af-content-item-duo__value">{value}</div>
+      <dt className="af-content-item-duo__label">{label}</dt>
+      <dd className="af-content-item-duo__value">{value}</dd>
+      {Boolean(buttonText && onButtonClick) && (
+        <ButtonComponent
+          className="af-content-item-duo__button"
+          variant="ghost"
+          onClick={onButtonClick}
+        >
+          {buttonText}
+        </ButtonComponent>
       )}
-      {buttonText ? (
-        <div className="af-content-item-duo__button">
-          <ButtonComponent variant="ghost" onClick={onButtonClick}>
-            {buttonText}
-          </ButtonComponent>
-        </div>
-      ) : null}
     </div>
   );
 };

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -67,7 +67,29 @@ describe("ContentItemDuoCommon", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("applies position and size modifiers", () => {
+  it("applies only position modifier on horizontal large", () => {
+    renderContentItemDuo({
+      position: "horizontal",
+      size: "large",
+    });
+
+    const container = screen.getByText("Label").closest("div");
+    expect(container).toHaveClass("af-content-item-duo--horizontal");
+    expect(container).not.toHaveClass("af-content-item-duo--large");
+  });
+
+  it("applies position and size modifiers on horizontal small", () => {
+    renderContentItemDuo({
+      position: "horizontal",
+      size: "small",
+    });
+
+    const container = screen.getByText("Label").closest("div");
+    expect(container).toHaveClass("af-content-item-duo--horizontal");
+    expect(container).toHaveClass("af-content-item-duo--small");
+  });
+
+  it("applies only position modifiers on vertical", () => {
     renderContentItemDuo({
       position: "vertical",
       size: "large",
@@ -75,7 +97,7 @@ describe("ContentItemDuoCommon", () => {
 
     const container = screen.getByText("Label").closest("div");
     expect(container).toHaveClass("af-content-item-duo--vertical");
-    expect(container).toHaveClass("af-content-item-duo--large");
+    expect(container).not.toHaveClass("af-content-item-duo--large");
   });
 
   it("renders correct semantic elements", () => {

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -31,11 +31,31 @@ describe("ContentItemDuoCommon", () => {
     expect(screen.getByText("Value")).toBeInTheDocument();
   });
 
+  it("applies vertical modifier when isVertical is true", () => {
+    renderContentItemDuo({ isVertical: true });
+    const container = screen.getByText("Label").closest("div");
+    expect(container).toHaveClass("af-content-item-duo--vertical");
+    expect(container).not.toHaveClass("af-content-item-duo--horizontal");
+  });
+
+  it("does not apply vertical modifier when isVertical is false", () => {
+    renderContentItemDuo({ isVertical: false });
+    const container = screen.getByText("Label").closest("div");
+    expect(container).toHaveClass("af-content-item-duo--horizontal");
+    expect(container).not.toHaveClass("af-content-item-duo--vertical");
+  });
+
   it("applies custom className", () => {
     renderContentItemDuo({ className: "custom-class" });
 
     const container = screen.getByText("Label").closest("div");
     expect(container).toHaveClass("custom-class");
+  });
+
+  it("applies custom classModifier", () => {
+    renderContentItemDuo({ classModifier: "custom-modifier" });
+    const container = screen.getByText("Label").closest("div");
+    expect(container).toHaveClass("af-content-item-duo--custom-modifier");
   });
 
   it("renders button when buttonText and onButtonClick are provided", async () => {


### PR DESCRIPTION
## Refactor ContentItemDuo component

This PR completely refactors the `ContentItemDuo` component.

- The props `classModifier` and `isVertical` are now **deprecated** and replaced by `position` and `size` for better clarity and consistency. Backward compatibility is maintained.
- The styles have been rewritten, resulting in a shorter and more robust implementation.
- The stories have also been updated, providing improved documentation and usage examples.