### PR TITLE
feat(canopee): [Fieldset] Nouveau composant technique (wrapper de champ)

### DIFF
--- a/apps/apollo-stories/src/components/Fieldset/Fieldset.stories.tsx
+++ b/apps/apollo-stories/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,0 +1,196 @@
+import {
+  Fieldset,
+  InputText,
+  CheckboxText,
+  Dropdown,
+  Radio,
+} from "@axa-fr/canopee-react/prospect";
+import homeIcon from "@material-symbols/svg-400/outlined/home.svg";
+import personIcon from "@material-symbols/svg-400/outlined/person.svg";
+import creditCardIcon from "@material-symbols/svg-400/outlined/credit_card.svg";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Fieldset> = {
+  title: "Components/Fieldset",
+  component: Fieldset,
+  argTypes: {
+    title: {
+      control: "text",
+      description: "Titre affiché dans la légende du fieldset",
+    },
+    icon: {
+      control: "text",
+      description: "Icône à afficher (déprécié, utiliser iconProps)",
+      table: {
+        category: "Deprecated",
+      },
+    },
+    iconProps: {
+      control: "object",
+      description: "Props de l'icône à afficher",
+    },
+    className: {
+      control: "text",
+      description: "Classes CSS additionnelles",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Fieldset>;
+
+export const Default: Story = {
+  name: "Par défaut",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Prénom" name="firstname" />
+      <InputText label="Nom" name="lastname" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Informations personnelles",
+  },
+};
+
+export const WithIcon: Story = {
+  name: "Avec icône",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Prénom" name="firstname" />
+      <InputText label="Nom" name="lastname" />
+      <InputText label="Email" name="email" type="email" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Informations personnelles",
+    iconProps: {
+      src: personIcon,
+    },
+  },
+};
+
+export const WithRadios: Story = {
+  name: "Avec boutons radio",
+  render: (args) => (
+    <Fieldset {...args}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Radio id="gender-male" name="gender" value="male" />
+        <label htmlFor="gender-male">Homme</label>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Radio id="gender-female" name="gender" value="female" />
+        <label htmlFor="gender-female">Femme</label>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Radio id="gender-other" name="gender" value="other" />
+        <label htmlFor="gender-other">Autre</label>
+      </div>
+    </Fieldset>
+  ),
+  args: {
+    title: "Genre",
+    iconProps: {
+      src: personIcon,
+    },
+  },
+};
+
+export const WithCheckboxes: Story = {
+  name: "Avec cases à cocher",
+  render: (args) => (
+    <Fieldset {...args}>
+      <CheckboxText label="Newsletter" name="newsletter" value="newsletter" />
+      <CheckboxText
+        label="Offres promotionnelles"
+        name="promotions"
+        value="promotions"
+      />
+      <CheckboxText label="Notifications SMS" name="sms" value="sms" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Préférences de communication",
+    iconProps: {
+      src: homeIcon,
+    },
+  },
+};
+
+export const PaymentForm: Story = {
+  name: "Formulaire de paiement",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Numéro de carte" name="cardNumber" />
+      <div style={{ display: "flex", gap: "1rem" }}>
+        <InputText label="Date d'expiration" name="expiry" />
+        <InputText label="CVV" name="cvv" />
+      </div>
+      <InputText label="Nom sur la carte" name="cardName" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Informations de paiement",
+    iconProps: {
+      src: creditCardIcon,
+    },
+  },
+};
+
+export const MultipleFieldsets: Story = {
+  name: "Plusieurs fieldsets",
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      <Fieldset
+        title="Informations personnelles"
+        iconProps={{ src: personIcon }}
+      >
+        <InputText label="Prénom" name="firstname" />
+        <InputText label="Nom" name="lastname" />
+        <InputText label="Email" name="email" type="email" />
+      </Fieldset>
+
+      <Fieldset title="Adresse" iconProps={{ src: homeIcon }}>
+        <InputText label="Rue" name="street" />
+        <div style={{ display: "flex", gap: "1rem" }}>
+          <InputText label="Code postal" name="zipcode" />
+          <InputText label="Ville" name="city" />
+        </div>
+        <Dropdown
+          label="Pays"
+          name="country"
+          placeholder="Sélectionner un pays"
+        >
+          <option value="fr">France</option>
+          <option value="be">Belgique</option>
+          <option value="ch">Suisse</option>
+        </Dropdown>
+      </Fieldset>
+
+      <Fieldset title="Paiement" iconProps={{ src: creditCardIcon }}>
+        <InputText label="Numéro de carte" name="cardNumber" />
+        <div style={{ display: "flex", gap: "1rem" }}>
+          <InputText label="Date d'expiration" name="expiry" />
+          <InputText label="CVV" name="cvv" />
+        </div>
+      </Fieldset>
+    </div>
+  ),
+};
+
+export const WithoutIcon: Story = {
+  name: "Sans icône",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Commentaire" name="comment" />
+      <CheckboxText
+        label="J'accepte les conditions générales"
+        name="terms"
+        value="terms"
+      />
+    </Fieldset>
+  ),
+  args: {
+    title: "Autres informations",
+  },
+};

--- a/apps/apollo-stories/src/components/Fieldset/Fieldset.stories.tsx
+++ b/apps/apollo-stories/src/components/Fieldset/Fieldset.stories.tsx
@@ -41,19 +41,6 @@ export default meta;
 type Story = StoryObj<typeof Fieldset>;
 
 export const Default: Story = {
-  name: "Par défaut",
-  render: (args) => (
-    <Fieldset {...args}>
-      <InputText label="Prénom" name="firstname" />
-      <InputText label="Nom" name="lastname" />
-    </Fieldset>
-  ),
-  args: {
-    title: "Informations personnelles",
-  },
-};
-
-export const WithIcon: Story = {
   name: "Avec icône",
   render: (args) => (
     <Fieldset {...args}>

--- a/apps/apollo-stories/src/components/Fieldset/Fieldset.stories.tsx
+++ b/apps/apollo-stories/src/components/Fieldset/Fieldset.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 type Story = StoryObj<typeof Fieldset>;
 
 export const Default: Story = {
-  name: "Avec icône",
+  name: "Default",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Prénom" name="firstname" />
@@ -58,7 +58,7 @@ export const Default: Story = {
 };
 
 export const WithRadios: Story = {
-  name: "Avec boutons radio",
+  name: "With radio buttons",
   render: (args) => (
     <Fieldset {...args}>
       <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
@@ -84,7 +84,7 @@ export const WithRadios: Story = {
 };
 
 export const WithCheckboxes: Story = {
-  name: "Avec cases à cocher",
+  name: "With checkboxes",
   render: (args) => (
     <Fieldset {...args}>
       <CheckboxText label="Newsletter" name="newsletter" value="newsletter" />
@@ -105,7 +105,7 @@ export const WithCheckboxes: Story = {
 };
 
 export const PaymentForm: Story = {
-  name: "Formulaire de paiement",
+  name: "Payment form",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Numéro de carte" name="cardNumber" />
@@ -125,7 +125,7 @@ export const PaymentForm: Story = {
 };
 
 export const MultipleFieldsets: Story = {
-  name: "Plusieurs fieldsets",
+  name: "Multiples fieldsets",
   render: () => (
     <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
       <Fieldset
@@ -166,7 +166,7 @@ export const MultipleFieldsets: Story = {
 };
 
 export const WithoutIcon: Story = {
-  name: "Sans icône",
+  name: "Without icon",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Commentaire" name="comment" />

--- a/apps/look-and-feel-stories/src/components/Fieldset/Fieldset.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Fieldset/Fieldset.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 type Story = StoryObj<typeof Fieldset>;
 
 export const Default: Story = {
-  name: "Par défaut",
+  name: "Default",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Prénom" name="firstname" />
@@ -54,7 +54,7 @@ export const Default: Story = {
 };
 
 export const WithIcon: Story = {
-  name: "Avec icône",
+  name: "With icon",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Prénom" name="firstname" />
@@ -71,7 +71,7 @@ export const WithIcon: Story = {
 };
 
 export const WithRadios: Story = {
-  name: "Avec boutons radio",
+  name: "With radios",
   render: (args) => (
     <Fieldset {...args}>
       <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
@@ -97,7 +97,7 @@ export const WithRadios: Story = {
 };
 
 export const WithCheckboxes: Story = {
-  name: "Avec cases à cocher",
+  name: "With checkboxes",
   render: (args) => (
     <Fieldset {...args}>
       <CheckboxText label="Newsletter" name="newsletter" value="newsletter" />
@@ -118,7 +118,7 @@ export const WithCheckboxes: Story = {
 };
 
 export const PaymentForm: Story = {
-  name: "Formulaire de paiement",
+  name: "Payment form",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Numéro de carte" name="cardNumber" />
@@ -138,7 +138,7 @@ export const PaymentForm: Story = {
 };
 
 export const MultipleFieldsets: Story = {
-  name: "Plusieurs fieldsets",
+  name: "Multiple fieldsets",
   render: () => (
     <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
       <Fieldset
@@ -179,7 +179,7 @@ export const MultipleFieldsets: Story = {
 };
 
 export const WithoutIcon: Story = {
-  name: "Sans icône",
+  name: "Without icon",
   render: (args) => (
     <Fieldset {...args}>
       <InputText label="Commentaire" name="comment" />

--- a/apps/look-and-feel-stories/src/components/Fieldset/Fieldset.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,0 +1,196 @@
+import {
+  Fieldset,
+  InputText,
+  CheckboxText,
+  Dropdown,
+  Radio,
+} from "@axa-fr/canopee-react/client";
+import homeIcon from "@material-symbols/svg-400/outlined/home.svg";
+import personIcon from "@material-symbols/svg-400/outlined/person.svg";
+import creditCardIcon from "@material-symbols/svg-400/outlined/credit_card.svg";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Fieldset> = {
+  title: "Components/Fieldset",
+  component: Fieldset,
+  argTypes: {
+    title: {
+      control: "text",
+      description: "Titre affiché dans la légende du fieldset",
+    },
+    icon: {
+      control: "text",
+      description: "Icône à afficher (déprécié, utiliser iconProps)",
+      table: {
+        category: "Deprecated",
+      },
+    },
+    iconProps: {
+      control: "object",
+      description: "Props de l'icône à afficher",
+    },
+    className: {
+      control: "text",
+      description: "Classes CSS additionnelles",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Fieldset>;
+
+export const Default: Story = {
+  name: "Par défaut",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Prénom" name="firstname" />
+      <InputText label="Nom" name="lastname" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Informations personnelles",
+  },
+};
+
+export const WithIcon: Story = {
+  name: "Avec icône",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Prénom" name="firstname" />
+      <InputText label="Nom" name="lastname" />
+      <InputText label="Email" name="email" type="email" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Informations personnelles",
+    iconProps: {
+      src: personIcon,
+    },
+  },
+};
+
+export const WithRadios: Story = {
+  name: "Avec boutons radio",
+  render: (args) => (
+    <Fieldset {...args}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Radio id="gender-male" name="gender" value="male" />
+        <label htmlFor="gender-male">Homme</label>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Radio id="gender-female" name="gender" value="female" />
+        <label htmlFor="gender-female">Femme</label>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Radio id="gender-other" name="gender" value="other" />
+        <label htmlFor="gender-other">Autre</label>
+      </div>
+    </Fieldset>
+  ),
+  args: {
+    title: "Genre",
+    iconProps: {
+      src: personIcon,
+    },
+  },
+};
+
+export const WithCheckboxes: Story = {
+  name: "Avec cases à cocher",
+  render: (args) => (
+    <Fieldset {...args}>
+      <CheckboxText label="Newsletter" name="newsletter" value="newsletter" />
+      <CheckboxText
+        label="Offres promotionnelles"
+        name="promotions"
+        value="promotions"
+      />
+      <CheckboxText label="Notifications SMS" name="sms" value="sms" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Préférences de communication",
+    iconProps: {
+      src: homeIcon,
+    },
+  },
+};
+
+export const PaymentForm: Story = {
+  name: "Formulaire de paiement",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Numéro de carte" name="cardNumber" />
+      <div style={{ display: "flex", gap: "1rem" }}>
+        <InputText label="Date d'expiration" name="expiry" />
+        <InputText label="CVV" name="cvv" />
+      </div>
+      <InputText label="Nom sur la carte" name="cardName" />
+    </Fieldset>
+  ),
+  args: {
+    title: "Informations de paiement",
+    iconProps: {
+      src: creditCardIcon,
+    },
+  },
+};
+
+export const MultipleFieldsets: Story = {
+  name: "Plusieurs fieldsets",
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      <Fieldset
+        title="Informations personnelles"
+        iconProps={{ src: personIcon }}
+      >
+        <InputText label="Prénom" name="firstname" />
+        <InputText label="Nom" name="lastname" />
+        <InputText label="Email" name="email" type="email" />
+      </Fieldset>
+
+      <Fieldset title="Adresse" iconProps={{ src: homeIcon }}>
+        <InputText label="Rue" name="street" />
+        <div style={{ display: "flex", gap: "1rem" }}>
+          <InputText label="Code postal" name="zipcode" />
+          <InputText label="Ville" name="city" />
+        </div>
+        <Dropdown
+          label="Pays"
+          name="country"
+          placeholder="Sélectionner un pays"
+        >
+          <option value="fr">France</option>
+          <option value="be">Belgique</option>
+          <option value="ch">Suisse</option>
+        </Dropdown>
+      </Fieldset>
+
+      <Fieldset title="Paiement" iconProps={{ src: creditCardIcon }}>
+        <InputText label="Numéro de carte" name="cardNumber" />
+        <div style={{ display: "flex", gap: "1rem" }}>
+          <InputText label="Date d'expiration" name="expiry" />
+          <InputText label="CVV" name="cvv" />
+        </div>
+      </Fieldset>
+    </div>
+  ),
+};
+
+export const WithoutIcon: Story = {
+  name: "Sans icône",
+  render: (args) => (
+    <Fieldset {...args}>
+      <InputText label="Commentaire" name="comment" />
+      <CheckboxText
+        label="J'accepte les conditions générales"
+        name="terms"
+        value="terms"
+      />
+    </Fieldset>
+  ),
+  args: {
+    title: "Autres informations",
+  },
+};

--- a/client/apollo/css/src/Fieldset/FieldsetApollo.css
+++ b/client/apollo/css/src/Fieldset/FieldsetApollo.css
@@ -1,0 +1,2 @@
+@import "@axa-fr/canopee-css/prospect/Fieldset/FieldsetApollo.css";
+

--- a/client/apollo/css/src/Fieldset/FieldsetLF.css
+++ b/client/apollo/css/src/Fieldset/FieldsetLF.css
@@ -1,0 +1,2 @@
+@import "@axa-fr/canopee-css/client/Fieldset/FieldsetLF.css";
+

--- a/packages/canopee-css/src/distributeur/Form/Checkbox/Checkbox.css
+++ b/packages/canopee-css/src/distributeur/Form/Checkbox/Checkbox.css
@@ -407,10 +407,10 @@
   display: flex;
   width: 1rem;
   height: 1rem;
+  aspect-ratio: 1 / 1;
   border: 1px solid var(--input-border-color);
   background-color: var(--white);
   fill: none;
-  aspect-ratio: 1 / 1;
 }
 
 .af-form__checkbox .af-form__indicator .ok-icon,

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetApollo.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetApollo.css
@@ -1,0 +1,3 @@
+@import "../Card/CardApollo.css";
+@import "../ContentItemMono/ContentItemMonoApollo.css";
+@import "./FieldsetCommon.css";

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetApollo.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetApollo.css
@@ -1,3 +1,1 @@
-@import "../Card/CardApollo.css";
-@import "../ContentItemMono/ContentItemMonoApollo.css";
 @import "./FieldsetCommon.css";

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
@@ -1,0 +1,21 @@
+.af-fieldset {
+  margin: 0;
+  border: none;
+
+  .af-fieldset__content {
+    display: flex;
+    flex-direction: column;
+    gap: calc(16 / var(--font-size-base) * 1rem);
+  }
+
+  > legend.af-content-item-mono {
+    float: left;
+    width: 100%;
+    margin-bottom: calc(24 / var(--font-size-base) * 1rem);
+    padding: 0;
+
+    + .af-fieldset__content {
+      clear: both;
+    }
+  }
+}

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
@@ -1,6 +1,7 @@
 .af-fieldset {
   display: flex;
   margin: 0;
+  padding: calc(16 / var(--font-size-base) * 1rem);
   border: none;
   flex-direction: column;
   gap: calc(24 / var(--font-size-base) * 1rem);

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
@@ -7,7 +7,7 @@
   gap: calc(24 / var(--font-size-base) * 1rem);
 
   > legend.af-content-item-mono {
-    padding: 0;
+    padding-top: calc(16 / var(--font-size-base) * 1rem);
   }
 
   .af-fieldset__content {

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetCommon.css
@@ -1,21 +1,17 @@
 .af-fieldset {
+  display: flex;
   margin: 0;
   border: none;
+  flex-direction: column;
+  gap: calc(24 / var(--font-size-base) * 1rem);
+
+  > legend.af-content-item-mono {
+    padding: 0;
+  }
 
   .af-fieldset__content {
     display: flex;
     flex-direction: column;
     gap: calc(16 / var(--font-size-base) * 1rem);
-  }
-
-  > legend.af-content-item-mono {
-    float: left;
-    width: 100%;
-    margin-bottom: calc(24 / var(--font-size-base) * 1rem);
-    padding: 0;
-
-    + .af-fieldset__content {
-      clear: both;
-    }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetLF.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetLF.css
@@ -1,3 +1,1 @@
-@import "../Card/CardLF.css";
-@import "../ContentItemMono/ContentItemMonoLF.css";
 @import "./FieldsetCommon.css";

--- a/packages/canopee-css/src/prospect-client/Fieldset/FieldsetLF.css
+++ b/packages/canopee-css/src/prospect-client/Fieldset/FieldsetLF.css
@@ -1,0 +1,3 @@
+@import "../Card/CardLF.css";
+@import "../ContentItemMono/ContentItemMonoLF.css";
+@import "./FieldsetCommon.css";

--- a/packages/canopee-css/src/prospect-client/client.css
+++ b/packages/canopee-css/src/prospect-client/client.css
@@ -54,3 +54,4 @@
 @import "./List/List/ListLF.css";
 @import "./LevelSelector/LevelSelectorLF.css";
 @import "./Skeleton/SkeletonLF.css";
+@import "./Fieldset/FieldsetLF.css";

--- a/packages/canopee-css/src/prospect-client/prospect.css
+++ b/packages/canopee-css/src/prospect-client/prospect.css
@@ -54,3 +54,4 @@
 @import "./List/List/ListApollo.css";
 @import "./LevelSelector/LevelSelectorApollo.css";
 @import "./Skeleton/SkeletonApollo.css";
+@import "./Fieldset/FieldsetApollo.css";

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -154,3 +154,7 @@ export {
   SkeletonList,
   type SkeletonListProps,
 } from "./prospect-client/SkeletonList/SkeletonListLF";
+export {
+  Fieldset,
+  type FieldsetProps,
+} from "./prospect-client/Fieldset/FieldsetLF";

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -30,10 +30,7 @@ export const ContentItemMonoCore = <T extends ElementType = "div">({
   const Component = as ?? "div";
 
   return (
-    <Component
-      data-testid="container"
-      className={`af-content-item-mono ${size}`}
-    >
+    <Component className={`af-content-item-mono ${size}`}>
       {leftComponent}
       <div className="text-content">
         {title ? <span className="title">{title}</span> : null}

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from "react";
-import { AtLeastOne } from "../utilities/types/AtLeastOne";
-
 import type { ElementType } from "react";
+import { ReactNode } from "react";
+
+import { AtLeastOne } from "../utilities/types/AtLeastOne";
 
 export type ContentMonoItemSize = "medium" | "large";
 

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
 import { AtLeastOne } from "../utilities/types/AtLeastOne";
 
+import type { ElementType } from "react";
+
 export type ContentMonoItemSize = "medium" | "large";
 
 type TextFields = {
@@ -11,20 +13,27 @@ type TextFields = {
 
 type AtLeastOneText = AtLeastOne<TextFields>;
 
-export type ContentItemCoreProps = {
+export type ContentItemCoreProps<T extends ElementType = "div"> = {
+  as?: T;
   size?: ContentMonoItemSize;
   leftComponent?: ReactNode;
 } & AtLeastOneText;
 
-export const ContentItemMonoCore = ({
+export const ContentItemMonoCore = <T extends ElementType = "div">({
+  as,
   size = "medium",
   leftComponent,
   title,
   primarySubtitle,
   subtitle,
-}: ContentItemCoreProps) => {
+}: ContentItemCoreProps<T>) => {
+  const Component = as ?? "div";
+
   return (
-    <div data-testid="container" className={`af-content-item-mono ${size}`}>
+    <Component
+      data-testid="container"
+      className={`af-content-item-mono ${size}`}
+    >
       {leftComponent}
       <div className="text-content">
         {title ? <span className="title">{title}</span> : null}
@@ -33,6 +42,6 @@ export const ContentItemMonoCore = ({
         ) : null}
         {subtitle ? <span className="subtitle">{subtitle}</span> : null}
       </div>
-    </div>
+    </Component>
   );
 };

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/__tests__/ContentItemMonoCore.test.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/__tests__/ContentItemMonoCore.test.tsx
@@ -4,7 +4,7 @@ import { ContentItemMonoCore } from "../ContentItemMonoCore";
 
 describe("ContentItemMonoCore Component", () => {
   it("renders with default size and displays title, primarySubtitle, and subtitle", () => {
-    render(
+    const { container } = render(
       <ContentItemMonoCore
         title="Test Title"
         primarySubtitle="Primary Subtitle"
@@ -13,8 +13,8 @@ describe("ContentItemMonoCore Component", () => {
     );
 
     // Vérifie que le conteneur principal est rendu avec la classe par défaut
-    const container = screen.getByTestId("container");
-    expect(container).toHaveClass("af-content-item-mono medium");
+    const component = container.firstElementChild;
+    expect(component).toHaveClass("af-content-item-mono medium");
 
     // Vérifie que le titre est affiché
     expect(screen.getByText("Test Title")).toBeInTheDocument();
@@ -27,7 +27,7 @@ describe("ContentItemMonoCore Component", () => {
   });
 
   it("renders with a custom size", () => {
-    render(
+    const { container } = render(
       <ContentItemMonoCore
         size="large"
         title="Custom Size Title"
@@ -37,8 +37,8 @@ describe("ContentItemMonoCore Component", () => {
     );
 
     // Vérifie que la classe de taille personnalisée est appliquée
-    const container = screen.getByTestId("container");
-    expect(container).toHaveClass("af-content-item-mono large");
+    const component = container.firstElementChild;
+    expect(component).toHaveClass("af-content-item-mono large");
   });
 
   it("renders without primarySubtitle when not provided", () => {
@@ -72,15 +72,15 @@ describe("ContentItemMonoCore Component", () => {
   });
 
   it("renders with a custom leftComponent", () => {
-    render(
+    const { container } = render(
       <ContentItemMonoCore
         title="Custom Left Component"
-        leftComponent={<div data-testid="custom-left">Custom Left</div>}
+        leftComponent={<div className="custom-left">Custom Left</div>}
       />,
     );
 
     // Vérifie que le composant gauche personnalisé est rendu
-    expect(screen.getByTestId("custom-left")).toBeInTheDocument();
+    expect(container.getElementsByClassName("custom-left").length).toBe(1);
 
     // Vérifie que le composant par défaut n'est pas rendu
     expect(
@@ -89,16 +89,18 @@ describe("ContentItemMonoCore Component", () => {
   });
 
   it("renders with a custom element using 'as' prop", () => {
-    render(<ContentItemMonoCore as="legend" title="Legend Title" />);
+    const { container } = render(
+      <ContentItemMonoCore as="legend" title="Legend Title" />,
+    );
 
-    const container = screen.getByTestId("container");
-    expect(container.tagName).toBe("LEGEND");
+    const component = container.firstElementChild;
+    expect(component?.tagName).toBe("LEGEND");
   });
 
   it("renders as a div by default", () => {
-    render(<ContentItemMonoCore title="Div Title" />);
+    const { container } = render(<ContentItemMonoCore title="Div Title" />);
 
-    const container = screen.getByTestId("container");
-    expect(container.tagName).toBe("DIV");
+    const component = container.firstElementChild;
+    expect(component?.tagName).toBe("DIV");
   });
 });

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/__tests__/ContentItemMonoCore.test.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/__tests__/ContentItemMonoCore.test.tsx
@@ -87,4 +87,18 @@ describe("ContentItemMonoCore Component", () => {
       screen.queryByText("", { selector: ".stick" }),
     ).not.toBeInTheDocument();
   });
+
+  it("renders with a custom element using 'as' prop", () => {
+    render(<ContentItemMonoCore as="legend" title="Legend Title" />);
+
+    const container = screen.getByTestId("container");
+    expect(container.tagName).toBe("LEGEND");
+  });
+
+  it("renders as a div by default", () => {
+    render(<ContentItemMonoCore title="Div Title" />);
+
+    const container = screen.getByTestId("container");
+    expect(container.tagName).toBe("DIV");
+  });
 });

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetApollo.tsx
@@ -1,0 +1,9 @@
+import "@axa-fr/canopee-css/prospect/Fieldset/FieldsetApollo.css";
+import { Icon } from "../Icon/IconApollo";
+import { FieldsetCommon, type FieldsetProps } from "./FieldsetCommon";
+
+export type { FieldsetProps };
+
+export const Fieldset = (props: FieldsetProps) => (
+  <FieldsetCommon {...props} IconComponent={Icon} />
+);

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetApollo.tsx
@@ -1,9 +1,10 @@
 import "@axa-fr/canopee-css/prospect/Fieldset/FieldsetApollo.css";
 import { Icon } from "../Icon/IconApollo";
+import { Card } from "../Card/CardApollo";
 import { FieldsetCommon, type FieldsetProps } from "./FieldsetCommon";
 
 export type { FieldsetProps };
 
 export const Fieldset = (props: FieldsetProps) => (
-  <FieldsetCommon {...props} IconComponent={Icon} />
+  <FieldsetCommon {...props} IconComponent={Icon} CardComponent={Card} />
 );

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetCommon.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps, ComponentType, PropsWithChildren } from "react";
+import classNames from "classnames";
 import { CardCommon } from "../Card/CardCommon";
 import { Icon, type IconProps } from "../Icon/IconCommon";
 import { ContentItemMonoCore } from "../ContentItemMono/ContentItemMonoCore";
@@ -6,35 +7,30 @@ import { ContentItemMonoCore } from "../ContentItemMono/ContentItemMonoCore";
 export type FieldsetProps = PropsWithChildren<{
   title: string;
   iconProps?: IconProps;
-  /**
-   * @deprecated Use `iconProps` instead.
-   */
-  icon?: string;
   className?: string;
 }>;
 
 export type FieldsetCommonProps = FieldsetProps & {
   IconComponent: ComponentType<ComponentProps<typeof Icon>>;
+  CardComponent: ComponentType<ComponentProps<typeof CardCommon>>;
 };
 
 export const FieldsetCommon = ({
   children,
   title,
-  icon,
   iconProps,
   className,
   IconComponent,
+  CardComponent,
 }: FieldsetCommonProps) => {
-  const iconComponent =
-    (iconProps && (
-      <IconComponent data-testid="fieldset-icon" {...iconProps} />
-    )) ||
-    (icon && <IconComponent data-testid="fieldset-icon" src={icon} />);
+  const iconComponent = iconProps && (
+    <IconComponent aria-hidden="true" {...iconProps} />
+  );
 
   return (
-    <CardCommon
+    <CardComponent
       as="fieldset"
-      className={`af-fieldset${className ? ` ${className}` : ""}`}
+      className={classNames("af-fieldset", className)}
     >
       <ContentItemMonoCore
         as="legend"
@@ -42,6 +38,6 @@ export const FieldsetCommon = ({
         leftComponent={iconComponent}
       />
       <div className="af-fieldset__content">{children}</div>
-    </CardCommon>
+    </CardComponent>
   );
 };

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetCommon.tsx
@@ -1,8 +1,8 @@
 import type { ComponentProps, ComponentType, PropsWithChildren } from "react";
-import classNames from "classnames";
 import { CardCommon } from "../Card/CardCommon";
 import { Icon, type IconProps } from "../Icon/IconCommon";
 import { ContentItemMonoCore } from "../ContentItemMono/ContentItemMonoCore";
+import { getClassName } from "../utilities/getClassName";
 
 export type FieldsetProps = PropsWithChildren<{
   title: string;
@@ -30,7 +30,7 @@ export const FieldsetCommon = ({
   return (
     <CardComponent
       as="fieldset"
-      className={classNames("af-fieldset", className)}
+      className={getClassName({ baseClassName: "af-fieldset", className })}
     >
       <ContentItemMonoCore
         as="legend"

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetCommon.tsx
@@ -1,0 +1,47 @@
+import type { ComponentProps, ComponentType, PropsWithChildren } from "react";
+import { CardCommon } from "../Card/CardCommon";
+import { Icon, type IconProps } from "../Icon/IconCommon";
+import { ContentItemMonoCore } from "../ContentItemMono/ContentItemMonoCore";
+
+export type FieldsetProps = PropsWithChildren<{
+  title: string;
+  iconProps?: IconProps;
+  /**
+   * @deprecated Use `iconProps` instead.
+   */
+  icon?: string;
+  className?: string;
+}>;
+
+export type FieldsetCommonProps = FieldsetProps & {
+  IconComponent: ComponentType<ComponentProps<typeof Icon>>;
+};
+
+export const FieldsetCommon = ({
+  children,
+  title,
+  icon,
+  iconProps,
+  className,
+  IconComponent,
+}: FieldsetCommonProps) => {
+  const iconComponent =
+    (iconProps && (
+      <IconComponent data-testid="fieldset-icon" {...iconProps} />
+    )) ||
+    (icon && <IconComponent data-testid="fieldset-icon" src={icon} />);
+
+  return (
+    <CardCommon
+      as="fieldset"
+      className={`af-fieldset${className ? ` ${className}` : ""}`}
+    >
+      <ContentItemMonoCore
+        as="legend"
+        title={title}
+        leftComponent={iconComponent}
+      />
+      <div className="af-fieldset__content">{children}</div>
+    </CardCommon>
+  );
+};

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetLF.tsx
@@ -1,9 +1,10 @@
 import "@axa-fr/canopee-css/client/Fieldset/FieldsetLF.css";
 import { Icon } from "../Icon/IconLF";
+import { Card } from "../Card/CardLF";
 import { FieldsetCommon, type FieldsetProps } from "./FieldsetCommon";
 
 export type { FieldsetProps };
 
 export const Fieldset = (props: FieldsetProps) => (
-  <FieldsetCommon {...props} IconComponent={Icon} />
+  <FieldsetCommon {...props} IconComponent={Icon} CardComponent={Card} />
 );

--- a/packages/canopee-react/src/prospect-client/Fieldset/FieldsetLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/FieldsetLF.tsx
@@ -1,0 +1,9 @@
+import "@axa-fr/canopee-css/client/Fieldset/FieldsetLF.css";
+import { Icon } from "../Icon/IconLF";
+import { FieldsetCommon, type FieldsetProps } from "./FieldsetCommon";
+
+export type { FieldsetProps };
+
+export const Fieldset = (props: FieldsetProps) => (
+  <FieldsetCommon {...props} IconComponent={Icon} />
+);

--- a/packages/canopee-react/src/prospect-client/Fieldset/__tests__/Fieldset.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/__tests__/Fieldset.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { FieldsetCommon } from "../FieldsetCommon";
+import { Icon } from "../../Icon/IconCommon";
+
+describe("Fieldset", () => {
+  it("should render with title", () => {
+    render(
+      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
+        <input type="text" />
+      </FieldsetCommon>,
+    );
+
+    expect(screen.getByText("Mon titre")).toBeInTheDocument();
+  });
+
+  it("should render as a fieldset element", () => {
+    render(
+      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
+        <input type="text" />
+      </FieldsetCommon>,
+    );
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset.tagName).toBe("FIELDSET");
+    expect(fieldset).toHaveClass("af-card");
+    expect(fieldset).toHaveClass("af-fieldset");
+  });
+
+  it("should render legend element", () => {
+    render(
+      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
+        <input type="text" />
+      </FieldsetCommon>,
+    );
+
+    const legend = screen.getByTestId("container");
+    expect(legend.tagName).toBe("LEGEND");
+    expect(legend).toHaveClass("af-content-item-mono");
+  });
+
+  it("should render children", () => {
+    render(
+      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
+        <input type="text" data-testid="test-input" />
+      </FieldsetCommon>,
+    );
+
+    expect(screen.getByTestId("test-input")).toBeInTheDocument();
+  });
+
+  it("should render icon when iconProps is provided", () => {
+    render(
+      <FieldsetCommon
+        title="Mon titre"
+        iconProps={{ src: "icon.svg" }}
+        IconComponent={Icon}
+      >
+        <input type="text" />
+      </FieldsetCommon>,
+    );
+
+    expect(screen.getByTestId("fieldset-icon")).toBeInTheDocument();
+  });
+
+  it("should render icon when icon prop is provided (deprecated)", () => {
+    render(
+      <FieldsetCommon title="Mon titre" icon="icon.svg" IconComponent={Icon}>
+        <input type="text" />
+      </FieldsetCommon>,
+    );
+
+    expect(screen.getByTestId("fieldset-icon")).toBeInTheDocument();
+  });
+
+  it("should have custom class", () => {
+    render(
+      <FieldsetCommon
+        title="Mon titre"
+        className="custom-class"
+        IconComponent={Icon}
+      >
+        <input type="text" />
+      </FieldsetCommon>,
+    );
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).toHaveClass("custom-class");
+  });
+});

--- a/packages/canopee-react/src/prospect-client/Fieldset/__tests__/Fieldset.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/__tests__/Fieldset.test.tsx
@@ -1,11 +1,16 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { FieldsetCommon } from "../FieldsetCommon";
 import { Icon } from "../../Icon/IconCommon";
+import { CardCommon } from "../../Card/CardCommon";
 
 describe("Fieldset", () => {
   it("should render with title", () => {
     render(
-      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
+      <FieldsetCommon
+        title="Mon titre"
+        IconComponent={Icon}
+        CardComponent={CardCommon}
+      >
         <input type="text" />
       </FieldsetCommon>,
     );
@@ -15,7 +20,11 @@ describe("Fieldset", () => {
 
   it("should render as a fieldset element", () => {
     render(
-      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
+      <FieldsetCommon
+        title="Mon titre"
+        IconComponent={Icon}
+        CardComponent={CardCommon}
+      >
         <input type="text" />
       </FieldsetCommon>,
     );
@@ -26,50 +35,40 @@ describe("Fieldset", () => {
     expect(fieldset).toHaveClass("af-fieldset");
   });
 
-  it("should render legend element", () => {
-    render(
-      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
-        <input type="text" />
-      </FieldsetCommon>,
-    );
-
-    const legend = screen.getByTestId("container");
-    expect(legend.tagName).toBe("LEGEND");
-    expect(legend).toHaveClass("af-content-item-mono");
-  });
-
-  it("should render children", () => {
-    render(
-      <FieldsetCommon title="Mon titre" IconComponent={Icon}>
-        <input type="text" data-testid="test-input" />
-      </FieldsetCommon>,
-    );
-
-    expect(screen.getByTestId("test-input")).toBeInTheDocument();
-  });
-
-  it("should render icon when iconProps is provided", () => {
+  it("should render legend element with title and icon", () => {
     render(
       <FieldsetCommon
         title="Mon titre"
         iconProps={{ src: "icon.svg" }}
         IconComponent={Icon}
+        CardComponent={CardCommon}
       >
         <input type="text" />
       </FieldsetCommon>,
     );
 
-    expect(screen.getByTestId("fieldset-icon")).toBeInTheDocument();
+    const title = screen.getByText("Mon titre");
+    const legend = title.closest("legend");
+    expect(legend).toBeInTheDocument();
+    expect(legend).toHaveClass("af-content-item-mono");
+    expect(within(legend!).getByText("Mon titre")).toBeInTheDocument();
+    expect(legend?.getElementsByClassName("af-icon").length).toBe(1);
   });
 
-  it("should render icon when icon prop is provided (deprecated)", () => {
+  it("should render children", () => {
     render(
-      <FieldsetCommon title="Mon titre" icon="icon.svg" IconComponent={Icon}>
-        <input type="text" />
+      <FieldsetCommon
+        title="Mon titre"
+        IconComponent={Icon}
+        CardComponent={CardCommon}
+      >
+        <input type="text" placeholder="Saisir une valeur" />
       </FieldsetCommon>,
     );
 
-    expect(screen.getByTestId("fieldset-icon")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Saisir une valeur"),
+    ).toBeInTheDocument();
   });
 
   it("should have custom class", () => {
@@ -78,6 +77,7 @@ describe("Fieldset", () => {
         title="Mon titre"
         className="custom-class"
         IconComponent={Icon}
+        CardComponent={CardCommon}
       >
         <input type="text" />
       </FieldsetCommon>,

--- a/packages/canopee-react/src/prospect-client/Fieldset/__tests__/Fieldset.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Fieldset/__tests__/Fieldset.test.tsx
@@ -52,7 +52,7 @@ describe("Fieldset", () => {
     expect(legend).toBeInTheDocument();
     expect(legend).toHaveClass("af-content-item-mono");
     expect(within(legend!).getByText("Mon titre")).toBeInTheDocument();
-    expect(legend?.getElementsByClassName("af-icon").length).toBe(1);
+    expect(legend?.getElementsByClassName("af-icon")).toHaveLength(1);
   });
 
   it("should render children", () => {

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -146,3 +146,7 @@ export {
   SkeletonList,
   type SkeletonListProps,
 } from "./prospect-client/SkeletonList/SkeletonListApollo";
+export {
+  Fieldset,
+  type FieldsetProps,
+} from "./prospect-client/Fieldset/FieldsetApollo";


### PR DESCRIPTION
Nouveau composant permettant de regrouper un liste de champs (radio, checkbox, input, etc.)

En entrée, on doit pouvoir paramétrer le titre et l'icon : 
On peut utiliser le Content Item Mono mais il faut le modifier pour pouvoir forcer le tag html pour avoir une 'legend'.

Le composant doit réutiliser le composant Card déjà développé et forcer le tag html pour avoir un 'fieldset'.



Lien vers la maquette : https://www.figma.com/design/mSXpRZY53Znuy8Pd41kqUT/Formulaire-Multi-equipement?node-id=1566-12557&t=NofmNM0eAZEo3GwS-4