### PR TITLE
feat(distributeur): add action option

### DIFF
--- a/packages/canopee-react/src/distributeur/Form/Radio/RadioCardGroup.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/RadioCardGroup.tsx
@@ -1,6 +1,6 @@
 import "@axa-fr/canopee-css/distributeur/Form/Radio/RadioCardGroup.css";
 
-import { ComponentProps, useId } from "react";
+import { ComponentProps, ReactNode, useId } from "react";
 import classNames from "classnames";
 import type { Option } from "../core";
 import { Svg } from "../../Svg";
@@ -8,8 +8,10 @@ import { Svg } from "../../Svg";
 const DEFAULT_CLASSNAME = "af-card";
 const DEFAULT_CONTAINER_CLASSNAME = "af-form__radio-card-group";
 
+type RadioOptions = Option & { action?: ReactNode };
+
 type Props = ComponentProps<"input"> & {
-  options: Option[];
+  options: RadioOptions[];
   orientation?: "horizontal" | "vertical";
 };
 
@@ -42,8 +44,9 @@ export const RadioCardGroup = ({
           label,
           disabled: optionDisabled,
           value: optionValue,
+          action,
           ...otherOptionProps
-        }: Option) => {
+        }) => {
           const newName = name || optionName || idGenerated;
           const allClassNames = classNames([
             DEFAULT_CLASSNAME,
@@ -53,19 +56,22 @@ export const RadioCardGroup = ({
 
           const isDisabled = disabled || optionDisabled;
           return (
-            <label key={optionValue} className={allClassNames}>
-              <input
-                {...otherProps}
-                type="radio"
-                name={newName}
-                disabled={isDisabled}
-                checked={isDisabled ? false : optionValue === value}
-                value={optionValue}
-                {...otherOptionProps}
-              />
-              {typeof icon === "string" ? <Svg src={icon} /> : icon}
-              {label}
-            </label>
+            <div key={optionValue}>
+              <label key={optionValue} className={allClassNames}>
+                <input
+                  {...otherProps}
+                  type="radio"
+                  name={newName}
+                  disabled={isDisabled}
+                  checked={isDisabled ? false : optionValue === value}
+                  value={optionValue}
+                  {...otherOptionProps}
+                />
+                {typeof icon === "string" ? <Svg src={icon} /> : icon}
+                {label}
+              </label>
+              {action}
+            </div>
           );
         },
       )}

--- a/packages/canopee-react/src/distributeur/Form/Radio/__tests__/RadioInput.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/__tests__/RadioInput.test.tsx
@@ -7,7 +7,11 @@ import { Option } from "../../core";
 const languageOptions = [
   { label: "French", value: "french" },
   { label: "English", value: "english" },
-  { label: "Spanish", value: "spanish" },
+  {
+    label: "Spanish",
+    value: "spanish",
+    action: <span>Modifier les informations</span>,
+  },
 ];
 
 describe("RadioInput", () => {
@@ -56,8 +60,10 @@ describe("RadioInput", () => {
       const radioGroup = screen.getByRole("radiogroup", { name: "Radio card" });
 
       const radioCards = within(radioGroup).getAllByRole("radio");
-      const radioGroupWrapper = radioCards[0].closest("div");
-      expect(radioGroupWrapper).toHaveClass("af-form__radio-card-group");
+      const radioGroupWrapper = radioCards[0].closest(
+        ".af-form__radio-card-group",
+      );
+      expect(radioGroupWrapper).toBeInTheDocument();
       expect(radioCards).toHaveLength(3);
     });
 
@@ -87,10 +93,10 @@ describe("RadioInput", () => {
       // Assert
       const radioGroup = screen.getByRole("radiogroup", { name: "Radio card" });
       const radioCards = within(radioGroup).getAllByRole("radio");
-      const radioGroupWrapper = radioCards[0].closest("div");
-      expect(radioGroupWrapper).toHaveClass(
-        "af-form__radio-card-group--horizontal",
+      const radioGroupWrapper = radioCards[0].closest(
+        ".af-form__radio-card-group--horizontal",
       );
+      expect(radioGroupWrapper).toBeInTheDocument();
     });
 
     it("should have custom class", () => {
@@ -127,6 +133,20 @@ describe("RadioInput", () => {
       expect(
         within(radioGroup).getByText("Child component"),
       ).toBeInTheDocument();
+    });
+
+    it("should have action element", () => {
+      // Act
+      render(
+        <RadioInput
+          mode="cardRadio"
+          options={languageOptions}
+          label="Radio card"
+        />,
+      );
+
+      // Assert
+      expect(screen.getByText("Modifier les informations")).toBeInTheDocument();
     });
 
     it("shouldn't have an accessibility violation", async () => {


### PR DESCRIPTION
Ajout d'une action pour une option sur le radio en mode card.

# Besoin
<img width="414" height="352" alt="image" src="https://github.com/user-attachments/assets/e0c7fae0-d240-4774-9f36-94e77013e55b" />

# Screenshot de la modification
<img width="956" height="314" alt="image" src="https://github.com/user-attachments/assets/c1dcbae9-389d-44be-a63f-bb39f831912d" />
