### PR TITLE
feat(slash): add readonly option for VerticalStep and set id props op…

### DIFF
--- a/apps/slash-stories/src/VerticalStep.stories.tsx
+++ b/apps/slash-stories/src/VerticalStep.stories.tsx
@@ -25,7 +25,6 @@ export const VerticalStepEditedStory: Story = {
   name: "Test composant VerticalStep en édition",
   args: {
     title: "Configuration",
-    id: "configuration",
     stepMode: "edited",
     onEdit: () => {},
     form: (
@@ -76,6 +75,18 @@ export const VerticalStepValidatedWithContentRightStory: Story = {
     onEdit: () => {},
     form: <h3>Formulaire de l&apos;étape configuration</h3>,
     restitution: <h3>Resitution de l&apos;étape configuration</h3>,
+  },
+};
+
+export const VerticalStepValidatedReadOnlyStory = {
+  name: "Test composant VerticalStep validé en lecture seule",
+  args: {
+    title: "Configuration",
+    stepMode: "validated",
+    onEdit: () => {},
+    form: <h3>Formulaire de l&apos;étape configuration</h3>,
+    restitution: <h3>Resitution de l&apos;étape configuration</h3>,
+    readonly: true,
   },
 };
 

--- a/packages/canopee-react/src/distributeur/Steps/VerticalStep.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/VerticalStep.tsx
@@ -2,7 +2,7 @@ import check from "@material-symbols/svg-400/sharp/check.svg";
 import edit from "@material-symbols/svg-400/sharp/edit-fill.svg";
 import lock from "@material-symbols/svg-400/sharp/lock-fill.svg";
 import classNames from "classnames";
-import { ReactNode } from "react";
+import { ReactNode, useId } from "react";
 import { Svg } from "../Svg";
 import { Title } from "../Title/Title";
 import type { VerticalStepMode } from "./types";
@@ -14,7 +14,7 @@ type Props = {
   /** The title of the step. */
   title: string;
   /** The id of the step, used for accessibility. It should be unique within the document. */
-  id: string;
+  id?: string;
   /** The mode of the step, can be "edited", "validated", or "locked". */
   stepMode: VerticalStepMode;
   /** The function to call when the edit button is clicked. */
@@ -33,26 +33,31 @@ type Props = {
   contentRight?: string;
   /** The aria-label for the additional content on the right side of the title. */
   contentRightAriaLabel?: string;
+  /** Add the section in read only mode by hiding edit button */
+  readonly?: boolean;
 };
 
 const defaultClassName = "af-vertical-step";
 
 export const VerticalStep = ({
   title,
-  id,
   stepMode,
   editButtonLabel = "Modifier",
   editButtonAriaLabel = `Modifier l'étape ${title}`,
   contentRightAriaLabel = `Contenu supplémentaire étape verticale ${title}`,
   onEdit,
+  id,
   form,
   restitution,
   showRestitution = true,
+  readonly = false,
   contentRight,
 }: Props) => {
   const isStepInEdition = stepMode === "edited";
   const isStepValidated = stepMode === "validated";
   const isStepLocked = stepMode === "locked";
+  const generatedId = useId();
+  const stepId = id ?? generatedId;
 
   return (
     <section
@@ -73,9 +78,9 @@ export const VerticalStep = ({
         {isStepInEdition ? <Svg role="presentation" src={edit} /> : null}
       </div>
       <Title
-        id={id}
+        id={stepId}
         contentLeft={
-          isStepValidated ? (
+          isStepValidated && !readonly ? (
             <Button
               aria-label={editButtonAriaLabel}
               onClick={onEdit}

--- a/packages/canopee-react/src/distributeur/Steps/__tests__/VerticalStep.spec.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/__tests__/VerticalStep.spec.tsx
@@ -118,7 +118,44 @@ describe("VerticalStep", () => {
     expect(screen.queryByText("Contenu à droite")).toBeInTheDocument();
   });
 
-  it("ne doit pas avoir de violations d’accessibilité (axe)", async () => {
+  it("should not allow edit if readonly is true", async () => {
+    render(
+      <VerticalStep
+        title="title"
+        id="id"
+        stepMode="validated"
+        onEdit={setStepMode}
+        form={<p>Formulaire</p>}
+        restitution={<p>Restitution</p>}
+        contentRight="Contenu à droite"
+        readonly
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Modifier l'étape title" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should allow edit if readonly is false", async () => {
+    render(
+      <VerticalStep
+        title="title"
+        id="id"
+        stepMode="validated"
+        onEdit={setStepMode}
+        form={<p>Formulaire</p>}
+        restitution={<p>Restitution</p>}
+        contentRight="Contenu à droite"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Modifier l'étape title" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ne doit pas avoir de violations d'accessibilité (axe)", async () => {
     const { container } = render(VerticalStepComponent("validated"));
     const results = await axe(container);
     expect(results).toHaveNoViolations();


### PR DESCRIPTION
- Add an optional isReadonly boolean to VerticalStep props to be able to hide edit button on validated mode
- Set id props optional with a default value when not specified