### PR TITLE
feat(distributeur): add experimental input components with Storybook …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,17 @@
 		"source.fixAll.eslint": "explicit",
 		"source.fixAll.stylelint": "explicit"
 	},
-	"stylelint.validate": ["css", "scss"],
+	"stylelint.validate": [
+		"css",
+		"scss"
+	],
 	"github.copilot.chat.commitMessageGeneration.instructions": [
 		{
 			"file": ".github/git-commit-instructions.md"
 		}
-	]
+	],
+	"search.exclude": {
+		"**/slash": true,
+		"**/client": true
+	}
 }

--- a/apps/slash-stories/src/Form/Experimental/Input.mdx
+++ b/apps/slash-stories/src/Form/Experimental/Input.mdx
@@ -1,0 +1,81 @@
+import {
+  Canvas,
+  Controls,
+  Description,
+  Meta,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
+import * as Stories from "./Input.stories";
+
+<Meta of={Stories} title="Form/Experimental/Input" />
+
+<Title />
+
+## ⚠️ Experimental Component
+
+This component is **experimental** and may change in future releases. You can however use it in your projects, but be aware that the API might change.
+We welcome your feedback and contributions to improve this component.
+
+## Overview
+
+The `Input` component is a low-level form input component that provides a styled HTML input element. It serves as the foundation for more complex input components like `TextInput`.
+
+This component is a wrapper around the native HTML `input` element with predefined styles and accessibility features. It's typically used in combination with other form components like `Label`, `InputContainer`, and `InputUnit` to create complete form fields.
+
+## Playground
+
+<Primary />
+<Controls />
+
+## Usage
+
+The `Input` component forwards all props to the underlying HTML input element, making it fully compatible with standard input attributes.
+
+```tsx
+import { Input } from "@axa-fr/design-system-slash-react/experimental";
+
+const MyComponent = () => {
+  return <Input type="text" placeholder="Enter your name" />;
+};
+```
+
+## States
+
+### Disabled
+
+Set the `disabled` prop to true to disable the input field.
+
+<Canvas of={Stories.DisabledStory} />
+
+### Required
+
+Set the `required` prop to mark the input as required.
+
+<Canvas of={Stories.RequiredStory} />
+
+### Invalid
+
+Use the `aria-invalid` attribute to mark the input as invalid. This will apply error styling.
+
+<Canvas of={Stories.InvalidStory} />
+
+## Form Integration
+
+This component can be used with form libraries like [react-hook-form](https://react-hook-form.com/) or [Formik](https://formik.org/). It supports controlled and uncontrolled usage patterns and forwards refs properly.
+
+```tsx
+import { Input } from "@axa-fr/design-system-slash-react/experimental";
+import { useForm } from "react-hook-form";
+
+const MyForm = () => {
+  const { register, handleSubmit } = useForm();
+
+  return (
+    <form onSubmit={handleSubmit(console.log)}>
+      <Input {...register("fieldName")} />
+    </form>
+  );
+};
+```

--- a/apps/slash-stories/src/Form/Experimental/Input.stories.tsx
+++ b/apps/slash-stories/src/Form/Experimental/Input.stories.tsx
@@ -1,0 +1,57 @@
+import { Input } from "@axa-fr/canopee-react/distributeur/experimental";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Experimental/Form/Atoms/Input",
+  component: Input,
+  argTypes: {
+    placeholder: { control: "text" },
+    disabled: { control: "boolean" },
+    required: { control: "boolean" },
+    type: {
+      control: { type: "select" },
+      options: ["text", "email", "password", "number", "tel", "url"],
+    },
+    onChange: { action: "changed", table: { disable: true } },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const DefaultStory: Story = {
+  name: "Default",
+  render: (args) => <Input {...args} />,
+  args: {
+    placeholder: "Enter text...",
+  },
+};
+
+export const DisabledStory: Story = {
+  name: "Disabled",
+  render: (args) => <Input {...args} />,
+  args: {
+    placeholder: "Disabled input",
+    disabled: true,
+    value: "Cannot edit this",
+  },
+};
+
+export const RequiredStory: Story = {
+  name: "Required",
+  render: (args) => <Input {...args} />,
+  args: {
+    placeholder: "Required field",
+    required: true,
+  },
+};
+
+export const InvalidStory: Story = {
+  name: "Invalid",
+  render: (args) => <Input {...args} />,
+  args: {
+    placeholder: "Invalid input",
+    "aria-invalid": true,
+    value: "Invalid value",
+  },
+};

--- a/apps/slash-stories/src/Form/Experimental/InputContainer.mdx
+++ b/apps/slash-stories/src/Form/Experimental/InputContainer.mdx
@@ -1,0 +1,93 @@
+import {
+  Canvas,
+  Controls,
+  Description,
+  Meta,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
+import * as Stories from "./InputContainer.stories";
+
+<Meta of={Stories} title="Form/Experimental/InputContainer" />
+
+<Title />
+
+## ⚠️ Experimental Component
+
+This component is **experimental** and may change in future releases. You can however use it in your projects, but be aware that the API might change.
+We welcome your feedback and contributions to improve this component.
+
+## Overview
+
+The `InputContainer` component is a layout component that manages the positioning of form elements using CSS Grid. It coordinates the display of labels, inputs, units, and messages in either horizontal or vertical layouts.
+
+This component is essential for building consistent form layouts and is typically used to wrap `Label`, `Input`, `InputUnit`, and `ItemMessage` components together.
+
+## Playground
+
+<Primary />
+<Controls />
+
+## Usage
+
+The `InputContainer` component uses CSS Grid to arrange its children. It automatically positions elements based on their CSS class names (grid areas).
+
+```tsx
+import {
+  Input,
+  InputContainer,
+  InputUnit,
+  Label,
+} from "@axa-fr/design-system-slash-react/experimental";
+
+const MyFormField = () => {
+  return (
+    <InputContainer>
+      <Label htmlFor="amount">Amount</Label>
+      <Input id="amount" type="number" />
+      <InputUnit>€</InputUnit>
+    </InputContainer>
+  );
+};
+```
+
+## Layout Options
+
+### Horizontal Layout (Default)
+
+By default, the container arranges elements horizontally with the label, input, and unit on the same row.
+
+<Canvas of={Stories.HorizontalStory} />
+
+### Vertical Layout
+
+Set the `vertical` prop to true to stack the label above the input.
+
+<Canvas of={Stories.VerticalStory} />
+
+### Without Unit
+
+The unit element is optional. You can omit it when not needed.
+
+<Canvas of={Stories.WithoutUnitStory} />
+
+## Grid Areas
+
+The container defines the following grid areas that child components automatically fill:
+
+- **label**: Filled by `Label` components
+- **input**: Filled by `Input` components
+- **unit**: Filled by `InputUnit` components
+- **helper-message**: Filled by `ItemMessage` components
+- **error-message**: Additional area for error messages
+
+Child components are positioned automatically based on their CSS class names. This makes the container flexible and easy to compose with different combinations of form elements.
+
+## Customization
+
+You can pass a custom `className` to override or extend the default styling:
+
+```tsx
+<InputContainer className="my-custom-container">{/* ... */}</InputContainer>
+```

--- a/apps/slash-stories/src/Form/Experimental/InputContainer.stories.tsx
+++ b/apps/slash-stories/src/Form/Experimental/InputContainer.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  Input,
+  InputContainer,
+  InputUnit,
+  Label,
+} from "@axa-fr/canopee-react/distributeur/experimental";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Experimental/Form/Atoms/InputContainer",
+  component: InputContainer,
+  argTypes: {
+    vertical: { control: "boolean" },
+  },
+} satisfies Meta<typeof InputContainer>;
+
+export default meta;
+type Story = StoryObj<typeof InputContainer>;
+
+export const HorizontalStory: Story = {
+  name: "Horizontal Layout",
+  render: (args) => (
+    <InputContainer {...args}>
+      <Label htmlFor="input-1">Label</Label>
+      <Input id="input-1" placeholder="Enter text" />
+      <InputUnit>€</InputUnit>
+    </InputContainer>
+  ),
+  args: {
+    vertical: false,
+  },
+};
+
+export const VerticalStory: Story = {
+  name: "Vertical Layout",
+  render: (args) => (
+    <InputContainer {...args}>
+      <Label htmlFor="input-2">Label</Label>
+      <Input id="input-2" placeholder="Enter text" />
+      <InputUnit>€</InputUnit>
+    </InputContainer>
+  ),
+  args: {
+    vertical: true,
+  },
+};
+
+export const WithoutUnitStory: Story = {
+  name: "Without Unit",
+  render: (args) => (
+    <InputContainer {...args}>
+      <Label htmlFor="input-3">Label</Label>
+      <Input id="input-3" placeholder="Enter text" />
+    </InputContainer>
+  ),
+  args: {
+    vertical: false,
+  },
+};

--- a/apps/slash-stories/src/Form/Experimental/InputUnit.mdx
+++ b/apps/slash-stories/src/Form/Experimental/InputUnit.mdx
@@ -1,0 +1,84 @@
+import {
+  Canvas,
+  Controls,
+  Description,
+  Meta,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
+import * as Stories from "./InputUnit.stories";
+
+<Meta of={Stories} title="Form/Experimental/InputUnit" />
+
+<Title />
+
+## ⚠️ Experimental Component
+
+This component is **experimental** and may change in future releases. You can however use it in your projects, but be aware that the API might change.
+We welcome your feedback and contributions to improve this component.
+
+## Overview
+
+The `InputUnit` component displays a unit of measurement or suffix next to an input field. It's commonly used to show currency symbols, percentages, or other measurement units.
+
+This component is designed to be used within an `InputContainer` and automatically positions itself in the designated grid area.
+
+## Playground
+
+<Primary />
+<Controls />
+
+## Usage
+
+The `InputUnit` component accepts any React children, typically a string representing the unit.
+
+```tsx
+import {
+  Input,
+  InputContainer,
+  InputUnit,
+  Label,
+} from "@axa-fr/design-system-slash-react/experimental";
+
+const PriceField = () => {
+  return (
+    <InputContainer>
+      <Label htmlFor="price">Price</Label>
+      <Input id="price" type="number" />
+      <InputUnit>€</InputUnit>
+    </InputContainer>
+  );
+};
+```
+
+## Examples
+
+### Currency Symbol
+
+The most common use case is displaying currency symbols.
+
+<Canvas of={Stories.DefaultStory} />
+
+### Percentage
+
+Display percentage symbols for rate inputs.
+
+<Canvas of={Stories.PercentageStory} />
+
+### Text Unit
+
+You can also use longer text descriptions as units.
+
+<Canvas of={Stories.TextUnitStory} />
+
+## Best Practices
+
+- Keep unit text concise and clear
+- Use standard symbols when available (€, $, %, etc.)
+- Consider internationalization when displaying units
+- Use semantic HTML for complex units if needed
+
+## Accessibility
+
+The unit is displayed as a `<span>` element and is read by screen readers as part of the form field context. Ensure that the input label clearly indicates what the unit represents for better accessibility.

--- a/apps/slash-stories/src/Form/Experimental/InputUnit.stories.tsx
+++ b/apps/slash-stories/src/Form/Experimental/InputUnit.stories.tsx
@@ -1,0 +1,43 @@
+import { InputUnit } from "@axa-fr/canopee-react/distributeur/experimental";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Experimental/Form/Atoms/InputUnit",
+  component: InputUnit,
+  argTypes: {
+    children: { control: "text" },
+  },
+} satisfies Meta<typeof InputUnit>;
+
+export default meta;
+type Story = StoryObj<typeof InputUnit>;
+
+export const DefaultStory: Story = {
+  name: "Default",
+  render: ({ children, ...args }) => (
+    <InputUnit {...args}>{children}</InputUnit>
+  ),
+  args: {
+    children: "€",
+  },
+};
+
+export const PercentageStory: Story = {
+  name: "Percentage",
+  render: ({ children, ...args }) => (
+    <InputUnit {...args}>{children}</InputUnit>
+  ),
+  args: {
+    children: "%",
+  },
+};
+
+export const TextUnitStory: Story = {
+  name: "Text Unit",
+  render: ({ children, ...args }) => (
+    <InputUnit {...args}>{children}</InputUnit>
+  ),
+  args: {
+    children: "per month",
+  },
+};

--- a/apps/slash-stories/src/Form/Experimental/ItemMessage.mdx
+++ b/apps/slash-stories/src/Form/Experimental/ItemMessage.mdx
@@ -1,0 +1,116 @@
+import {
+  Canvas,
+  Controls,
+  Description,
+  Meta,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
+import * as Stories from "./ItemMessage.stories";
+
+<Meta of={Stories} title="Form/Experimental/ItemMessage" />
+
+<Title />
+
+## ⚠️ Experimental Component
+
+This component is **experimental** and may change in future releases. You can however use it in your projects, but be aware that the API might change.
+We welcome your feedback and contributions to improve this component.
+
+## Overview
+
+The `ItemMessage` component displays contextual messages for form fields, such as help text, validation errors, or success confirmations. It supports three variants: a neutral help message (default), an error message with an error icon, and a success message with a success icon.
+
+## Playground
+
+<Primary />
+<Controls />
+
+## Usage
+
+### Basic Help Message
+
+Use the `ItemMessage` component without a variant to display neutral help text:
+
+<Canvas of={Stories.ItemMessageHelpStory} />
+
+### Error Message
+
+Set `variant="error"` to display an error message with an error icon:
+
+<Canvas of={Stories.ItemMessageErrorStory} />
+
+### Success Message
+
+Set `variant="success"` to display a success message with a success icon:
+
+<Canvas of={Stories.ItemMessageSuccessStory} />
+
+### With Form Fields
+
+The `ItemMessage` component is typically used within an `InputContainer` alongside form fields. Use the `id` prop to link the message to the input via `aria-describedby`:
+
+```tsx
+import {
+  Input,
+  InputContainer,
+  ItemMessage,
+  Label,
+} from "@axa-fr/canopee-react/distributeur/experimental";
+
+const MyFormField = () => {
+  const [error, setError] = useState("");
+
+  return (
+    <InputContainer>
+      <Label htmlFor="email">Email</Label>
+      <Input id="email" type="email" aria-describedby="email-message" />
+      <ItemMessage id="email-message" variant="error">
+        {error}
+      </ItemMessage>
+    </InputContainer>
+  );
+};
+```
+
+## Features
+
+- **Three Variants**: Neutral help text, error messages, and success messages
+- **Automatic Icons**: Error and success variants automatically display appropriate icons
+- **Flexible Content**: Accepts any React node as children
+- **Customizable**: Supports custom class names for additional styling
+- **Accessible**: Can be linked to form controls via the `id` prop for screen reader support
+
+## Accessibility
+
+- Use the `id` prop to create a unique identifier for the message
+- Link the message to form controls using `aria-describedby` on the input element
+- Error messages should be announced to screen readers when validation fails
+- Keep messages concise and clear to benefit all users
+- Ensure sufficient color contrast for different message variants
+
+## Best Practices
+
+- **Use variants appropriately**: Reserve error messages for validation failures, success messages for confirmations, and help messages for guidance
+- **Keep messages concise**: Short, clear messages are easier to understand
+- **Link to inputs**: Always use the `id` prop and `aria-describedby` to associate messages with their corresponding form fields
+- **Dynamic messages**: Update messages in response to user interaction (e.g., show error after blur or submit)
+- **Consistent placement**: Place messages below their associated form fields for predictable user experience
+
+## Customization
+
+You can customize the component's appearance using the `className` prop:
+
+```tsx
+<ItemMessage className="my-custom-class" variant="error">
+  Custom styled error message
+</ItemMessage>
+```
+
+The component uses the following CSS classes:
+
+- `af-item-message`: Base class for all variants
+- `af-item-message--error`: Applied when variant is "error"
+- `af-item-message--success`: Applied when variant is "success"
+- `af-item-message__icon`: Applied to the icon element

--- a/apps/slash-stories/src/Form/Experimental/ItemMessage.stories.tsx
+++ b/apps/slash-stories/src/Form/Experimental/ItemMessage.stories.tsx
@@ -1,0 +1,52 @@
+import { ItemMessage } from "@axa-fr/canopee-react/distributeur/experimental";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Experimental/Form/Atoms/ItemMessage",
+  component: ItemMessage,
+  argTypes: {
+    children: { control: "text" },
+    variant: {
+      control: { type: "inline-radio" },
+      options: [undefined, "error", "success"],
+    },
+  },
+} satisfies Meta<typeof ItemMessage>;
+
+export default meta;
+type Story = StoryObj<typeof ItemMessage>;
+
+export const ItemMessageHelpStory: Story = {
+  name: "Help Message",
+  render: ({ children, ...args }) => (
+    <ItemMessage {...args}>{children}</ItemMessage>
+  ),
+  args: {
+    children: "Help message",
+  },
+  argTypes: {},
+};
+
+export const ItemMessageErrorStory: Story = {
+  name: "Error Message",
+  render: ({ children, ...args }) => (
+    <ItemMessage {...args}>{children}</ItemMessage>
+  ),
+  args: {
+    variant: "error",
+    children: "Error message",
+  },
+  argTypes: {},
+};
+
+export const ItemMessageSuccessStory: Story = {
+  name: "Success Message",
+  render: ({ children, ...args }) => (
+    <ItemMessage {...args}>{children}</ItemMessage>
+  ),
+  args: {
+    variant: "success",
+    children: "Success message",
+  },
+  argTypes: {},
+};

--- a/apps/slash-stories/src/Form/Experimental/Label.mdx
+++ b/apps/slash-stories/src/Form/Experimental/Label.mdx
@@ -1,0 +1,93 @@
+import {
+  Canvas,
+  Controls,
+  Description,
+  Meta,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
+import * as Stories from "./Label.stories";
+
+<Meta of={Stories} title="Form/Experimental/Label" />
+
+<Title />
+
+## ⚠️ Experimental Component
+
+This component is **experimental** and may change in future releases. You can however use it in your projects, but be aware that the API might change.
+We welcome your feedback and contributions to improve this component.
+
+## Overview
+
+The `Label` component provides a styled form label with optional required field indicator. It extends the native HTML `<label>` element with consistent styling and accessibility features.
+
+This component is designed to be used within an `InputContainer` and automatically positions itself in the designated grid area.
+
+## Playground
+
+<Primary />
+<Controls />
+
+## Usage
+
+The `Label` component accepts all standard label attributes and automatically links to form controls via the `htmlFor` prop.
+
+```tsx
+import {
+  Input,
+  InputContainer,
+  Label,
+} from "@axa-fr/design-system-slash-react/experimental";
+
+const MyFormField = () => {
+  return (
+    <InputContainer>
+      <Label htmlFor="username">Username</Label>
+      <Input id="username" type="text" />
+    </InputContainer>
+  );
+};
+```
+
+## Features
+
+### Required Field Indicator
+
+Set the `required` prop to display an asterisk (\*) after the label text, indicating that the field is required.
+
+<Canvas of={Stories.RequiredStory} />
+
+**Note:** The required indicator is purely presentational. It does not enforce validation. You must still set the `required` attribute on the input element for validation.
+
+```tsx
+<Label htmlFor="email" required>
+  Email
+</Label>
+<Input id="email" type="email" required />
+```
+
+## Accessibility
+
+- Always use the `htmlFor` prop to associate the label with its input field
+- The `htmlFor` value should match the `id` of the corresponding input
+- Screen readers will announce the label text when the input receives focus
+- The required asterisk is marked with `aria-hidden` to avoid redundant announcements
+
+## Best Practices
+
+- Keep label text clear and concise
+- Use sentence case for label text (capitalize only the first word)
+- Place labels consistently (all above or all beside inputs)
+- For required fields, use both the visual indicator and the `required` attribute on the input
+- Consider providing help text for complex or ambiguous labels
+
+## Customization
+
+The component accepts all standard label props, including `className` for custom styling:
+
+```tsx
+<Label htmlFor="field" className="my-custom-label">
+  Custom Label
+</Label>
+```

--- a/apps/slash-stories/src/Form/Experimental/Label.stories.tsx
+++ b/apps/slash-stories/src/Form/Experimental/Label.stories.tsx
@@ -1,0 +1,33 @@
+import { Label } from "@axa-fr/canopee-react/distributeur/experimental";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Experimental/Form/Atoms/Label",
+  component: Label,
+  argTypes: {
+    children: { control: "text" },
+    required: { control: "boolean" },
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const DefaultStory: Story = {
+  name: "Default",
+  render: ({ children, ...args }) => <Label {...args}>{children}</Label>,
+  args: {
+    children: "Label text",
+    htmlFor: "input-id",
+  },
+};
+
+export const RequiredStory: Story = {
+  name: "Required",
+  render: ({ children, ...args }) => <Label {...args}>{children}</Label>,
+  args: {
+    children: "Required field",
+    htmlFor: "input-id",
+    required: true,
+  },
+};

--- a/apps/slash-stories/src/Form/Experimental/TextInput.mdx
+++ b/apps/slash-stories/src/Form/Experimental/TextInput.mdx
@@ -1,0 +1,79 @@
+import { Message } from "@axa-fr/design-system-slash-react";
+import {
+  Canvas,
+  Controls,
+  Description,
+  Meta,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
+import * as Stories from "./TextInput.stories";
+
+<Meta of={Stories} title="Form/Experimental/TextInput" />
+
+<Title />
+
+## ⚠️ Experimental Component
+
+This component is **experimental** and may change in future releases. You can however use it in your projects, but be aware that the API might change.
+We welcome your feedback and contributions to improve this component.
+
+## Playground
+
+<Primary />
+<Controls />
+
+## Usage with form libraries
+
+This component can be used with form libraries like [react-hook-form](https://react-hook-form.com/) or [Formik](https://formik.org/). It supports controlled and uncontrolled usage patterns.
+
+You can pass a ref to the component to access the underlying input element, which is useful for form libraries that require direct access to the input.
+
+```tsx
+import { TextInput } from "@axa-fr/canopee-react/distributeur/experimental";
+import { useForm } from "react-hook-form";
+const MyForm = () => {
+  const { register, handleSubmit } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <TextInput label="My Input" {...register("myInput")} />
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+```
+
+## Customization examples
+
+### Disabled Input
+
+Set the `disabled` prop to true to disable the input field.
+
+<Canvas of={Stories.Disabled} />
+
+### Rich Label
+
+If you need to display a label with HTML content, you can pass a ReactNode in the `label` prop.
+
+<Canvas of={Stories.RichLabel} />
+
+### Error Message
+
+If you want to display an error message, you can use the `error` prop.
+This will render the error message below the input field, and apply the appropriate styles to indicate an error state. The input will also be marked as `aria-invalid`.
+
+<Canvas of={Stories.ErrorStory} />
+
+### With Unit
+
+If you want to display a unit next to the input field, you can use the `rightContent` prop. It can be a string or a ReactNode. This is useful for inputs that require a unit of measurement, like currency or percentage.
+
+It can technically be used to display any content on the right side of the input, such as an icon or a button, however, it is primarily intended for units.
+
+<Canvas of={Stories.WithUnit} />

--- a/apps/slash-stories/src/Form/Experimental/TextInput.stories.tsx
+++ b/apps/slash-stories/src/Form/Experimental/TextInput.stories.tsx
@@ -1,0 +1,180 @@
+import {
+  SingleLineLabelPosition,
+  TextInput,
+} from "@axa-fr/canopee-react/distributeur/experimental";
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+
+const meta: Meta<typeof TextInput> = {
+  component: TextInput,
+  title: "Experimental/Form/TextInput",
+  argTypes: {
+    onChange: {
+      action: "onChange",
+      table: {
+        disable: true,
+      },
+    },
+    label: {
+      table: {
+        category: "Visual Content",
+      },
+    },
+    helpMessage: {
+      table: {
+        category: "Visual Content",
+      },
+      control: {
+        type: "text",
+      },
+    },
+    errorMessage: {
+      table: {
+        category: "Visual Content",
+      },
+    },
+    placeholder: {
+      table: {
+        category: "Visual Content",
+      },
+    },
+    labelPosition: {
+      table: {
+        category: "Visual Content",
+        // type: {
+        //   summary: '"centerLeft" | "above"',
+        // },
+      },
+      control: {
+        type: "select",
+        options: ["centerLeft", "above", undefined] satisfies (
+          | SingleLineLabelPosition
+          | undefined
+        )[],
+      },
+    },
+    contentRight: {
+      table: {
+        category: "Visual Content",
+      },
+      control: {
+        type: "text",
+      },
+    },
+    required: {
+      table: {
+        category: "Field state",
+      },
+    },
+    disabled: {
+      table: {
+        category: "Field state",
+      },
+    },
+    value: {
+      table: {
+        category: "Field state",
+      },
+    },
+    id: {
+      table: {
+        category: "Technical Details",
+      },
+    },
+    name: {
+      table: {
+        category: "Technical Details",
+      },
+    },
+    inputClassName: {
+      table: {
+        category: "Technical Details",
+      },
+      control: {
+        type: "text",
+      },
+    },
+    labelClassName: {
+      table: {
+        category: "Technical Details",
+      },
+      control: {
+        type: "text",
+      },
+    },
+    containerClassName: {
+      table: {
+        category: "Technical Details",
+      },
+      control: {
+        type: "text",
+      },
+    },
+  },
+  args: {
+    label: "What is your name?",
+    helpMessage: "This is your government name",
+    labelPosition: "centerLeft",
+    errorMessage: "",
+    placeholder: "Your name",
+    required: true,
+    disabled: false,
+    value: "John Doe",
+    id: "nameid",
+    name: "myTextInput",
+    onChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextInput>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Vertical: Story = {
+  args: {
+    disabled: true,
+    labelPosition: "above",
+  },
+};
+
+export const ErrorStory: Story = {
+  args: {
+    required: true,
+    errorMessage: "This field is required",
+    helpMessage: "",
+    value: "",
+    name: "errorInput",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: "Disabled input",
+    name: "disabledInput",
+  },
+};
+
+export const WithUnit: Story = {
+  args: {
+    label: "Price",
+    placeholder: "Enter amount",
+    contentRight: "€",
+    name: "unitInput",
+  },
+};
+
+export const RichLabel: Story = {
+  args: {
+    label: (
+      <span>
+        Place name <em>optional</em>
+      </span>
+    ),
+    name: "richLabelInput",
+  },
+};

--- a/packages/canopee-css/src/distributeur/Form/Experimental/Input.css
+++ b/packages/canopee-css/src/distributeur/Form/Experimental/Input.css
@@ -1,0 +1,43 @@
+.af-input__input {
+  --input-color: var(--text-color);
+  --input-border-color: var(--input-border-color);
+  --input-background-color: var(--white);
+
+  padding: 0 0 0 1rem;
+  border: 1px solid var(--input-border-color);
+  font-size: 1rem;
+  line-height: 2.5rem;
+  color: var(--input-color);
+  background-color: var(--input-background-color);
+  outline: 1px solid transparent;
+}
+
+.af-input__input[aria-invalid="true"] {
+  --input-color: var(--error-color);
+  --input-border-color: var(--error-color);
+  --input-background-color: var(--white);
+}
+
+.af-input__input:disabled {
+  --input-color: var(--disabled-color);
+  --input-border-color: var(--disabled-color);
+  --input-background-color: var(--gray10);
+
+  cursor: not-allowed;
+}
+
+.af-input__input:hover:not(:disabled),
+.af-input__input:active:not(:disabled) {
+  --input-border-color: var(--color-border-selected);
+  --input-color: var(--active-button-border-color);
+
+  box-shadow: 0 0 0 1px var(--input-border-color);
+}
+
+.af-input__input:focus:not(:disabled) {
+  outline: 2px solid var(--color-border-selected);
+  outline-offset: 2px;
+
+  --input-border-color: var(--input-border-color);
+  --input-color: var(--active-button-border-color);
+}

--- a/packages/canopee-css/src/distributeur/Form/Experimental/InputContainer.css
+++ b/packages/canopee-css/src/distributeur/Form/Experimental/InputContainer.css
@@ -1,0 +1,45 @@
+.af-input__container {
+  --label-margin-bottom: 0;
+
+  display: grid;
+  width: fit-content;
+  margin-bottom: 3rem;
+  grid-template-areas:
+    "label input unit"
+    ". helper-message helper-message"
+    ". error-message error-message";
+  grid-template-columns: 17rem auto auto;
+  align-items: center;
+  column-gap: 0.5rem;
+
+  .af-label {
+    grid-area: label;
+  }
+
+  .af-input__input {
+    grid-area: input;
+  }
+
+  .af-input__unit {
+    grid-area: unit;
+  }
+
+  .af-item-message {
+    grid-area: helper-message;
+  }
+
+  .af-item-message--error {
+    grid-area: error-message;
+  }
+}
+
+.af-input__container--vertical {
+  --label-margin-bottom: 8px;
+
+  grid-template-areas:
+    "label label"
+    "input unit"
+    "helper-message helper-message"
+    "error-message error-message";
+  grid-template-columns: 1fr auto;
+}

--- a/packages/canopee-css/src/distributeur/Form/Experimental/InputUnit.css
+++ b/packages/canopee-css/src/distributeur/Form/Experimental/InputUnit.css
@@ -1,0 +1,5 @@
+.af-input__unit {
+  font-size: calc(14rem / 16);
+  line-height: 1rem;
+  color: var(--text-color);
+}

--- a/packages/canopee-css/src/distributeur/Form/Experimental/ItemMessage.css
+++ b/packages/canopee-css/src/distributeur/Form/Experimental/ItemMessage.css
@@ -1,0 +1,26 @@
+.af-item-message {
+  --color: var(--help-color);
+
+  display: flex;
+  margin-top: 8px;
+  align-items: center;
+  gap: 4px;
+  font-size: calc(13rem / 16);
+  line-height: 16px;
+  color: var(--color);
+
+  .af-item-message__icon {
+    width: 1rem;
+    height: 1rem;
+    vertical-align: baseline;
+    fill: var(--color);
+  }
+}
+
+.af-item-message--error {
+  --color: var(--error-color);
+}
+
+.af-item-message--success {
+  --color: var(--valid-element-color);
+}

--- a/packages/canopee-css/src/distributeur/Form/Experimental/Label.css
+++ b/packages/canopee-css/src/distributeur/Form/Experimental/Label.css
@@ -1,0 +1,10 @@
+.af-label {
+  margin-bottom: var(--label-margin-bottom, 0);
+  font-size: 1rem;
+  line-height: 20px;
+}
+
+.af-label__required {
+  padding-left: calc(4rem / 16);
+  color: var(--error-color);
+}

--- a/packages/canopee-react/package.json
+++ b/packages/canopee-react/package.json
@@ -7,6 +7,10 @@
       "import": "./dist/distributeur.js",
       "types": "./dist/distributeur.d.ts"
     },
+    "./distributeur/experimental": {
+      "import": "./dist/distributeur-experimental.js",
+      "types": "./dist/distributeur-experimental.d.ts"
+    },
     "./client": {
       "import": "./dist/client.js",
       "types": "./dist/client.d.ts"

--- a/packages/canopee-react/src/distributeur-experimental.ts
+++ b/packages/canopee-react/src/distributeur-experimental.ts
@@ -1,0 +1,1 @@
+export * from "./distributeur/Form/Experimental";

--- a/packages/canopee-react/src/distributeur/Form/Experimental/Input.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/Input.tsx
@@ -1,0 +1,20 @@
+import "@axa-fr/canopee-css/distributeur/Form/Experimental/Input.css";
+import { type ComponentPropsWithRef, forwardRef } from "react";
+import { getClassName } from "../../utilities/helpers/getClassName";
+
+const Input = forwardRef<HTMLInputElement, ComponentPropsWithRef<"input">>(
+  ({ className, ...otherProps }, inputRef) => {
+    const componentClassName = getClassName({
+      baseClassName: "af-input__input",
+      className,
+    });
+
+    return (
+      <input className={componentClassName} ref={inputRef} {...otherProps} />
+    );
+  },
+);
+
+Input.displayName = "Input";
+
+export { Input };

--- a/packages/canopee-react/src/distributeur/Form/Experimental/InputContainer.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/InputContainer.tsx
@@ -1,0 +1,21 @@
+import "@axa-fr/canopee-css/distributeur/Form/Experimental/InputContainer.css";
+import classNames from "classnames";
+import type { PropsWithChildren } from "react";
+
+type InputContainerProps = PropsWithChildren<{
+  vertical?: boolean;
+  className?: string;
+}>;
+
+export const InputContainer = ({
+  children,
+  vertical,
+  className,
+}: InputContainerProps) => {
+  const containerClass = classNames(
+    "af-input__container",
+    { "af-input__container--vertical": vertical },
+    className,
+  );
+  return <div className={containerClass}>{children}</div>;
+};

--- a/packages/canopee-react/src/distributeur/Form/Experimental/InputUnit.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/InputUnit.tsx
@@ -1,0 +1,7 @@
+import "@axa-fr/canopee-css/distributeur/Form/Experimental/InputUnit.css";
+
+import type { PropsWithChildren } from "react";
+
+export const InputUnit = ({ children }: PropsWithChildren) => (
+  <span className="af-input__unit">{children}</span>
+);

--- a/packages/canopee-react/src/distributeur/Form/Experimental/ItemMessage.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/ItemMessage.tsx
@@ -1,0 +1,54 @@
+import "@axa-fr/canopee-css/distributeur/Form/Experimental/ItemMessage.css";
+import success from "@material-symbols/svg-400/outlined/check_circle-fill.svg";
+import error from "@material-symbols/svg-400/outlined/error-fill.svg";
+
+import type { ReactNode } from "react";
+import { Svg } from "../../Svg";
+import { getClassName } from "../../utilities/helpers/getClassName";
+
+type Props = {
+  children: ReactNode;
+  /**
+   * The variant of the message.
+   * - "error": displays an error message with an error icon.
+   * - "success": displays a success message with a success icon.
+   * - undefined: displays an help message without any icon.
+   *
+   * @default undefined
+   */
+  variant?: "error" | "success";
+  /**
+   * Additional class name(s) to apply to the component.
+   */
+  className?: string;
+  /**
+   * The id attribute for the component.
+   *
+   * Useful for linking the message to other elements for accessibility.
+   * @default undefined
+   *
+   */
+  id?: string;
+};
+
+const iconByVariant = {
+  success,
+  error,
+};
+
+export const ItemMessage = ({ variant, children, className, id }: Props) => {
+  const componentClassName = getClassName({
+    baseClassName: "af-item-message",
+    className,
+    modifiers: [variant],
+  });
+
+  const icon = variant ? iconByVariant[variant] : null;
+
+  return (
+    <div className={componentClassName} id={id}>
+      {icon ? <Svg src={icon} className="af-item-message__icon" /> : null}
+      {children}
+    </div>
+  );
+};

--- a/packages/canopee-react/src/distributeur/Form/Experimental/Label.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/Label.tsx
@@ -1,0 +1,22 @@
+import "@axa-fr/canopee-css/distributeur/Form/Experimental/Label.css";
+import type { ComponentProps } from "react";
+
+type LabelProps = ComponentProps<"label"> & {
+  /**
+   * Whether the label is required or not.
+   * This will add a `*` after the label text.
+   * This is purely presentational and does not enforce any validation logic.
+   * @default false
+   */
+  required?: boolean;
+};
+export const Label = ({ children, required = false, ...props }: LabelProps) => (
+  <label className="af-label" {...props}>
+    {children}
+    {required ? (
+      <span className="af-label__required" aria-hidden>
+        *
+      </span>
+    ) : null}
+  </label>
+);

--- a/packages/canopee-react/src/distributeur/Form/Experimental/TextInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/TextInput.tsx
@@ -1,0 +1,85 @@
+import { type ComponentProps, forwardRef } from "react";
+import { Input } from "./Input";
+import { InputContainer } from "./InputContainer";
+import { InputUnit } from "./InputUnit";
+import { ItemMessage } from "./ItemMessage";
+import { Label } from "./Label";
+import type { InputBaseProps } from "./types";
+import { useInput } from "./useInput.hook";
+
+export type TextInputProps = Omit<ComponentProps<typeof Input>, "children"> &
+  InputBaseProps;
+
+/**
+ * This component renders a label, a text input field and optionnally help and  error messages.
+ * It can be customized to render the label on top, or on the left of the input.
+ * It also supports adding a unit on the right of the input.
+ */
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  (
+    {
+      contentRight,
+      id,
+      labelPosition,
+      inputClassName: inputClassNameProp,
+      labelClassName: labelClassNameProp,
+      helpMessage,
+      containerClassName,
+      required,
+      label,
+      errorMessage,
+      ...props
+    },
+    inputRef,
+  ) => {
+    const {
+      describedBy,
+      errorId,
+      helperId,
+      inputClassName,
+      inputId,
+      isContainerVertical,
+      isInvalid,
+      labelClassName,
+    } = useInput({
+      id,
+      labelPosition,
+      inputClassName: inputClassNameProp,
+      labelClassName: labelClassNameProp,
+      errorMessage,
+      helpMessage,
+    });
+
+    return (
+      <InputContainer
+        vertical={isContainerVertical}
+        className={containerClassName}
+      >
+        <Label htmlFor={inputId} required={required} className={labelClassName}>
+          {label}
+        </Label>
+        <Input
+          {...props}
+          className={inputClassName}
+          id={inputId}
+          ref={inputRef}
+          aria-describedby={describedBy}
+          aria-invalid={isInvalid}
+        />
+        {contentRight ? <InputUnit>{contentRight}</InputUnit> : null}
+        {helpMessage ? (
+          <ItemMessage id={helperId}>{helpMessage}</ItemMessage>
+        ) : null}
+        {errorMessage ? (
+          <ItemMessage variant="error" id={errorId}>
+            {errorMessage}
+          </ItemMessage>
+        ) : null}
+      </InputContainer>
+    );
+  },
+);
+
+TextInput.displayName = "TextInput";
+
+export { TextInput };

--- a/packages/canopee-react/src/distributeur/Form/Experimental/index.ts
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/index.ts
@@ -1,0 +1,13 @@
+export { Input } from "./Input";
+export { InputContainer } from "./InputContainer";
+export { InputUnit } from "./InputUnit";
+export { ItemMessage } from "./ItemMessage";
+export { Label } from "./Label";
+export { TextInput } from "./TextInput";
+export type { TextInputProps } from "./TextInput";
+export type {
+  InputBaseProps,
+  LabelPosition,
+  SingleLineLabelPosition,
+} from "./types";
+export { useInput } from "./useInput.hook";

--- a/packages/canopee-react/src/distributeur/Form/Experimental/types.ts
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/types.ts
@@ -1,0 +1,66 @@
+import { type ReactNode } from "react";
+
+export type InputBaseProps = {
+  /**
+   * The id of the input element.
+   * This is used to link the label to the input, and its descriptions (helper and error messages).
+   * If not provided, a unique id will be generated.
+   */
+  id?: string;
+
+  /**
+   * The label text for the input.
+   */
+  label: ReactNode;
+
+  /**
+   * Whether the input is required or not.
+   * This will add a `*` after the label text.
+   * This is purely presentational and does not enforce any validation logic.
+   * @default false
+   */
+  required?: boolean;
+
+  /**
+   * className for the container. Use this to apply styles to the input container.
+   */
+  containerClassName?: string;
+
+  /**
+   * className for the label. Use this to apply styles to the label.
+   */
+  labelClassName?: string;
+
+  /**
+   * className for the input. Use this to apply styles to the input.
+   */
+  inputClassName?: string;
+
+  /**
+   * The position of the label relative to the input.
+   * - `centerLeft` will place the label on the left of the input, centered vertically. This is the default position for most inputs.
+   * - `leftAbove` will place the label above the input, aligned to the left. This is used to have the label above the input.
+   * @default "centerLeft"
+   */
+  labelPosition?: SingleLineLabelPosition;
+
+  /**
+   * The help message to display below the input.
+   */
+  helpMessage?: string;
+
+  /**
+   * The error message to display below the input.
+   * This will also set the `aria-invalid` attribute on the input, and apply the error styles to the input.
+   */
+  errorMessage?: string;
+
+  /**
+   * The right element to display next to the input.
+   * This should be used to display a unit, but **if you really need to** an icon, or any other element that should be displayed next to the input.
+   */
+  contentRight?: ReactNode;
+};
+
+export type LabelPosition = "topLeft" | SingleLineLabelPosition;
+export type SingleLineLabelPosition = "centerLeft" | "above";

--- a/packages/canopee-react/src/distributeur/Form/Experimental/useInput.hook.ts
+++ b/packages/canopee-react/src/distributeur/Form/Experimental/useInput.hook.ts
@@ -1,0 +1,44 @@
+import { type ReactNode, useId } from "react";
+import { getClassName } from "../../utilities/helpers/getClassName";
+import { type LabelPosition } from "./types";
+
+type useInputProps = {
+  id?: string;
+  labelPosition?: LabelPosition;
+  inputClassName?: string;
+  labelClassName?: string;
+  errorMessage?: ReactNode;
+  helpMessage?: ReactNode;
+};
+
+export const useInput = (props: useInputProps) => {
+  const inputUseId = useId();
+  const inputId = props.id ?? inputUseId;
+
+  const isInvalid = Boolean(props.errorMessage);
+
+  const inputClassName = getClassName({
+    baseClassName: "af-input__input",
+    className: props.inputClassName,
+  });
+  const labelClassName = getClassName({
+    baseClassName: "af-label",
+    modifiers: [props.labelPosition === "above" && "top"],
+    className: props.labelClassName,
+  });
+
+  const errorId = isInvalid ? `${inputId}-description` : undefined;
+  const helperId = props.helpMessage ? `${inputId}-helper` : undefined;
+  const describedBy = [errorId, helperId].filter(Boolean).join(" ").trim();
+
+  return {
+    isInvalid,
+    isContainerVertical: props.labelPosition === "above",
+    inputClassName,
+    labelClassName,
+    describedBy,
+    errorId,
+    helperId,
+    inputId,
+  };
+};


### PR DESCRIPTION
…documentation

- Add Input, Label, InputContainer, InputUnit, and ItemMessage components
- Add corresponding CSS styles with grid-based layout system
- Create Storybook stories and MDX documentation for all components
- Export experimental components via distributeur/experimental entry point

This is intended to be an experiment to collect feedback on input usage.