### PR TITLE
feat(client,prospect): add word-break to content item duo value

### DIFF
--- a/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
+++ b/packages/canopee-css/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.css
@@ -29,6 +29,7 @@
     );
     font-weight: 600;
     line-height: 125%;
+    word-break: break-word;
     color: var(--content-item-duo-value-color);
   }
 


### PR DESCRIPTION
Add word break to ContentItemDuo value to avoid to have a part of the text out of the container limits.