### PR TITLE
feat(client): change content item mono title

### DIFF
--- a/apps/apollo-stories/src/components/DataAgent/DataAgent.stories.tsx
+++ b/apps/apollo-stories/src/components/DataAgent/DataAgent.stories.tsx
@@ -32,19 +32,16 @@ export const Default: Story = {
         type: "icon",
         icon: accountBalance,
         subtitle1: "6 place du 14 juillet 28 240 Ivry la Bataille",
-        title: "",
       },
       {
         type: "icon",
         icon: accountBalance,
         subtitle1: "01 23 34 45 67",
-        title: "",
       },
       {
         type: "icon",
         icon: accountBalance,
         subtitle1: "Ouvert aujourd’hui de 09h00 à 13h00 et de 14h00 à 18h00",
-        title: "",
       },
     ],
     clickContents: [

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCommon.tsx
@@ -18,12 +18,12 @@ export type ContentMonoItemPictureProps = {
 
 export type ContentMonoItemIconProps = {
   type: "icon";
-  /**
-   * @deprecated Use `iconProps` instead.
-   */
   title?: string;
   subtitle1?: string;
   subtitle2?: string;
+  /**
+   * @deprecated Use `iconProps` instead.
+   */
   icon?: string;
   iconProps?: IconProps;
 };

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCommon.tsx
@@ -21,11 +21,11 @@ export type ContentMonoItemIconProps = {
   /**
    * @deprecated Use `iconProps` instead.
    */
-  icon?: string;
-  iconProps?: IconProps;
-  title: string;
+  title?: string;
   subtitle1?: string;
   subtitle2?: string;
+  icon?: string;
+  iconProps?: IconProps;
 };
 
 export type ContentMonoItemStickProps = {
@@ -59,7 +59,7 @@ export const getContentItemCoreProps = ({
       leftComponent:
         (iconProps && <IconComponent data-testid="icon" {...iconProps} />) ||
         (icon && <IconComponent data-testid="icon" src={icon} />),
-    };
+    } as ContentItemCoreProps;
   }
 
   if (type === "picture") {
@@ -71,13 +71,13 @@ export const getContentItemCoreProps = ({
           alt={props.title}
         />
       ),
-    };
+    } as ContentItemCoreProps;
   }
 
   return {
     ...props,
     leftComponent: <div className="stick" />,
-  };
+  } as ContentItemCoreProps;
 };
 
 export const ContentItemMonoCommon = (props: ContentItemCommonProps) => {

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -1,21 +1,19 @@
+import { ReactNode } from "react";
+import { AtLeastOne } from "../utilities/types/AtLeastOne";
+
 export type ContentMonoItemSize = "medium" | "large";
 
-type AtLeastOne<T, K extends keyof T = keyof T> = Partial<T> &
-  { [P in K]: Required<Pick<T, P>> }[K];
-
-// shape of the text props (all optional by default)
 type TextFields = {
   title?: string;
   primarySubtitle?: string;
   subtitle?: string;
 };
 
-// concrete type: at least one of title | primarySubtitle | subtitle must be present
 type AtLeastOneText = AtLeastOne<TextFields>;
 
 export type ContentItemCoreProps = {
   size?: ContentMonoItemSize;
-  leftComponent?: React.ReactNode;
+  leftComponent?: ReactNode;
 } & AtLeastOneText;
 
 export const ContentItemMonoCore = ({

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -19,7 +19,7 @@ export const ContentItemMonoCore = ({
     <div data-testid="container" className={`af-content-item-mono ${size}`}>
       {leftComponent}
       <div className="text-content">
-        <span className="title">{title}</span>
+        {title ? <span className="title">{title}</span> : null}
         {primarySubtitle ? (
           <span className="subtitle-primary">{primarySubtitle}</span>
         ) : null}

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -1,12 +1,22 @@
 export type ContentMonoItemSize = "medium" | "large";
 
-export type ContentItemCoreProps = {
-  size?: ContentMonoItemSize;
+type AtLeastOne<T, K extends keyof T = keyof T> = Partial<T> &
+  { [P in K]: Required<Pick<T, P>> }[K];
+
+// shape of the text props (all optional by default)
+type TextFields = {
   title?: string;
   primarySubtitle?: string;
   subtitle?: string;
-  leftComponent?: React.ReactNode;
 };
+
+// concrete type: at least one of title | primarySubtitle | subtitle must be present
+type AtLeastOneText = AtLeastOne<TextFields>;
+
+export type ContentItemCoreProps = {
+  size?: ContentMonoItemSize;
+  leftComponent?: React.ReactNode;
+} & AtLeastOneText;
 
 export const ContentItemMonoCore = ({
   size = "medium",

--- a/packages/canopee-react/src/prospect-client/utilities/types/AtLeastOne.ts
+++ b/packages/canopee-react/src/prospect-client/utilities/types/AtLeastOne.ts
@@ -1,0 +1,2 @@
+export type AtLeastOne<T, K extends keyof T = keyof T> = Partial<T> &
+  { [P in K]: Required<Pick<T, P>> }[K];


### PR DESCRIPTION
https://github.com/AxaFrance/design-system/issues/1649

Content mono item title est optionel dans les props mais pas conditioné.
ca cree une div title en plus et un margin-bottom de 2.4px en plus dans les composants.