### PR TITLE
feat(distributeur): optionnal check for last step

### DIFF
--- a/apps/slash-stories/src/Steps.stories.tsx
+++ b/apps/slash-stories/src/Steps.stories.tsx
@@ -5,6 +5,7 @@ import { fn } from "@storybook/test";
 type StoryProps = React.ComponentProps<typeof Steps> & {
   onClick: (e: React.MouseEvent) => void;
   mode?: "link" | "active" | "disabled";
+  showLastStepCheck?: boolean;
 };
 
 const meta: Meta<StoryProps> = {
@@ -22,6 +23,7 @@ const meta: Meta<StoryProps> = {
         type: "select",
       },
     },
+    showLastStepCheck: { control: "boolean" },
   },
 };
 
@@ -38,8 +40,18 @@ type Story = StoryObj<StoryProps>;
 
 export const NewStepsStory: Story = {
   name: "New Design Steps",
-  render: ({ classModifier, className, mode, onClick }: StoryProps) => (
-    <Steps classModifier={classModifier} className={className}>
+  render: ({
+    classModifier,
+    className,
+    mode,
+    onClick,
+    showLastStepCheck,
+  }: StoryProps) => (
+    <Steps
+      classModifier={classModifier}
+      className={className}
+      showLastStepCheck={showLastStepCheck}
+    >
       <Step
         id="id1"
         href="/etape1"
@@ -78,6 +90,7 @@ export const NewStepsStory: Story = {
   args: {
     classModifier: "",
     className: "",
+    showLastStepCheck: true,
   },
 };
 

--- a/packages/canopee-css/src/distributeur/Steps/Steps.css
+++ b/packages/canopee-css/src/distributeur/Steps/Steps.css
@@ -121,6 +121,11 @@
   fill: var(--green30);
 }
 
+/* Cacher le check du dernier step quand no-last-check est présent */
+.af-steps-new--no-last-check .af-steps-list-step:last-child svg:first-child {
+  display: none;
+}
+
 .af-steps-new .af-steps-list-step:last-child svg:last-child {
   display: none;
 }

--- a/packages/canopee-react/src/distributeur.ts
+++ b/packages/canopee-react/src/distributeur.ts
@@ -95,7 +95,7 @@ export { Summary } from "./distributeur/Summary";
 export { Svg } from "./distributeur/Svg";
 export { Tabs } from "./distributeur/Tabs/Tabs";
 export { Title } from "./distributeur/Title/Title";
-export { getComponentClassName } from "./distributeur/utilities";
+export { getComponentClassName, getClassName } from "./distributeur/utilities";
 
 /** @deprecated Use `Tag` instead. */
 const Badge = Tag;

--- a/packages/canopee-react/src/distributeur/Steps/StepBase.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/StepBase.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import chevronSvg from "@material-symbols/svg-400/outlined/chevron_right.svg";
 import checkSvg from "@material-symbols/svg-400/outlined/check.svg";
-import { getComponentClassName, Svg } from "../../distributeur";
+import { getClassName, Svg } from "../../distributeur";
 
 type Props = {
   id: string;
@@ -11,11 +11,11 @@ type Props = {
   classModifier?: string;
 };
 const StepBase = ({ children, id, title, className, classModifier }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-steps-list-step",
+    modifiers: [classModifier],
     className,
-    classModifier,
-    "af-steps-list-step",
-  );
+  });
   return (
     <li key={id} className={componentClassName} title={title}>
       <Svg src={checkSvg} />

--- a/packages/canopee-react/src/distributeur/Steps/Steps.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/Steps.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities";
 
 const defaultClassName = "af-steps-new";
 
@@ -7,17 +7,22 @@ type Props = {
   children: ReactNode;
   className?: string;
   classModifier?: string;
+  showLastStepCheck?: boolean;
 };
 const Steps = ({
   children,
   className = defaultClassName,
   classModifier,
+  showLastStepCheck = true, // Par défaut à true pour comportement actuel
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: [
+      classModifier,
+      !showLastStepCheck ? "no-last-check" : undefined,
+    ],
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/utilities.ts
+++ b/packages/canopee-react/src/distributeur/utilities.ts
@@ -1,3 +1,4 @@
 export { BREAKPOINT } from "./utilities/constants";
 export { getComponentClassName } from "./utilities/helpers/getComponentClassName";
+export { getClassName } from "./utilities/helpers/getClassName";
 export { useIsSmallScreen } from "./utilities/hooks/useIsSmallScreen";


### PR DESCRIPTION
Bonjour,

Une mise à jour du composant "Steps" a été faite pour ne plus afficher la coche sur le dernier étape si ce n'est pas nécessaire. La nouvelle propriété est optionnelle pour assurer la rétrocompatibilité (par défaut === true).

J’en ai aussi profité pour remplacer la méthode "getComponentClassName" (qui est dépréciée) par "getClassName".

<img width="1012" height="558" alt="image" src="https://github.com/user-attachments/assets/d7aedf14-81b9-411c-92f3-26bfd4bb425f" />

<img width="1016" height="536" alt="image" src="https://github.com/user-attachments/assets/6adf5924-bb28-4055-9cbe-27ee6caf8800" />
