### PR TITLE
feat(prospect,client): implementation de l'ItemMessage dans ContentItemDuo

### DIFF
--- a/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof ContentItemDuo> = {
   args: {
     label: "Label",
     value: "Value",
+    itemMessage: "Titre du message",
     buttonText: "Learn more",
   },
   argTypes: {
@@ -19,6 +20,15 @@ const meta: Meta<typeof ContentItemDuo> = {
         type: "select",
       },
     },
+    itemMessage: { control: "text" },
+    itemMessageType: {
+      options: ["error", "warning", "sucess"],
+      control: {
+        type: "select",
+      },
+    },
+    valueIsVisible: { control: "boolean" },
+    buttonIsVisible: { control: "boolean" },
     isVertical: { control: "boolean" },
     size: {
       options: ["small", "large"],

--- a/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/apollo-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof ContentItemDuo> = {
   args: {
     label: "Label",
     value: "Value",
-    itemMessage: "Titre du message",
+    message: "Titre du message",
     buttonText: "Learn more",
   },
   argTypes: {
@@ -20,15 +20,13 @@ const meta: Meta<typeof ContentItemDuo> = {
         type: "select",
       },
     },
-    itemMessage: { control: "text" },
-    itemMessageType: {
-      options: ["error", "warning", "sucess"],
+    message: { control: "text" },
+    messageType: {
+      options: ["error", "warning", "success"],
       control: {
         type: "select",
       },
     },
-    valueIsVisible: { control: "boolean" },
-    buttonIsVisible: { control: "boolean" },
     isVertical: { control: "boolean" },
     size: {
       options: ["small", "large"],

--- a/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof ContentItemDuo> = {
   args: {
     label: "Label",
     value: "Value",
+    itemMessage: "Titre du message",
     buttonText: "Learn more",
   },
   argTypes: {
@@ -19,6 +20,15 @@ const meta: Meta<typeof ContentItemDuo> = {
         type: "select",
       },
     },
+    itemMessage: { control: "text" },
+    itemMessageType: {
+      options: ["error", "warning", "sucess"],
+      control: {
+        type: "select",
+      },
+    },
+    valueIsVisible: { control: "boolean" },
+    buttonIsVisible: { control: "boolean" },
     isVertical: { control: "boolean" },
     size: {
       options: ["small", "large"],

--- a/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/ContentItemDuo/ContentItemDuo.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof ContentItemDuo> = {
   args: {
     label: "Label",
     value: "Value",
-    itemMessage: "Titre du message",
+    message: "Titre du message",
     buttonText: "Learn more",
   },
   argTypes: {
@@ -20,15 +20,13 @@ const meta: Meta<typeof ContentItemDuo> = {
         type: "select",
       },
     },
-    itemMessage: { control: "text" },
-    itemMessageType: {
-      options: ["error", "warning", "sucess"],
+    message: { control: "text" },
+    messageType: {
+      options: ["error", "warning", "success"],
       control: {
         type: "select",
       },
     },
-    valueIsVisible: { control: "boolean" },
-    buttonIsVisible: { control: "boolean" },
     isVertical: { control: "boolean" },
     size: {
       options: ["small", "large"],

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoApollo.tsx
@@ -4,7 +4,12 @@ import {
   ContentItemDuoCommon,
   type ContentItemDuoProps,
 } from "./ContentItemDuoCommon";
+import { ItemMessage } from "../../../client";
 
 export const ContentItemDuo = (props: ContentItemDuoProps) => (
-  <ContentItemDuoCommon {...props} ButtonComponent={Button} />
+  <ContentItemDuoCommon
+    {...props}
+    ButtonComponent={Button}
+    ItemMessageComponent={ItemMessage}
+  />
 );

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -25,13 +25,13 @@ export type ContentItemDuoProps = {
   isVertical?: boolean;
   /** @deprecated Use `size` or `className` instead */
   classModifier?: string;
-  message?: ReactNode;
-  messageType?: ItemMessageProps["messageType"];
-} & ContentItemDuoPositions &
+} & Pick<ItemMessageProps, "message" | "messageType"> &
+  ContentItemDuoPositions &
   ComponentProps<"div">;
 
 type ContentItemDuoCommonProps = ContentItemDuoProps & {
   ButtonComponent: ComponentType<ButtonProps>;
+  ItemMessageComponent: ComponentType<ComponentProps<typeof ItemMessage>>;
 };
 
 export const ContentItemDuoCommon = ({
@@ -46,7 +46,8 @@ export const ContentItemDuoCommon = ({
   onButtonClick,
   ButtonComponent,
   message,
-  messageType = "warning",
+  messageType,
+  ItemMessageComponent,
   ...containerProps
 }: ContentItemDuoCommonProps) => {
   const componentClassName = getClassName({
@@ -65,7 +66,7 @@ export const ContentItemDuoCommon = ({
       <dd className="af-content-item-duo__value">
         {value}
         {message ? (
-          <ItemMessage message={message} messageType={messageType} />
+          <ItemMessageComponent message={message} messageType={messageType} />
         ) : null}
       </dd>
       {buttonText && onButtonClick ? (

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -25,7 +25,7 @@ export type ContentItemDuoProps = {
   isVertical?: boolean;
   /** @deprecated Use `size` or `className` instead */
   classModifier?: string;
-  message?: string;
+  message?: ReactNode;
   messageType?: ItemMessageProps["messageType"];
 } & ContentItemDuoPositions &
   ComponentProps<"div">;

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -1,8 +1,10 @@
 import { type ComponentProps, type ComponentType, type ReactNode } from "react";
 import type { ButtonProps } from "../../Button/ButtonCommon";
 import { getClassName } from "../../utilities/getClassName";
-import { ItemMessage } from "../../Form/ItemMessage/ItemMessageCommon";
-import type { ItemMessageVariants } from "../../Form/ItemMessage/ItemMessageCommon";
+import {
+  ItemMessage,
+  type ItemMessageProps,
+} from "../../Form/ItemMessage/ItemMessageCommon";
 
 type ContentItemDuoPositions =
   | {
@@ -23,10 +25,8 @@ export type ContentItemDuoProps = {
   isVertical?: boolean;
   /** @deprecated Use `size` or `className` instead */
   classModifier?: string;
-  itemMessage?: string;
-  itemMessageType?: ItemMessageVariants;
-  valueIsVisible?: boolean;
-  buttonIsVisible?: boolean;
+  message?: string;
+  messageType?: ItemMessageProps["messageType"];
 } & ContentItemDuoPositions &
   ComponentProps<"div">;
 
@@ -45,10 +45,8 @@ export const ContentItemDuoCommon = ({
   buttonText,
   onButtonClick,
   ButtonComponent,
-  itemMessage,
-  itemMessageType,
-  valueIsVisible = true,
-  buttonIsVisible = true,
+  message,
+  messageType = "warning",
   ...containerProps
 }: ContentItemDuoCommonProps) => {
   const componentClassName = getClassName({
@@ -65,12 +63,12 @@ export const ContentItemDuoCommon = ({
     <div className={componentClassName} {...containerProps}>
       <dt className="af-content-item-duo__label">{label}</dt>
       <dd className="af-content-item-duo__value">
-        {valueIsVisible ? value : null}
-        {itemMessage ? (
-          <ItemMessage message={itemMessage} messageType={itemMessageType} />
+        {value}
+        {message ? (
+          <ItemMessage message={message} messageType={messageType} />
         ) : null}
       </dd>
-      {buttonIsVisible && Boolean(buttonText && onButtonClick) ? (
+      {buttonText && onButtonClick ? (
         <ButtonComponent
           className="af-content-item-duo__button"
           variant="ghost"

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoCommon.tsx
@@ -1,6 +1,8 @@
 import { type ComponentProps, type ComponentType, type ReactNode } from "react";
 import type { ButtonProps } from "../../Button/ButtonCommon";
 import { getClassName } from "../../utilities/getClassName";
+import { ItemMessage } from "../../Form/ItemMessage/ItemMessageCommon";
+import type { ItemMessageVariants } from "../../Form/ItemMessage/ItemMessageCommon";
 
 type ContentItemDuoPositions =
   | {
@@ -21,6 +23,10 @@ export type ContentItemDuoProps = {
   isVertical?: boolean;
   /** @deprecated Use `size` or `className` instead */
   classModifier?: string;
+  itemMessage?: string;
+  itemMessageType?: ItemMessageVariants;
+  valueIsVisible?: boolean;
+  buttonIsVisible?: boolean;
 } & ContentItemDuoPositions &
   ComponentProps<"div">;
 
@@ -39,6 +45,10 @@ export const ContentItemDuoCommon = ({
   buttonText,
   onButtonClick,
   ButtonComponent,
+  itemMessage,
+  itemMessageType,
+  valueIsVisible = true,
+  buttonIsVisible = true,
   ...containerProps
 }: ContentItemDuoCommonProps) => {
   const componentClassName = getClassName({
@@ -54,8 +64,13 @@ export const ContentItemDuoCommon = ({
   return (
     <div className={componentClassName} {...containerProps}>
       <dt className="af-content-item-duo__label">{label}</dt>
-      <dd className="af-content-item-duo__value">{value}</dd>
-      {Boolean(buttonText && onButtonClick) && (
+      <dd className="af-content-item-duo__value">
+        {valueIsVisible ? value : null}
+        {itemMessage ? (
+          <ItemMessage message={itemMessage} messageType={itemMessageType} />
+        ) : null}
+      </dd>
+      {buttonIsVisible && Boolean(buttonText && onButtonClick) ? (
         <ButtonComponent
           className="af-content-item-duo__button"
           variant="ghost"
@@ -63,7 +78,7 @@ export const ContentItemDuoCommon = ({
         >
           {buttonText}
         </ButtonComponent>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoLF.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/ContentItemDuoLF.tsx
@@ -4,7 +4,12 @@ import {
   ContentItemDuoCommon,
   type ContentItemDuoProps,
 } from "./ContentItemDuoCommon";
+import { ItemMessage } from "../../../client";
 
 export const ContentItemDuo = (props: ContentItemDuoProps) => (
-  <ContentItemDuoCommon {...props} ButtonComponent={Button} />
+  <ContentItemDuoCommon
+    {...props}
+    ButtonComponent={Button}
+    ItemMessageComponent={ItemMessage}
+  />
 );

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -8,6 +8,7 @@ import {
   ContentItemDuoCommon,
   type ContentItemDuoProps,
 } from "../ContentItemDuoCommon";
+import { ItemMessage } from "../../../../client";
 
 const ButtonComponent = (props: ButtonProps) => (
   <ButtonCommon SpinnerComponent={Spinner} {...props} />
@@ -21,6 +22,7 @@ const renderContentItemDuo = (props: Partial<ContentItemDuoProps> = {}) =>
       message="Titre du message"
       {...props}
       ButtonComponent={ButtonComponent}
+      ItemMessageComponent={ItemMessage}
     />,
   );
 
@@ -141,6 +143,7 @@ describe("ContentItemDuoCommon", () => {
           label="Label"
           value="Value"
           ButtonComponent={ButtonComponent}
+          ItemMessageComponent={ItemMessage}
         />
         <ContentItemDuoCommon
           label="Label with button"
@@ -148,6 +151,7 @@ describe("ContentItemDuoCommon", () => {
           buttonText="Action"
           onButtonClick={() => {}}
           ButtonComponent={ButtonComponent}
+          ItemMessageComponent={ItemMessage}
         />
       </dl>,
     );

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -18,7 +18,7 @@ const renderContentItemDuo = (props: Partial<ContentItemDuoProps> = {}) =>
     <ContentItemDuoCommon
       label="Label"
       value="Value"
-      itemMessage="Titre du message"
+      message="Titre du message"
       {...props}
       ButtonComponent={ButtonComponent}
     />,
@@ -27,10 +27,18 @@ const renderContentItemDuo = (props: Partial<ContentItemDuoProps> = {}) =>
 describe("ContentItemDuoCommon", () => {
   it("renders label and value", () => {
     renderContentItemDuo();
-
     expect(screen.getByText("Label")).toBeInTheDocument();
     expect(screen.getByText("Value")).toBeInTheDocument();
     expect(screen.getByText("Titre du message")).toBeInTheDocument();
+  });
+
+  it("renders message with correct messageType", () => {
+    renderContentItemDuo({
+      message: "Message warning",
+      messageType: "warning",
+    });
+    const message = screen.getByText("Message warning");
+    expect(message).toBeInTheDocument();
   });
 
   it("applies vertical modifier when isVertical is true", () => {
@@ -49,7 +57,6 @@ describe("ContentItemDuoCommon", () => {
 
   it("applies custom className", () => {
     renderContentItemDuo({ className: "custom-class" });
-
     const container = screen.getByText("Label").closest("div");
     expect(container).toHaveClass("custom-class");
   });
@@ -66,7 +73,6 @@ describe("ContentItemDuoCommon", () => {
       buttonText: "Click me",
       onButtonClick: handleClick,
     });
-
     const button = screen.getByRole("button", { name: "Click me" });
     expect(button).toBeInTheDocument();
     await userEvent.click(button);
@@ -124,9 +130,15 @@ describe("ContentItemDuoCommon", () => {
 
   it("renders correct semantic elements", () => {
     renderContentItemDuo();
-
     expect(screen.getByText("Label").tagName).toBe("DT");
     expect(screen.getByText("Value").tagName).toBe("DD");
+  });
+
+  it("renders ItemMessage component when message prop is provided", () => {
+    renderContentItemDuo({
+      message: <div data-testid="custom-message">Message</div>,
+    });
+    expect(screen.getByTestId("custom-message")).toBeInTheDocument();
   });
 
   it("has no accessibility violations", async () => {
@@ -159,33 +171,5 @@ describe("ContentItemDuoCommon", () => {
       (v) => v.id !== "definition-list",
     );
     expect(filteredResults).toHaveNoViolations();
-  });
-
-  it("renders ItemMessage always, even if value or button are hidden", () => {
-    renderContentItemDuo({
-      itemMessage: "Test message",
-      itemMessageType: "warning",
-      valueIsVisible: false,
-      buttonIsVisible: false,
-    });
-    expect(screen.getByText("Test message")).toBeInTheDocument();
-  });
-
-  it("hides value when valueIsVisible is false", () => {
-    renderContentItemDuo({ valueIsVisible: false });
-    expect(screen.queryByText("Value")).not.toBeInTheDocument();
-  });
-
-  it("renders button when buttonText and onButtonClick are provided", async () => {
-    const handleClick = vi.fn();
-    renderContentItemDuo({
-      buttonIsVisible: true,
-      buttonText: "Click me",
-      onButtonClick: handleClick,
-    });
-    const button = screen.getByRole("button", { name: "Click me" });
-    expect(button).toBeInTheDocument();
-    await userEvent.click(button);
-    expect(handleClick).toHaveBeenCalled();
   });
 });

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -134,13 +134,6 @@ describe("ContentItemDuoCommon", () => {
     expect(screen.getByText("Value").tagName).toBe("DD");
   });
 
-  it("renders ItemMessage component when message prop is provided", () => {
-    renderContentItemDuo({
-      message: <div data-testid="custom-message">Message</div>,
-    });
-    expect(screen.getByTestId("custom-message")).toBeInTheDocument();
-  });
-
   it("has no accessibility violations", async () => {
     const { container } = render(
       <dl>

--- a/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ContentItemDuo/__tests__/ContentItemDuo.test.tsx
@@ -18,6 +18,7 @@ const renderContentItemDuo = (props: Partial<ContentItemDuoProps> = {}) =>
     <ContentItemDuoCommon
       label="Label"
       value="Value"
+      itemMessage="Titre du message"
       {...props}
       ButtonComponent={ButtonComponent}
     />,
@@ -29,6 +30,7 @@ describe("ContentItemDuoCommon", () => {
 
     expect(screen.getByText("Label")).toBeInTheDocument();
     expect(screen.getByText("Value")).toBeInTheDocument();
+    expect(screen.getByText("Titre du message")).toBeInTheDocument();
   });
 
   it("applies vertical modifier when isVertical is true", () => {
@@ -157,5 +159,33 @@ describe("ContentItemDuoCommon", () => {
       (v) => v.id !== "definition-list",
     );
     expect(filteredResults).toHaveNoViolations();
+  });
+
+  it("renders ItemMessage always, even if value or button are hidden", () => {
+    renderContentItemDuo({
+      itemMessage: "Test message",
+      itemMessageType: "warning",
+      valueIsVisible: false,
+      buttonIsVisible: false,
+    });
+    expect(screen.getByText("Test message")).toBeInTheDocument();
+  });
+
+  it("hides value when valueIsVisible is false", () => {
+    renderContentItemDuo({ valueIsVisible: false });
+    expect(screen.queryByText("Value")).not.toBeInTheDocument();
+  });
+
+  it("renders button when buttonText and onButtonClick are provided", async () => {
+    const handleClick = vi.fn();
+    renderContentItemDuo({
+      buttonIsVisible: true,
+      buttonText: "Click me",
+      onButtonClick: handleClick,
+    });
+    const button = screen.getByRole("button", { name: "Click me" });
+    expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Ajout de la possibilité d'avoir un item message au niveau des "Réponses".
Ajout d'une règle : L'item message peut apparaître en plus du texte de réponse et du Ghost Button.

Figma : https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/9WTQue9ixIFMihpZcIozIB/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=24206-8981&t=CzfPbLIGLH1JJRjg-0

issues : #1582 