### PR TITLE
fix(distributeur): form checkbox shrink style

### DIFF
--- a/packages/canopee-css/src/distributeur/Form/Checkbox/Checkbox.css
+++ b/packages/canopee-css/src/distributeur/Form/Checkbox/Checkbox.css
@@ -410,6 +410,7 @@
   border: 1px solid var(--input-border-color);
   background-color: var(--white);
   fill: none;
+  aspect-ratio: 1 / 1;
 }
 
 .af-form__checkbox .af-form__indicator .ok-icon,


### PR DESCRIPTION
<img width="801" height="572" alt="image" src="https://github.com/user-attachments/assets/8f0b6d13-f3e1-49b2-bf6c-f76050b3f3d9" />

There was a scenario where CheckboxItem needed to be displayed in a narrow space, which resulted in an unsatisfactory rendering. We have fixed this by forcing the checkbox indicator to be a square. This fix addresses the styling issue and has been tested in our application.


