### PR TITLE
feat(canopee): add MultiMessage component for prospect-client

### DIFF
--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.mdx
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.mdx
@@ -1,0 +1,57 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import * as MultiMessageStories from "./MultiMessage.stories";
+
+<Meta of={MultiMessageStories} name="MultiMessage" />
+
+# MultiMessage
+
+To use the multi-message import it like that:
+
+```tsx
+import { MultiMessage } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => {
+  const notifications = [
+    { key: "Notification 1", value: "First important message" },
+    { key: "Notification 2", value: "Second important message" },
+    { key: "Notification 3", value: "Third important message" },
+  ];
+
+  return <MultiMessage notifications={notifications} />;
+};
+```
+
+## Description
+
+The `MultiMessage` component allows you to display multiple notifications with navigation controls. When there's only one notification, it displays as a simple message without navigation controls. When there are multiple notifications, users can navigate between them using previous/next buttons and see their current position.
+
+## Heading
+
+You can set the title level with `heading` prop : "h2" | "h3" | "h4" | "h5" | "h6", the default is "h2".
+
+```tsx
+<MultiMessage notifications={notifications} heading="h3" />
+```
+
+## Customization
+
+You can customize the labels for accessibility:
+
+```tsx
+<MultiMessage
+  notifications={notifications}
+  previousLabel="Previous notification"
+  nextLabel="Next notification"
+  separatorText="of"
+/>
+```
+
+## Playground
+
+<Canvas of={MultiMessageStories.Playground}></Canvas>
+
+<Controls of={MultiMessageStories.Playground} />
+
+## Examples
+
+<Canvas of={MultiMessageStories.All} layout="fullscreen" />

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.stories.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { MultiMessage, messageVariants } from "@axa-fr/canopee-react/prospect";
+
+import { renderMultiMessage, renderMultiMessageAll } from "./render";
+
+import "./MultiMessage.story.scss";
+
+const meta: Meta<typeof MultiMessage> = {
+  component: MultiMessage,
+  title: "Components/MultiMessage",
+  parameters: {
+    layout: "centered fullscreen",
+  },
+  argTypes: {
+    variant: {
+      options: Object.values(messageVariants),
+      control: { type: "select" },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiMessage>;
+
+export const Playground: Story = {
+  name: "MultiMessage",
+  render: renderMultiMessage,
+  args: {
+    notifications: [
+      { key: "Notification 1", value: "First important message" },
+      { key: "Notification 2", value: "Second important message" },
+      { key: "Notification 3", value: "Third important message" },
+    ],
+  },
+};
+
+export const All: StoryObj<typeof MultiMessage> = {
+  render: renderMultiMessageAll,
+};

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.story.scss
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.story.scss
@@ -1,0 +1,7 @@
+.af-multimessage-demo {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 2rem;
+  padding: 2rem;
+}

--- a/apps/apollo-stories/src/components/MultiMessage/render.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/render.tsx
@@ -1,0 +1,100 @@
+import {
+  MultiMessage,
+  messageVariants,
+  type Notification,
+} from "@axa-fr/canopee-react/prospect";
+import { type Args } from "storybook/internal/types";
+
+export const renderMultiMessageAll = () => {
+  const singleNotification: Notification[] = [
+    {
+      key: "Single Notification",
+      value:
+        "This is a single notification without navigation controls. Lorem ipsum dolor sit amet consectetur adipisicing elit.",
+    },
+  ];
+
+  const multipleNotifications: Notification[] = [
+    {
+      key: "Important Update",
+      value:
+        "Your account has been successfully updated. All changes have been saved and will take effect immediately.",
+    },
+    {
+      key: "New Feature Available",
+      value:
+        "We've added a new feature to help you manage your notifications more efficiently. Check it out in the settings menu.",
+    },
+    {
+      key: "Maintenance Schedule",
+      value:
+        "Scheduled maintenance will occur this weekend from 2:00 AM to 4:00 AM. During this time, some services may be temporarily unavailable.",
+    },
+    {
+      key: "Security Notice",
+      value:
+        "We've enhanced our security measures to better protect your data. No action is required from your side.",
+    },
+  ];
+
+  const customLabels: Notification[] = [
+    {
+      key: "Message 1",
+      value: "This example uses custom labels for the navigation controls.",
+    },
+    {
+      key: "Message 2",
+      value: "Previous and next buttons have different aria-labels.",
+    },
+    {
+      key: "Message 3",
+      value: "The separator text is also customized.",
+    },
+  ];
+
+  return (
+    <div className="af-multimessage-demo">
+      <div>
+        <h2>Single Notification</h2>
+        <MultiMessage notifications={singleNotification} />
+      </div>
+
+      <div>
+        <h2>Multiple Notifications</h2>
+        <MultiMessage notifications={multipleNotifications} />
+      </div>
+
+      <div>
+        <h2>All Variants</h2>
+        {Object.values(messageVariants).map((variant) => (
+          <div key={variant}>
+            <h3>{variant.charAt(0).toUpperCase() + variant.slice(1)}</h3>
+            <MultiMessage
+              notifications={multipleNotifications}
+              variant={variant}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <h2>Custom Labels</h2>
+        <MultiMessage
+          notifications={customLabels}
+          previousLabel="Previous message"
+          nextLabel="Next message"
+          separatorText="of"
+        />
+      </div>
+
+      <div>
+        <h2>With Custom Heading Level</h2>
+        <MultiMessage notifications={multipleNotifications} heading="h3" />
+      </div>
+    </div>
+  );
+};
+
+export const renderMultiMessage = ({ ...args }: Args) => (
+  <MultiMessage {...args} />
+);

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.mdx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.mdx
@@ -1,0 +1,57 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import * as MultiMessageStories from "./MultiMessage.stories";
+
+<Meta of={MultiMessageStories} name="MultiMessage" />
+
+# MultiMessage
+
+To use the multi-message import it like that:
+
+```tsx
+import { MultiMessage } from "@axa-fr/canopee-react/client";
+
+const MyComponent = () => {
+  const notifications = [
+    { key: "Notification 1", value: "First important message" },
+    { key: "Notification 2", value: "Second important message" },
+    { key: "Notification 3", value: "Third important message" },
+  ];
+
+  return <MultiMessage notifications={notifications} />;
+};
+```
+
+## Description
+
+The `MultiMessage` component allows you to display multiple notifications with navigation controls. When there's only one notification, it displays as a simple message without navigation controls. When there are multiple notifications, users can navigate between them using previous/next buttons and see their current position.
+
+## Heading
+
+You can set the title level with `heading` prop : "h2" | "h3" | "h4" | "h5" | "h6", the default is "h2".
+
+```tsx
+<MultiMessage notifications={notifications} heading="h3" />
+```
+
+## Customization
+
+You can customize the labels for accessibility:
+
+```tsx
+<MultiMessage
+  notifications={notifications}
+  previousLabel="Previous notification"
+  nextLabel="Next notification"
+  separatorText="of"
+/>
+```
+
+## Playground
+
+<Canvas of={MultiMessageStories.Playground}></Canvas>
+
+<Controls of={MultiMessageStories.Playground} />
+
+## Examples
+
+<Canvas of={MultiMessageStories.All} layout="fullscreen" />

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { MultiMessage, messageVariants } from "@axa-fr/canopee-react/client";
+
+import { renderMultiMessage, renderMultiMessageAll } from "./render";
+
+import "./MultiMessage.story.scss";
+
+const meta: Meta<typeof MultiMessage> = {
+  component: MultiMessage,
+  title: "Components/MultiMessage",
+  parameters: {
+    layout: "centered fullscreen",
+  },
+  argTypes: {
+    variant: {
+      options: Object.values(messageVariants),
+      control: { type: "select" },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiMessage>;
+
+export const Playground: Story = {
+  name: "MultiMessage",
+  render: renderMultiMessage,
+  args: {
+    notifications: [
+      { key: "Notification 1", value: "First important message" },
+      { key: "Notification 2", value: "Second important message" },
+      { key: "Notification 3", value: "Third important message" },
+    ],
+  },
+};
+
+export const All: StoryObj<typeof MultiMessage> = {
+  render: renderMultiMessageAll,
+};

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.story.scss
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.story.scss
@@ -1,0 +1,7 @@
+.af-multimessage-demo {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 2rem;
+  padding: 2rem;
+}

--- a/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
@@ -1,0 +1,98 @@
+import {
+  MultiMessage,
+  messageVariants,
+  type Notification,
+} from "@axa-fr/canopee-react/client";
+import { type Args } from "storybook/internal/types";
+
+export const renderMultiMessageAll = () => {
+  const singleNotification: Notification[] = [
+    {
+      key: "Single Notification",
+      value:
+        "This is a single notification without navigation controls. Lorem ipsum dolor sit amet consectetur adipisicing elit.",
+    },
+  ];
+
+  const multipleNotifications: Notification[] = [
+    {
+      key: "Important Update",
+      value:
+        "Your account has been successfully updated. All changes have been saved and will take effect immediately.",
+    },
+    {
+      key: "New Feature Available",
+      value:
+        "We've added a new feature to help you manage your notifications more efficiently. Check it out in the settings menu.",
+    },
+    {
+      key: "Maintenance Schedule",
+      value:
+        "Scheduled maintenance will occur this weekend from 2:00 AM to 4:00 AM. During this time, some services may be temporarily unavailable.",
+    },
+    {
+      key: "Security Notice",
+      value:
+        "We've enhanced our security measures to better protect your data. No action is required from your side.",
+    },
+  ];
+
+  const customLabels: Notification[] = [
+    {
+      key: "Message 1",
+      value: "This example uses custom labels for the navigation controls.",
+    },
+    {
+      key: "Message 2",
+      value: "Previous and next buttons have different aria-labels.",
+    },
+    {
+      key: "Message 3",
+      value: "The separator text is also customized.",
+    },
+  ];
+
+  return (
+    <div className="af-multimessage-demo">
+      <div>
+        <h2>Single Notification</h2>
+        <MultiMessage notifications={singleNotification} />
+      </div>
+
+      <div>
+        <h2>Multiple Notifications</h2>
+        <MultiMessage notifications={multipleNotifications} />
+      </div>
+
+      <div>
+        <h2>All Variants</h2>
+        {Object.values(messageVariants).map((variant) => (
+          <div key={variant}>
+            <h3>{variant.charAt(0).toUpperCase() + variant.slice(1)}</h3>
+            <MultiMessage
+              notifications={multipleNotifications}
+              variant={variant}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <h2>Custom Labels</h2>
+        <MultiMessage
+          notifications={customLabels}
+          previousLabel="Previous message"
+          nextLabel="Next message"
+          separatorText="of"
+        />
+      </div>
+
+      <div>
+        <h2>With Custom Heading Level</h2>
+        <MultiMessage notifications={multipleNotifications} heading="h3" />
+      </div>
+    </div>
+  );
+};
+
+export const renderMultiMessage = (args: Args) => <MultiMessage {...args} />;

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
@@ -1,0 +1,7 @@
+@import "./MultiMessageCommon.css";
+
+.af-multimessage {
+  --multimessage-controls-bg-color: var(--axa-blue-4);
+  --multimessage-controls-border-color: var(--axa-blue-100);
+  --multimessage-counter-color: var(--axa-blue-100);
+}

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageCommon.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageCommon.css
@@ -1,0 +1,35 @@
+.af-multimessage {
+  margin-block: calc(32 / var(--font-size-base) * 1rem);
+}
+
+.af-multimessage__wrapper {
+  position: relative;
+}
+
+.af-multimessage__message {
+  padding-bottom: calc(80 / var(--font-size-base) * 1rem);
+}
+
+.af-multimessage__controls {
+  position: absolute;
+  right: calc(16 / var(--font-size-base) * 1rem);
+  bottom: calc(16 / var(--font-size-base) * 1rem);
+  display: flex;
+  padding: calc(8 / var(--font-size-base) * 1rem);
+  border: 1px solid var(--multimessage-controls-border-color);
+  border-radius: 100vmax;
+  align-items: center;
+  gap: calc(16 / var(--font-size-base) * 1rem);
+  background-color: var(--multimessage-controls-bg-color);
+
+  @media (width < 768px) {
+    right: calc(8 / var(--font-size-base) * 1rem);
+    bottom: calc(8 / var(--font-size-base) * 1rem);
+  }
+}
+
+.af-multimessage__counter {
+  font-size: calc(16 / var(--font-size-base) * 1rem);
+  text-align: center;
+  color: var(--multimessage-counter-color);
+}

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
@@ -1,0 +1,7 @@
+@import "./MultiMessageCommon.css";
+
+.af-multimessage {
+  --multimessage-controls-bg-color: var(--color-white);
+  --multimessage-controls-border-color: var(--color-gray-400);
+  --multimessage-counter-color: var(--color-gray-900);
+}

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -15,6 +15,7 @@ export {
   buttonVariants,
   type ButtonVariants,
 } from "./prospect-client/Button/ButtonLF";
+export { Card, type CardProps } from "./prospect-client/Card/CardLF";
 export {
   CardMessage,
   cardMessageVariants,
@@ -84,6 +85,10 @@ export {
   type FooterProps,
 } from "./prospect-client/Layout/Footer/FooterLF";
 export {
+  LevelSelector,
+  type LevelSelectorProps,
+} from "./prospect-client/LevelSelector/LevelSelectorLF";
+export {
   Link,
   linkVariants,
   type LinkVariants,
@@ -96,6 +101,7 @@ export {
   type ClickItemVariants,
 } from "./prospect-client/List/ClickItem/ClickItemLF";
 export { ContentItemDuo } from "./prospect-client/List/ContentItemDuo/ContentItemDuoLF";
+export { List, type ListProps } from "./prospect-client/List/List/ListLF";
 export {
   Message,
   messageVariants,
@@ -108,6 +114,15 @@ export {
   ModalCoreFooter,
   ModalCoreHeader,
 } from "./prospect-client/Modal/ModalLF";
+export {
+  MultiMessage,
+  type Notification,
+} from "./prospect-client/MultiMessage/MultiMessageLF";
+export {
+  ItemPagination,
+  type ItemPaginationProps,
+} from "./prospect-client/Pagination/ItemPagination/ItemPaginationLF";
+export { Pagination } from "./prospect-client/Pagination/PaginationLF";
 export { ProgressBar } from "./prospect-client/ProgressBar/ProgressBarLF";
 export { ProgressBarGroup } from "./prospect-client/ProgressBarGroup/ProgressBarGroupLF";
 export {
@@ -130,14 +145,3 @@ export {
 } from "./prospect-client/Tag/TagLF";
 export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalLF";
 export { Toggle } from "./prospect-client/Toggle/ToggleLF";
-export { Pagination } from "./prospect-client/Pagination/PaginationLF";
-export {
-  ItemPagination,
-  type ItemPaginationProps,
-} from "./prospect-client/Pagination/ItemPagination/ItemPaginationLF";
-export { Card, type CardProps } from "./prospect-client/Card/CardLF";
-export { List, type ListProps } from "./prospect-client/List/List/ListLF";
-export {
-  LevelSelector,
-  type LevelSelectorProps,
-} from "./prospect-client/LevelSelector/LevelSelectorLF";

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageApollo.tsx
@@ -1,0 +1,23 @@
+import "@axa-fr/canopee-css/prospect/MultiMessage/MultiMessageApollo.css";
+import keyboardLeft from "@material-symbols/svg-400/rounded/keyboard_arrow_left-fill.svg";
+import keyboardRight from "@material-symbols/svg-400/rounded/keyboard_arrow_right-fill.svg";
+import { Button } from "../Button/ButtonApollo";
+import { Icon } from "../Icon/IconApollo";
+import { Message } from "../Message/MessageApollo";
+import {
+  MultiMessageCommon,
+  type MultiMessageProps,
+} from "./MultiMessageCommon";
+
+export type { Notification } from "./MultiMessageCommon";
+
+export const MultiMessage = (props: MultiMessageProps) => (
+  <MultiMessageCommon
+    {...props}
+    MessageComponent={Message}
+    ButtonComponent={Button}
+    IconComponent={Icon}
+    iconLeft={keyboardLeft}
+    iconRight={keyboardRight}
+  />
+);

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageCommon.tsx
@@ -1,0 +1,128 @@
+import type { ComponentPropsWithoutRef, ComponentType } from "react";
+import { useState } from "react";
+import type { ButtonProps } from "../Button/ButtonCommon";
+import type { Icon } from "../Icon/IconCommon";
+import type { MessageProps } from "../Message/MessageCommon";
+import type { MessageVariants } from "../Message/types";
+
+type Headings = "h2" | "h3" | "h4" | "h5" | "h6";
+
+export type Notification = {
+  /** Unique identifier for the notification */
+  key: string;
+  /** Content of the notification */
+  value: string;
+};
+
+export type MultiMessageProps = {
+  /** Array of notifications to display */
+  notifications: Notification[];
+  /** Message variant (validation, error, warning, information, neutral) */
+  variant?: MessageVariants;
+  /** HTML heading level used for the message titles */
+  heading?: Headings;
+  /** Label for the previous button (for accessibility) */
+  previousLabel?: string;
+  /** Label for the next button (for accessibility) */
+  nextLabel?: string;
+  /** Text displayed between current and total count */
+  separatorText?: string;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+type MultiMessagePropsWithComponents = MultiMessageProps & {
+  MessageComponent: ComponentType<MessageProps>;
+  ButtonComponent: ComponentType<ButtonProps>;
+  IconComponent: typeof Icon;
+  iconLeft: string;
+  iconRight: string;
+};
+
+const defaultClassName = "af-multimessage";
+
+export const MultiMessageCommon = ({
+  notifications,
+  variant = "information",
+  heading = "h2",
+  previousLabel = "Notification précédente",
+  nextLabel = "Notification suivante",
+  separatorText = "sur",
+  className,
+  MessageComponent,
+  ButtonComponent,
+  IconComponent,
+  iconLeft,
+  iconRight,
+  ...divProps
+}: MultiMessagePropsWithComponents) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (notifications.length === 0) return null;
+
+  if (notifications.length === 1) {
+    return (
+      <div
+        className={[defaultClassName, className].filter(Boolean).join(" ")}
+        {...divProps}
+      >
+        <MessageComponent
+          title={notifications[0].key}
+          heading={heading}
+          variant={variant}
+        >
+          {notifications[0].value}
+        </MessageComponent>
+      </div>
+    );
+  }
+
+  const currentNotification = notifications[currentIndex];
+  const totalNotifications = notifications.length;
+
+  const goToPrevious = () => {
+    setCurrentIndex((prev) => (prev === 0 ? totalNotifications - 1 : prev - 1));
+  };
+
+  const goToNext = () => {
+    setCurrentIndex((prev) => (prev === totalNotifications - 1 ? 0 : prev + 1));
+  };
+
+  return (
+    <div
+      className={[defaultClassName, className].filter(Boolean).join(" ")}
+      {...divProps}
+    >
+      <div className={`${defaultClassName}__wrapper`}>
+        <MessageComponent
+          title={currentNotification.key}
+          heading={heading}
+          variant={variant}
+          className={`${defaultClassName}__message`}
+        >
+          {currentNotification.value}
+        </MessageComponent>
+
+        <div className={`${defaultClassName}__controls`}>
+          <ButtonComponent
+            variant="ghost"
+            iconLeft={<IconComponent src={iconLeft} />}
+            aria-label={previousLabel}
+            onClick={goToPrevious}
+          />
+
+          <div className={`${defaultClassName}__counter`}>
+            <span>{currentIndex + 1}</span>
+            <span> {separatorText} </span>
+            <span>{totalNotifications}</span>
+          </div>
+
+          <ButtonComponent
+            variant="ghost"
+            iconLeft={<IconComponent src={iconRight} />}
+            aria-label={nextLabel}
+            onClick={goToNext}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageLF.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageLF.tsx
@@ -1,0 +1,23 @@
+import "@axa-fr/canopee-css/client/MultiMessage/MultiMessageLF.css";
+import keyboardLeft from "@material-symbols/svg-400/rounded/keyboard_arrow_left-fill.svg";
+import keyboardRight from "@material-symbols/svg-400/rounded/keyboard_arrow_right-fill.svg";
+import { Button } from "../Button/ButtonLF";
+import { Icon } from "../Icon/IconLF";
+import { Message } from "../Message/MessageLF";
+import {
+  MultiMessageCommon,
+  type MultiMessageProps,
+} from "./MultiMessageCommon";
+
+export type { Notification } from "./MultiMessageCommon";
+
+export const MultiMessage = (props: MultiMessageProps) => (
+  <MultiMessageCommon
+    {...props}
+    MessageComponent={Message}
+    ButtonComponent={Button}
+    IconComponent={Icon}
+    iconLeft={keyboardLeft}
+    iconRight={keyboardRight}
+  />
+);

--- a/packages/canopee-react/src/prospect-client/MultiMessage/__tests__/MultiMessageCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/__tests__/MultiMessageCommon.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { ComponentProps } from "react";
+import { Button } from "../../Button/ButtonLF";
+import { Icon } from "../../Icon/IconCommon";
+import { Message, messageVariants } from "../../Message/MessageLF";
+import { Spinner } from "../../Spinner/SpinnerLF";
+import {
+  MultiMessageCommon,
+  type MultiMessageProps,
+  type Notification,
+} from "../MultiMessageCommon";
+
+const defaultNotifications: Notification[] = [
+  { key: "Notification 1", value: "Premier message important" },
+  { key: "Notification 2", value: "Deuxième message important" },
+  { key: "Notification 3", value: "Troisième message important" },
+];
+
+const ButtonWithSpinner = (props: ComponentProps<typeof Button>) => (
+  <Button {...props} SpinnerComponent={Spinner} />
+);
+
+const defaultProps = {
+  notifications: defaultNotifications,
+  MessageComponent: Message,
+  ButtonComponent: ButtonWithSpinner,
+  IconComponent: Icon,
+  iconLeft: "keyboard_arrow_left-fill.svg",
+  iconRight: "keyboard_arrow_right-fill.svg",
+};
+
+describe("MultiMessageCommon", () => {
+  const renderMultiMessageCommon = (props: Partial<MultiMessageProps> = {}) =>
+    render(
+      <MultiMessageCommon
+        {...defaultProps}
+        {...props}
+        notifications={props.notifications || defaultNotifications}
+      />,
+    );
+
+  it("should return null when notifications array is empty", () => {
+    const { container } = renderMultiMessageCommon({ notifications: [] });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render a single message without controls when there is only one notification", () => {
+    const singleNotification = [{ key: "Solo", value: "Unique message" }];
+    renderMultiMessageCommon({ notifications: singleNotification });
+
+    expect(screen.getByText("Solo")).toBeInTheDocument();
+    expect(screen.getByText("Unique message")).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Notification précédente"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Notification suivante"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render the first notification by default", () => {
+    renderMultiMessageCommon();
+
+    expect(screen.getByText("Notification 1")).toBeInTheDocument();
+    expect(screen.getByText("Premier message important")).toBeInTheDocument();
+  });
+
+  it("should display counter with correct format", () => {
+    renderMultiMessageCommon();
+
+    const counter = screen.getByText((content, element) => {
+      return (
+        element?.className === "af-multimessage__counter" &&
+        element?.textContent?.includes("1") &&
+        element?.textContent?.includes("sur") &&
+        element?.textContent?.includes("3")
+      );
+    });
+    expect(counter).toBeInTheDocument();
+  });
+
+  it("should navigate to next notification when next button is clicked", async () => {
+    const user = userEvent.setup();
+    renderMultiMessageCommon();
+
+    const nextButton = screen.getByLabelText("Notification suivante");
+    await user.click(nextButton);
+
+    expect(screen.getByText("Notification 2")).toBeInTheDocument();
+    expect(screen.getByText("Deuxième message important")).toBeInTheDocument();
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element?.className === "af-multimessage__counter" &&
+          element?.textContent?.includes("2") &&
+          element?.textContent?.includes("sur") &&
+          element?.textContent?.includes("3")
+        );
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should navigate to previous notification when previous button is clicked", async () => {
+    const user = userEvent.setup();
+    renderMultiMessageCommon();
+
+    const prevButton = screen.getByLabelText("Notification précédente");
+    await user.click(prevButton);
+
+    expect(screen.getByText("Notification 3")).toBeInTheDocument();
+    expect(screen.getByText("Troisième message important")).toBeInTheDocument();
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element?.className === "af-multimessage__counter" &&
+          element?.textContent?.includes("3") &&
+          element?.textContent?.includes("sur") &&
+          element?.textContent?.includes("3")
+        );
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should wrap from last to first notification when clicking next", async () => {
+    const user = userEvent.setup();
+    renderMultiMessageCommon();
+
+    const nextButton = screen.getByLabelText("Notification suivante");
+
+    await user.click(nextButton);
+    await user.click(nextButton);
+    await user.click(nextButton);
+
+    expect(screen.getByText("Notification 1")).toBeInTheDocument();
+    expect(screen.getByText("Premier message important")).toBeInTheDocument();
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element?.className === "af-multimessage__counter" &&
+          element?.textContent?.includes("1") &&
+          element?.textContent?.includes("sur") &&
+          element?.textContent?.includes("3")
+        );
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render with custom heading level", () => {
+    renderMultiMessageCommon({ heading: "h3" });
+
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading).toHaveTextContent("Notification 1");
+  });
+
+  it("should render with custom aria labels", () => {
+    renderMultiMessageCommon({
+      previousLabel: "Message précédent",
+      nextLabel: "Message suivant",
+    });
+
+    expect(screen.getByLabelText("Message précédent")).toBeInTheDocument();
+    expect(screen.getByLabelText("Message suivant")).toBeInTheDocument();
+  });
+
+  it("should render with custom separator text", () => {
+    renderMultiMessageCommon({ separatorText: "de" });
+
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element?.className === "af-multimessage__counter" &&
+          element?.textContent?.includes("1") &&
+          element?.textContent?.includes("de") &&
+          element?.textContent?.includes("3")
+        );
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render with the given className", () => {
+    renderMultiMessageCommon({ className: "my-custom-class" });
+
+    const container = screen.getByRole("status").parentElement?.parentElement;
+    expect(container).toHaveClass("af-multimessage my-custom-class");
+  });
+
+  it("should apply className to single notification wrapper", () => {
+    const singleNotification = [{ key: "Solo", value: "Unique message" }];
+    renderMultiMessageCommon({
+      notifications: singleNotification,
+      className: "my-custom-class",
+    });
+
+    const container = screen.getByRole("status").parentElement;
+    expect(container).toHaveClass("af-multimessage my-custom-class");
+  });
+
+  it("should have correct structure with controls", () => {
+    renderMultiMessageCommon();
+
+    const wrapper = document.querySelector(".af-multimessage__wrapper");
+    expect(wrapper).toBeInTheDocument();
+
+    const message = document.querySelector(".af-multimessage__message");
+    expect(message).toBeInTheDocument();
+
+    const controls = document.querySelector(".af-multimessage__controls");
+    expect(controls).toBeInTheDocument();
+
+    const counter = document.querySelector(".af-multimessage__counter");
+    expect(counter).toBeInTheDocument();
+  });
+
+  describe("A11Y", () => {
+    it("shouldn't have an accessibility violation with single notification", async () => {
+      const singleNotification = [{ key: "Solo", value: "Unique message" }];
+      const { container } = renderMultiMessageCommon({
+        notifications: singleNotification,
+      });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("shouldn't have an accessibility violation with multiple notifications", async () => {
+      const { container } = renderMultiMessageCommon();
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("should have proper aria-labels on navigation buttons", () => {
+      renderMultiMessageCommon();
+
+      const prevButton = screen.getByLabelText("Notification précédente");
+      const nextButton = screen.getByLabelText("Notification suivante");
+
+      expect(prevButton).toHaveAttribute(
+        "aria-label",
+        "Notification précédente",
+      );
+      expect(nextButton).toHaveAttribute("aria-label", "Notification suivante");
+    });
+  });
+
+  describe("Variants", () => {
+    it.each(Object.values(messageVariants))(
+      "should render with variant %s",
+      (variant) => {
+        renderMultiMessageCommon({ variant });
+
+        const role =
+          variant === "error" || variant === "warning" ? "alert" : "status";
+        const message = screen.getByRole(role);
+        expect(message).toHaveClass(`af-message--${variant}`);
+      },
+    );
+
+    it("should use information variant by default", () => {
+      renderMultiMessageCommon();
+
+      const message = screen.getByRole("status");
+      expect(message).toHaveClass("af-message--information");
+    });
+
+    it("should apply variant to single notification", () => {
+      const singleNotification = [{ key: "Solo", value: "Unique message" }];
+      renderMultiMessageCommon({
+        notifications: singleNotification,
+        variant: "error",
+      });
+
+      const message = screen.getByRole("alert");
+      expect(message).toHaveClass("af-message--error");
+    });
+  });
+});

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -15,6 +15,7 @@ export {
   buttonVariants,
   type ButtonVariants,
 } from "./prospect-client/Button/ButtonApollo";
+export { Card, type CardProps } from "./prospect-client/Card/CardApollo";
 export {
   CardMessage,
   cardMessageVariants,
@@ -76,6 +77,10 @@ export {
   type FooterProps,
 } from "./prospect-client/Layout/Footer/FooterApollo";
 export {
+  LevelSelector,
+  type LevelSelectorProps,
+} from "./prospect-client/LevelSelector/LevelSelectorApollo";
+export {
   Link,
   linkVariants,
   type LinkVariants,
@@ -88,6 +93,7 @@ export {
   type ClickItemVariants,
 } from "./prospect-client/List/ClickItem/ClickItemApollo";
 export { ContentItemDuo } from "./prospect-client/List/ContentItemDuo/ContentItemDuoApollo";
+export { List, type ListProps } from "./prospect-client/List/List/ListApollo";
 export {
   Message,
   messageVariants,
@@ -100,6 +106,15 @@ export {
   ModalCoreFooter,
   ModalCoreHeader,
 } from "./prospect-client/Modal/ModalApollo";
+export {
+  MultiMessage,
+  type Notification,
+} from "./prospect-client/MultiMessage/MultiMessageApollo";
+export {
+  ItemPagination,
+  type ItemPaginationProps,
+} from "./prospect-client/Pagination/ItemPagination/ItemPaginationApollo";
+export { Pagination } from "./prospect-client/Pagination/PaginationApollo";
 export { ProgressBar } from "./prospect-client/ProgressBar/ProgressBarApollo";
 export { ProgressBarGroup } from "./prospect-client/ProgressBarGroup/ProgressBarGroupApollo";
 export {
@@ -122,14 +137,3 @@ export {
 } from "./prospect-client/Tag/TagApollo";
 export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalApollo";
 export { Toggle } from "./prospect-client/Toggle/ToggleApollo";
-export { Pagination } from "./prospect-client/Pagination/PaginationApollo";
-export {
-  ItemPagination,
-  type ItemPaginationProps,
-} from "./prospect-client/Pagination/ItemPagination/ItemPaginationApollo";
-export { Card, type CardProps } from "./prospect-client/Card/CardApollo";
-export { List, type ListProps } from "./prospect-client/List/List/ListApollo";
-export {
-  LevelSelector,
-  type LevelSelectorProps,
-} from "./prospect-client/LevelSelector/LevelSelectorApollo";


### PR DESCRIPTION
- [x] - Add new MultiMessage component to display multiple notifications with navigation controls.
- [x] - Add comprehensive test suite for MultiMessage component.
- [x] - Add Storybook documentation and examples for MultiMessage component.

Issue for more details : https://github.com/AxaFrance/design-system/issues/1622