### PR TITLE
build(design-system): force use of import type

### DIFF
--- a/packages/canopee-react/src/distributeur/Accordion/Accordion.tsx
+++ b/packages/canopee-react/src/distributeur/Accordion/Accordion.tsx
@@ -1,8 +1,8 @@
 import "@axa-fr/canopee-css/distributeur/Accordion/Accordion.css";
 import React, { useId } from "react";
 import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
-import { CollapseCard, CollapseProps } from "./CollapseCard";
-import { AccordionVariant, TDefaultProps } from "./types";
+import { CollapseCard, type CollapseProps } from "./CollapseCard";
+import type { AccordionVariant, TDefaultProps } from "./types";
 
 const defaultClassName = "af-accordion";
 

--- a/packages/canopee-react/src/distributeur/Action/Action.tsx
+++ b/packages/canopee-react/src/distributeur/Action/Action.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Action/Action.css";
-import { ComponentPropsWithoutRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 type ActionCoreProps = ComponentPropsWithoutRef<"a"> & {

--- a/packages/canopee-react/src/distributeur/Button/Button.tsx
+++ b/packages/canopee-react/src/distributeur/Button/Button.tsx
@@ -1,9 +1,9 @@
 import classNames from "classnames";
 import {
-  ComponentPropsWithoutRef,
+  type ComponentPropsWithoutRef,
   forwardRef,
-  PropsWithChildren,
-  ReactNode,
+  type PropsWithChildren,
+  type ReactNode,
 } from "react";
 
 import "@axa-fr/canopee-css/distributeur/Button/Button.css";

--- a/packages/canopee-react/src/distributeur/CardData/CardData.tsx
+++ b/packages/canopee-react/src/distributeur/CardData/CardData.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { PropsWithChildren } from "react";
+import React, { type PropsWithChildren } from "react";
 import { CardDataHeader } from "./CardDataHeader";
 
 import "@axa-fr/canopee-css/distributeur/CardData/CardData.css";

--- a/packages/canopee-react/src/distributeur/CardData/CardDataHeader.tsx
+++ b/packages/canopee-react/src/distributeur/CardData/CardDataHeader.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import "@axa-fr/canopee-css/distributeur/CardData/CardData.css";
 import classNames from "classnames";
-import { Svg } from "../Svg";
-import { CardDataVariant } from "./CardData";
 import { Divider } from "../Divider/Divider";
+import { Svg } from "../Svg";
 import { Title } from "../Title/Title";
+import type { CardDataVariant } from "./CardData";
 
 type CardDataHeaderProps = {
   title: React.ReactNode;

--- a/packages/canopee-react/src/distributeur/Divider/Divider.tsx
+++ b/packages/canopee-react/src/distributeur/Divider/Divider.tsx
@@ -1,7 +1,7 @@
 import classnames from "classnames";
 
 import "@axa-fr/canopee-css/distributeur/Divider/Divider.css";
-import { ComponentProps } from "react";
+import type { ComponentProps } from "react";
 
 type DividerProps = ComponentProps<"hr"> & {
   mode?: "horizontal" | "vertical";

--- a/packages/canopee-react/src/distributeur/Form/Checkbox/Checkbox.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
-import React, { ComponentProps, forwardRef, ReactNode } from "react";
-import { Option } from "../core";
+import React, { type ComponentProps, forwardRef, type ReactNode } from "react";
+import type { Option } from "../core";
 import { CheckboxItem } from "./CheckboxItem";
 import { CheckboxModes } from "./CheckboxModes";
 

--- a/packages/canopee-react/src/distributeur/Form/Checkbox/CheckboxInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Checkbox/CheckboxInput.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, forwardRef } from "react";
+import { type ComponentProps, forwardRef } from "react";
 
 import { type ConsumerFieldProps, Field, useOptionsWithId } from "../core";
 import { Checkbox } from "./Checkbox";

--- a/packages/canopee-react/src/distributeur/Form/Checkbox/CheckboxItem.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Checkbox/CheckboxItem.tsx
@@ -1,5 +1,10 @@
 import check from "@material-symbols/svg-700/sharp/check.svg";
-import { ComponentPropsWithoutRef, ReactNode, forwardRef, useId } from "react";
+import {
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  forwardRef,
+  useId,
+} from "react";
 import { getOptionClassName } from "../core";
 
 import "@axa-fr/canopee-css/distributeur/Form/Checkbox/Checkbox.css";

--- a/packages/canopee-react/src/distributeur/Form/Date/Date.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Date/Date.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Form/Date/Date.css";
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { type ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../../utilities";
 import { formatDateInputValue } from "../../utilities/helpers/date";
 

--- a/packages/canopee-react/src/distributeur/Form/Date/DateInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Date/DateInput.tsx
@@ -1,5 +1,5 @@
-import { ComponentProps, forwardRef, ReactNode } from "react";
-import { ConsumerFieldProps, Field } from "../core";
+import { type ComponentProps, forwardRef, type ReactNode } from "react";
+import { type ConsumerFieldProps, Field } from "../core";
 import { Date } from "./Date";
 
 type Props = ConsumerFieldProps &

--- a/packages/canopee-react/src/distributeur/Form/File/File.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/File.tsx
@@ -1,13 +1,13 @@
+import { useId } from "react";
 import {
-  DropzoneInputProps,
-  DropzoneOptions,
-  FileRejection,
+  type DropzoneInputProps,
+  type DropzoneOptions,
+  type FileRejection,
   useDropzone,
 } from "react-dropzone";
-import { useId } from "react";
-import { getComponentClassName } from "../../utilities";
 import { Button } from "../../Button/Button";
-import { FileActions } from "./constants";
+import { getComponentClassName } from "../../utilities";
+import type { FileActions } from "./constants";
 
 type Dropzone = DropzoneInputProps & DropzoneOptions;
 type Props = Omit<Dropzone, "onDrop" | "onChange"> & {

--- a/packages/canopee-react/src/distributeur/Form/File/FileErrors.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/FileErrors.tsx
@@ -1,4 +1,4 @@
-import { FileRejection } from "react-dropzone";
+import { type FileRejection } from "react-dropzone";
 
 type Props = {
   errors?: FileRejection[];

--- a/packages/canopee-react/src/distributeur/Form/File/FileInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/FileInput.tsx
@@ -1,8 +1,8 @@
 import "@axa-fr/canopee-css/distributeur/Form/File/File.css";
-import { ComponentPropsWithoutRef, ReactNode, useId } from "react";
+import { type ComponentPropsWithoutRef, type ReactNode, useId } from "react";
 
 import { type ConsumerFieldProps, Field } from "../core";
-import { CustomFile, File } from "./File";
+import { type CustomFile, File } from "./File";
 import { FileTable } from "./FileTable";
 
 type FileProps = ComponentPropsWithoutRef<typeof File>;

--- a/packages/canopee-react/src/distributeur/Form/File/FileLine.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/FileLine.tsx
@@ -1,5 +1,5 @@
 import { getComponentClassName } from "../../utilities";
-import { CustomFile } from "./File";
+import type { CustomFile } from "./File";
 
 type Props = CustomFile & {
   onClick: (id: string) => void;

--- a/packages/canopee-react/src/distributeur/Form/File/FileTable.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/FileTable.tsx
@@ -1,9 +1,9 @@
-import { ComponentPropsWithoutRef } from "react";
-import { FileRejection } from "react-dropzone";
-import { FileLine } from "./FileLine";
-import { CustomFile } from "./File";
-import { FileErrors } from "./FileErrors";
+import type { ComponentPropsWithoutRef } from "react";
+import type { FileRejection } from "react-dropzone";
 import { getComponentClassName } from "../../utilities";
+import type { CustomFile } from "./File";
+import { FileErrors } from "./FileErrors";
+import { FileLine } from "./FileLine";
 
 type FileLineProps = ComponentPropsWithoutRef<typeof FileLine>;
 type Props = Pick<FileLineProps, "onClick"> & {

--- a/packages/canopee-react/src/distributeur/Form/File/__tests__/FileInput.spec.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/__tests__/FileInput.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { MessageTypes } from "../../core";
-import { FilePreview } from "../File";
+import type { FilePreview } from "../File";
 import { FileInput } from "../FileInput";
 
 const values = [

--- a/packages/canopee-react/src/distributeur/Form/File/__tests__/FileLine.spec.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/__tests__/FileLine.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from "@testing-library/react";
+import type { FilePreview } from "../File";
 import { FileLine } from "../FileLine";
-import { FilePreview } from "../File";
 
 describe("<File.FileInput>", () => {
   it("renders File.FileInput correctly", () => {

--- a/packages/canopee-react/src/distributeur/Form/File/__tests__/FileTable.spec.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/__tests__/FileTable.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
+import type { FilePreview } from "../File";
 import { FileTable } from "../FileTable";
-import { FilePreview } from "../File";
 
 describe("<File.FileTable>", () => {
   it("renders File.FileTable correctly", () => {

--- a/packages/canopee-react/src/distributeur/Form/MultiSelect/FormatOptionLabel.tsx
+++ b/packages/canopee-react/src/distributeur/Form/MultiSelect/FormatOptionLabel.tsx
@@ -1,8 +1,8 @@
-import classNames from "classnames";
 import checkIcon from "@material-symbols/svg-700/outlined/check.svg";
+import classNames from "classnames";
 import { type FormatOptionLabelMeta } from "react-select";
-import { Option } from "./MultiSelect";
 import { Svg } from "../../Svg";
+import type { Option } from "./MultiSelect";
 
 const formatOptionLabel = (
   data: Option,

--- a/packages/canopee-react/src/distributeur/Form/MultiSelect/MultiSelect.tsx
+++ b/packages/canopee-react/src/distributeur/Form/MultiSelect/MultiSelect.tsx
@@ -6,7 +6,7 @@ import Select, {
   type Options,
   type SingleValue,
 } from "react-select";
-import AsyncSelect, { AsyncProps } from "react-select/async";
+import AsyncSelect, { type AsyncProps } from "react-select/async";
 import { formatOptionLabel } from "./FormatOptionLabel";
 import { noOptionsMessage } from "./NoOptionsMessage";
 import { useMultiSelectStyle } from "./useMultiSelectStyle";

--- a/packages/canopee-react/src/distributeur/Form/MultiSelect/MultiSelectInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/MultiSelect/MultiSelectInput.tsx
@@ -1,7 +1,7 @@
 import "@axa-fr/canopee-css/distributeur/Form/MultiSelect/MultiSelect.css";
 
 import { type ComponentProps } from "react";
-import { ConsumerFieldProps, Field } from "../core";
+import { type ConsumerFieldProps, Field } from "../core";
 import { MultiSelect } from "./MultiSelect";
 
 type Props = ConsumerFieldProps & ComponentProps<typeof MultiSelect>;

--- a/packages/canopee-react/src/distributeur/Form/MultiSelect/ValueContainer.tsx
+++ b/packages/canopee-react/src/distributeur/Form/MultiSelect/ValueContainer.tsx
@@ -2,10 +2,10 @@ import React, { type CSSProperties } from "react";
 import {
   components,
   type GroupBase,
-  type ValueContainerProps,
   type MultiValueProps,
+  type ValueContainerProps,
 } from "react-select";
-import { Option } from "./MultiSelect";
+import type { Option } from "./MultiSelect";
 
 const ValueContainer = ({
   children,

--- a/packages/canopee-react/src/distributeur/Form/MultiSelect/useMultiSelectStyle.ts
+++ b/packages/canopee-react/src/distributeur/Form/MultiSelect/useMultiSelectStyle.ts
@@ -1,6 +1,6 @@
 import { type GroupBase, type StylesConfig } from "react-select";
 
-import { Option } from "./MultiSelect";
+import type { Option } from "./MultiSelect";
 
 export const useMultiSelectStyle = () => {
   // The recommended way to provide custom styles to react-select is to use the styles prop

--- a/packages/canopee-react/src/distributeur/Form/NestedQuestion/NestedQuestion.tsx
+++ b/packages/canopee-react/src/distributeur/Form/NestedQuestion/NestedQuestion.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Form/NestedQuestion/NestedQuestion.css";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { getComponentClassName } from "../../utilities";
 
 export const NestedQuestion = ({

--- a/packages/canopee-react/src/distributeur/Form/Number/Number.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Number/Number.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Form/Text/Text.css";
-import { ComponentPropsWithRef, forwardRef, useId } from "react";
+import { type ComponentPropsWithRef, forwardRef, useId } from "react";
 import { getComponentClassName } from "../../utilities";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "type"> & {

--- a/packages/canopee-react/src/distributeur/Form/Number/NumberInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Number/NumberInput.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from "react";
+import { type ComponentPropsWithRef } from "react";
 import { type ConsumerFieldProps, Field } from "../core";
 
 import { Number } from "./Number";

--- a/packages/canopee-react/src/distributeur/Form/Pass/Pass.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Pass/Pass.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { type ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../../utilities";
 
 import "@axa-fr/canopee-css/distributeur/Form/Pass/Pass.css";

--- a/packages/canopee-react/src/distributeur/Form/Pass/PassInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Pass/PassInput.tsx
@@ -1,5 +1,5 @@
-import { ComponentProps, ReactNode, useState } from "react";
-import { ConsumerFieldProps, Field } from "../core";
+import { type ComponentProps, type ReactNode, useState } from "react";
+import { type ConsumerFieldProps, Field } from "../core";
 import { Pass } from "./Pass";
 
 const strengthList: Record<number, string> = {

--- a/packages/canopee-react/src/distributeur/Form/Radio/Radio.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/Radio.tsx
@@ -1,9 +1,9 @@
+import classNames from "classnames";
 import {
-  ComponentPropsWithoutRef,
-  ComponentPropsWithRef,
+  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
   forwardRef,
 } from "react";
-import classNames from "classnames";
 import type { Option } from "../core";
 import { RadioCardGroup } from "./RadioCardGroup";
 import { RadioItem } from "./RadioItem";

--- a/packages/canopee-react/src/distributeur/Form/Radio/RadioCardGroup.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/RadioCardGroup.tsx
@@ -1,9 +1,9 @@
 import "@axa-fr/canopee-css/distributeur/Form/Radio/RadioCardGroup.css";
 
-import { ComponentProps, ReactNode, useId } from "react";
 import classNames from "classnames";
-import type { Option } from "../core";
+import { type ComponentProps, type ReactNode, useId } from "react";
 import { Svg } from "../../Svg";
+import type { Option } from "../core";
 
 const DEFAULT_CLASSNAME = "af-card";
 const DEFAULT_CONTAINER_CLASSNAME = "af-form__radio-card-group";

--- a/packages/canopee-react/src/distributeur/Form/Radio/RadioInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/RadioInput.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { type ConsumerFieldProps, Field, useOptionsWithId } from "../core";
 import { Radio, RadioModes } from "./Radio";
 

--- a/packages/canopee-react/src/distributeur/Form/Radio/RadioItem.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/RadioItem.tsx
@@ -1,5 +1,10 @@
 import "@axa-fr/canopee-css/distributeur/Form/Radio/Radio.css";
-import { ComponentPropsWithRef, forwardRef, ReactNode, useId } from "react";
+import {
+  type ComponentPropsWithRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+} from "react";
 import { getOptionClassName } from "../core";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "checked" | "type"> & {

--- a/packages/canopee-react/src/distributeur/Form/Radio/__tests__/RadioInput.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/__tests__/RadioInput.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, within } from "@testing-library/react";
 import villaIcon from "@material-symbols/svg-400/outlined/villa.svg";
+import { render, screen, within } from "@testing-library/react";
 import { axe } from "jest-axe";
+import type { Option } from "../../core";
 import { RadioInput } from "../RadioInput";
-import { Option } from "../../core";
 
 const languageOptions = [
   { label: "French", value: "french" },

--- a/packages/canopee-react/src/distributeur/Form/Select/Select.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Select/Select.tsx
@@ -1,8 +1,8 @@
 import {
-  ComponentProps,
+  type ComponentProps,
   forwardRef,
-  OptionHTMLAttributes,
-  PropsWithChildren,
+  type OptionHTMLAttributes,
+  type PropsWithChildren,
 } from "react";
 import { SelectBase } from "./SelectBase";
 import { SelectDefault } from "./SelectDefault";

--- a/packages/canopee-react/src/distributeur/Form/Select/SelectBase.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Select/SelectBase.tsx
@@ -1,8 +1,8 @@
 import "@axa-fr/canopee-css/distributeur/Form/Select/Select.css";
 import {
-  ComponentPropsWithoutRef,
+  type ComponentPropsWithoutRef,
   forwardRef,
-  OptionHTMLAttributes,
+  type OptionHTMLAttributes,
 } from "react";
 import { getComponentClassName } from "../../utilities";
 

--- a/packages/canopee-react/src/distributeur/Form/Select/SelectDefault.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Select/SelectDefault.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef, forwardRef, useId, useState } from "react";
+import { type ComponentPropsWithRef, forwardRef, useId, useState } from "react";
 import { SelectBase } from "./SelectBase";
 
 type Props = Omit<

--- a/packages/canopee-react/src/distributeur/Form/Select/SelectDefaultWithOptions.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Select/SelectDefaultWithOptions.tsx
@@ -1,7 +1,7 @@
 import {
-  ComponentPropsWithRef,
+  type ComponentPropsWithRef,
   forwardRef,
-  OptionHTMLAttributes,
+  type OptionHTMLAttributes,
   useId,
   useMemo,
   useState,

--- a/packages/canopee-react/src/distributeur/Form/Select/SelectInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Select/SelectInput.tsx
@@ -1,11 +1,11 @@
 import {
-  ComponentProps,
+  type ComponentProps,
   forwardRef,
-  OptionHTMLAttributes,
-  PropsWithChildren,
+  type OptionHTMLAttributes,
+  type PropsWithChildren,
 } from "react";
 
-import { ConsumerFieldProps, Field } from "../core";
+import { type ConsumerFieldProps, Field } from "../core";
 import { Select } from "./Select";
 
 type Props = ConsumerFieldProps &

--- a/packages/canopee-react/src/distributeur/Form/Slider/SliderInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Slider/SliderInput.tsx
@@ -1,5 +1,5 @@
 import { type ComponentProps } from "react";
-import { ConsumerFieldProps, Field } from "../core";
+import { type ConsumerFieldProps, Field } from "../core";
 import { Slider } from "./Slider";
 
 type Props = ConsumerFieldProps & ComponentProps<typeof Slider>;

--- a/packages/canopee-react/src/distributeur/Form/Slider/__tests__/Slider.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Slider/__tests__/Slider.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
+import userEvent, { type UserEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import userEvent, { UserEvent } from "@testing-library/user-event";
 import { Slider } from "../Slider";
 
 const options = [

--- a/packages/canopee-react/src/distributeur/Form/Text/Text.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Text/Text.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Form/Text/Text.css";
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { type ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../../utilities";
 
 type Props = ComponentPropsWithRef<"input"> & {

--- a/packages/canopee-react/src/distributeur/Form/Text/TextInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Text/TextInput.tsx
@@ -1,5 +1,5 @@
-import { ComponentProps, forwardRef } from "react";
-import { ConsumerFieldProps, Field } from "../core";
+import { type ComponentProps, forwardRef } from "react";
+import { type ConsumerFieldProps, Field } from "../core";
 import { Text } from "./Text";
 
 export type TextInputProps = ConsumerFieldProps & ComponentProps<typeof Text>;

--- a/packages/canopee-react/src/distributeur/Form/Textarea/Textarea.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Textarea/Textarea.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Form/Textarea/Textarea.css";
-import { ComponentPropsWithoutRef, forwardRef, useId } from "react";
+import { type ComponentPropsWithoutRef, forwardRef, useId } from "react";
 
 import { getComponentClassName } from "../../utilities";
 

--- a/packages/canopee-react/src/distributeur/Form/Textarea/TextareaInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Textarea/TextareaInput.tsx
@@ -1,6 +1,6 @@
 import "@axa-fr/canopee-css/distributeur/Form/Textarea/Textarea.css";
 
-import { ComponentProps, forwardRef } from "react";
+import { type ComponentProps, forwardRef } from "react";
 import { type ConsumerFieldProps, Field } from "../core";
 
 import { Textarea } from "./Textarea";

--- a/packages/canopee-react/src/distributeur/Form/core/Deprecated/FieldInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/core/Deprecated/FieldInput.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { getComponentClassName } from "../../../utilities";
 
 type FieldProps = {

--- a/packages/canopee-react/src/distributeur/Form/core/FormClassManager.ts
+++ b/packages/canopee-react/src/distributeur/Form/core/FormClassManager.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { MessageTypes } from "./MessageTypes";
 
 const getFieldInputClassModifier = (modifier: string, disabled: boolean) =>

--- a/packages/canopee-react/src/distributeur/Form/core/HelpMessage.tsx
+++ b/packages/canopee-react/src/distributeur/Form/core/HelpMessage.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 type HelpProps = {
   message?: ReactNode;

--- a/packages/canopee-react/src/distributeur/Form/core/index.ts
+++ b/packages/canopee-react/src/distributeur/Form/core/index.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export { LegacyField } from "./Deprecated/Field";
 export { FieldForm } from "./Deprecated/FieldForm";

--- a/packages/canopee-react/src/distributeur/HelpButton/index.tsx
+++ b/packages/canopee-react/src/distributeur/HelpButton/index.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Action/Action.css";
-import { ComponentPropsWithoutRef, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { Popover } from "../Popover";
 import { getComponentClassName } from "../utilities";
 

--- a/packages/canopee-react/src/distributeur/Layout/Footer/Footer.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Footer/Footer.tsx
@@ -1,8 +1,8 @@
-import logo from "@axa-fr/canopee-css/logo-axa.svg";
 import "@axa-fr/canopee-css/distributeur/Layout/Footer/Footer.css";
 import "@axa-fr/canopee-css/distributeur/common/breakpoints.css";
-import { PropsWithChildren, forwardRef } from "react";
+import logo from "@axa-fr/canopee-css/logo-axa.svg";
 import classNames from "classnames";
+import { type PropsWithChildren, forwardRef } from "react";
 
 type FooterProps = {
   href?: string;

--- a/packages/canopee-react/src/distributeur/Layout/Header/AnchorNavBar/AnchorNavBar.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/AnchorNavBar/AnchorNavBar.tsx
@@ -1,9 +1,9 @@
-import { ReactNode } from "react";
-import classNames from "classnames";
 import externalLinkIcon from "@material-symbols/svg-400/sharp/exit_to_app.svg";
-import { Svg } from "../../../Svg";
+import classNames from "classnames";
+import { type ReactNode } from "react";
 import { Link } from "../../../Link/Link";
 import { linkClassName } from "../../../Link/linkClassName";
+import { Svg } from "../../../Svg";
 
 import "@axa-fr/canopee-css/distributeur/Layout/Header/AnchorNavBar/AnchorNavBar.css";
 import "@axa-fr/canopee-css/distributeur/common/breakpoints.css";

--- a/packages/canopee-react/src/distributeur/Layout/Header/HeaderTitle/HeaderTitle.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/HeaderTitle/HeaderTitle.tsx
@@ -1,10 +1,13 @@
 import "@axa-fr/canopee-css/distributeur/Layout/Header/HeaderTitle/HeaderTitle.css";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import classNames from "classnames";
 import { Action } from "../../../Action/Action";
 import { getComponentClassName } from "../../../utilities";
-import { AnchorNavBar, AnchorNavBarItem } from "../AnchorNavBar/AnchorNavBar";
+import {
+  AnchorNavBar,
+  type AnchorNavBarItem,
+} from "../AnchorNavBar/AnchorNavBar";
 import { ToggleButton } from "../ToggleButton/ToggleButton";
 import { getClassModifier } from "./HeaderTitle.helpers";
 

--- a/packages/canopee-react/src/distributeur/Layout/Header/Infos/Infos.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/Infos/Infos.tsx
@@ -1,5 +1,5 @@
 import infoIcon from "@material-symbols/svg-400/outlined/info-fill.svg";
-import { Fragment, ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { getComponentClassName } from "../../../utilities";
 import { generateId } from "../../../utilities/helpers/generateId";
 

--- a/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarBase.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarBase.tsx
@@ -1,5 +1,5 @@
-import { FocusEvent, MouseEvent, ReactNode } from "react";
 import classNames from "classnames";
+import type { FocusEvent, MouseEvent, ReactNode } from "react";
 import { getComponentClassName } from "../../../utilities";
 
 const defaultClassName = "af-nav-container";

--- a/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarItem/NavBarItem.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarItem/NavBarItem.tsx
@@ -1,7 +1,7 @@
 import React, {
-  ComponentProps,
-  KeyboardEvent,
-  ReactElement,
+  type ComponentProps,
+  type KeyboardEvent,
+  type ReactElement,
   useCallback,
   useState,
 } from "react";

--- a/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarItem/NavBarItemBase.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarItem/NavBarItemBase.tsx
@@ -1,7 +1,7 @@
 import {
-  HTMLAttributes,
-  KeyboardEvent,
-  ReactElement,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactElement,
   useEffect,
   useMemo,
   useRef,

--- a/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarItem/NavBarItemLink.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarItem/NavBarItemLink.tsx
@@ -1,4 +1,4 @@
-import { AllHTMLAttributes, RefObject } from "react";
+import type { AllHTMLAttributes, RefObject } from "react";
 
 const defaultClassName = "af-nav__link";
 type Props = AllHTMLAttributes<HTMLAnchorElement> & {

--- a/packages/canopee-react/src/distributeur/Layout/Header/User/User.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/User/User.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Layout/Header/User/User.css";
-import { MouseEvent, ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { getComponentClassName } from "../../../utilities";
 import { InnerUser } from "./InnerUser";
 

--- a/packages/canopee-react/src/distributeur/Layout/MainContainer/MainContainer.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/MainContainer/MainContainer.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, PropsWithChildren } from "react";
+import type { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import "@axa-fr/canopee-css/distributeur/common/breakpoints.css";
 import "@axa-fr/canopee-css/distributeur/MainContainer/MainContainer.css";

--- a/packages/canopee-react/src/distributeur/Link/CustomLink.tsx
+++ b/packages/canopee-react/src/distributeur/Link/CustomLink.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { linkClassName } from "./linkClassName";
 
 type CustomLinkProps = {

--- a/packages/canopee-react/src/distributeur/Link/LinkAnchor.tsx
+++ b/packages/canopee-react/src/distributeur/Link/LinkAnchor.tsx
@@ -1,7 +1,11 @@
 import classnames from "classnames";
-import { ComponentPropsWithRef, forwardRef, ReactElement } from "react";
-import { linkClassName } from "./linkClassName";
+import {
+  type ComponentPropsWithRef,
+  forwardRef,
+  type ReactElement,
+} from "react";
 import { Svg } from "../Svg";
+import { linkClassName } from "./linkClassName";
 
 type AnchorLinkProps = {
   leftIcon?: ReactElement<typeof Svg>;

--- a/packages/canopee-react/src/distributeur/Link/__tests__/Link.test.tsx
+++ b/packages/canopee-react/src/distributeur/Link/__tests__/Link.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { describe, expect, it } from "vitest";
 import { Link } from "../Link";
 

--- a/packages/canopee-react/src/distributeur/Messages/Message.tsx
+++ b/packages/canopee-react/src/distributeur/Messages/Message.tsx
@@ -5,7 +5,7 @@ import errorSvg from "@material-symbols/svg-400/outlined/error-fill.svg";
 import infoSvg from "@material-symbols/svg-400/outlined/info-fill.svg";
 import warningSvg from "@material-symbols/svg-400/outlined/warning-fill.svg";
 
-import { MouseEventHandler, PropsWithChildren, ReactNode } from "react";
+import type { MouseEventHandler, PropsWithChildren, ReactNode } from "react";
 import { Svg } from "../Svg";
 import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
 

--- a/packages/canopee-react/src/distributeur/ModalAgent/BooleanModal.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/BooleanModal.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, getComponentClassName } from "../../distributeur";
 import { Body } from "./components/Body";
 import { Footer } from "./components/Footer";
 import { Header, type HeaderProps } from "./components/Header";
-import { ModalProps } from "./Modal";
+import type { ModalProps } from "./Modal";
 
 const defaultClassName = "af-modal";
 

--- a/packages/canopee-react/src/distributeur/ModalAgent/__tests__/BooleanModal.test.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/__tests__/BooleanModal.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { describe } from "vitest";
-import { BooleanModal, BooleanModalProps } from "../BooleanModal";
+import { BooleanModal, type BooleanModalProps } from "../BooleanModal";
 
 type Props = Pick<BooleanModalProps, "onSubmit" | "onCancel" | "size">;
 

--- a/packages/canopee-react/src/distributeur/ModalAgent/__tests__/Modal.test.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/__tests__/Modal.test.tsx
@@ -4,7 +4,7 @@ import { axe } from "jest-axe";
 import { type ComponentProps, type PropsWithChildren, useRef } from "react";
 import { describe, test } from "vitest";
 import { ModalBody, ModalFooter, ModalHeader } from "..";
-import { Modal, ModalProps } from "../Modal";
+import { Modal, type ModalProps } from "../Modal";
 
 type Props = Pick<
   ModalProps & ComponentProps<typeof ModalHeader>,

--- a/packages/canopee-react/src/distributeur/Popover/AnimatedPopover.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/AnimatedPopover.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useRef } from "react";
 import {
   arrow,
   FloatingArrow,
   offset,
-  Placement,
+  type Placement,
   useFloating,
 } from "@floating-ui/react";
+import React, { useRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 const defaultClassName = "af-popover__container";

--- a/packages/canopee-react/src/distributeur/Popover/Popover.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/Popover.tsx
@@ -1,6 +1,6 @@
+import type { Placement } from "@floating-ui/react";
 import React from "react";
-import { Placement } from "@floating-ui/react";
-import { PopoverModes } from "./Popover.types";
+import type { PopoverModes } from "./Popover.types";
 import { PopoverClick } from "./PopoverClick";
 import { PopoverOver } from "./PopoverOver";
 

--- a/packages/canopee-react/src/distributeur/Popover/Popover.types.ts
+++ b/packages/canopee-react/src/distributeur/Popover/Popover.types.ts
@@ -1,4 +1,4 @@
-import { Placement } from "@floating-ui/react";
+import type { Placement } from "@floating-ui/react";
 
 export type PopoverModes = "hover" | "click";
 

--- a/packages/canopee-react/src/distributeur/Popover/PopoverBase.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/PopoverBase.tsx
@@ -1,4 +1,4 @@
-import { Placement } from "@floating-ui/react";
+import type { Placement } from "@floating-ui/react";
 import React from "react";
 import { AnimatedPopover } from "./AnimatedPopover";
 

--- a/packages/canopee-react/src/distributeur/Popover/PopoverClick.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/PopoverClick.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PopoverProps } from "./Popover.types";
+import type { PopoverProps } from "./Popover.types";
 import { PopoverBase } from "./PopoverBase";
 
 export const PopoverClick = ({

--- a/packages/canopee-react/src/distributeur/Popover/PopoverOver.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/PopoverOver.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PopoverProps } from "./Popover.types";
+import type { PopoverProps } from "./Popover.types";
 import { PopoverBase } from "./PopoverBase";
 
 export const PopoverOver = ({

--- a/packages/canopee-react/src/distributeur/Popover/__tests__/Popover.spec.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/__tests__/Popover.spec.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import userEvent, { type UserEvent } from "@testing-library/user-event";
 import { act } from "react";
 import { Popover } from "../Popover";
 

--- a/packages/canopee-react/src/distributeur/Restitution/ArticleRestitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/ArticleRestitution.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, PropsWithChildren } from "react";
+import type { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 import { getComponentClassName } from "../utilities";
 
 type ArticleRestitutionProps = ComponentPropsWithoutRef<"article"> & {

--- a/packages/canopee-react/src/distributeur/Restitution/Restitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/Restitution.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, PropsWithChildren } from "react";
+import type { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 import { getComponentClassName } from "../utilities";
 
 export type RestitutionProps = ComponentPropsWithoutRef<"dl"> & {

--- a/packages/canopee-react/src/distributeur/Restitution/RestitutionList.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/RestitutionList.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 
 type RestitutionListProps = ComponentPropsWithoutRef<"ul"> & {
   values: string[];

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitution.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { getComponentClassName } from "../utilities";
 
 export type SectionRestitutionProps = {

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionColumn.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionColumn.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { getComponentClassName } from "../utilities";
 import { SectionRestitutionTitle } from "./SectionRestitutionTitle";
 

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionRow.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionRow.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { getComponentClassName } from "../utilities";
 import { SectionRestitutionTitle } from "./SectionRestitutionTitle";
 

--- a/packages/canopee-react/src/distributeur/Steps/Step.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/Step.tsx
@@ -1,7 +1,7 @@
 import { StepCurrent } from "./StepCurrent";
 import { StepDisabled } from "./StepDisabled";
 import { StepLink, type StepLinkProps } from "./StepLink";
-import { StepMode } from "./types";
+import type { StepMode } from "./types";
 
 type Props = Omit<StepLinkProps, "href"> & {
   href?: string;

--- a/packages/canopee-react/src/distributeur/Steps/StepCurrent.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/StepCurrent.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { StepNoLink } from "./StepNoLink";
 
 type Props = ComponentPropsWithoutRef<typeof StepNoLink>;

--- a/packages/canopee-react/src/distributeur/Steps/StepDisabled.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/StepDisabled.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { StepNoLink } from "./StepNoLink";
 
 type Props = ComponentPropsWithoutRef<typeof StepNoLink>;

--- a/packages/canopee-react/src/distributeur/Steps/StepLink.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/StepLink.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { StepBase, type StepBaseProps } from "./StepBase";
 import type { StepLinkOnClickHandler } from "./types";
 

--- a/packages/canopee-react/src/distributeur/Steps/StepNoLink.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/StepNoLink.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { StepBase } from "./StepBase";
 
 type Props = ComponentPropsWithoutRef<typeof StepBase> & {

--- a/packages/canopee-react/src/distributeur/Steps/Steps.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/Steps.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { getComponentClassName } from "../utilities";
 
 const defaultClassName = "af-steps-new";

--- a/packages/canopee-react/src/distributeur/Steps/VerticalStep.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/VerticalStep.tsx
@@ -2,7 +2,7 @@ import check from "@material-symbols/svg-400/sharp/check.svg";
 import edit from "@material-symbols/svg-400/sharp/edit-fill.svg";
 import lock from "@material-symbols/svg-400/sharp/lock-fill.svg";
 import classNames from "classnames";
-import { ReactNode, useId } from "react";
+import { type ReactNode, useId } from "react";
 import { Svg } from "../Svg";
 import { Title } from "../Title/Title";
 import type { VerticalStepMode } from "./types";

--- a/packages/canopee-react/src/distributeur/Steps/__tests__/VerticalStep.spec.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/__tests__/VerticalStep.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { vi } from "vitest";
 import { VerticalStep } from "../VerticalStep";
-import { VerticalStepMode } from "../types";
+import type { VerticalStepMode } from "../types";
 
 const setStepMode = vi.fn();
 

--- a/packages/canopee-react/src/distributeur/Steps/types.ts
+++ b/packages/canopee-react/src/distributeur/Steps/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export type CustomClickEvent = {
   href: string;

--- a/packages/canopee-react/src/distributeur/Summary/index.tsx
+++ b/packages/canopee-react/src/distributeur/Summary/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Message, type MessageProps } from "../Messages/Message";
 import { generateId } from "../utilities/helpers/generateId";
 

--- a/packages/canopee-react/src/distributeur/Svg/Svg.tsx
+++ b/packages/canopee-react/src/distributeur/Svg/Svg.tsx
@@ -1,5 +1,5 @@
 import {
-  ComponentProps,
+  type ComponentProps,
   type SVGAttributes,
   useLayoutEffect,
   useRef,

--- a/packages/canopee-react/src/distributeur/Table/Pagination/Li.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Pagination/Li.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from "react";
+import type { MouseEvent } from "react";
 
 type LiProps = {
   isVisible?: boolean;

--- a/packages/canopee-react/src/distributeur/Table/Pagination/LiPoint.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Pagination/LiPoint.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 type LiPointProps = { isVisible?: boolean; children?: ReactNode };
 

--- a/packages/canopee-react/src/distributeur/Table/Pagination/Pager.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Pagination/Pager.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Table/Pager.css";
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../../utilities";
 import { Li } from "./Li";
 import { LiPoint } from "./LiPoint";

--- a/packages/canopee-react/src/distributeur/Table/Pagination/PaginationButton.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Pagination/PaginationButton.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 type PaginationButtonProps = {
   isVisible?: boolean;

--- a/packages/canopee-react/src/distributeur/Table/Pagination/Paging.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Pagination/Paging.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Table/Paging.css";
-import { ComponentPropsWithoutRef, useCallback } from "react";
+import { type ComponentPropsWithoutRef, useCallback } from "react";
 import { getComponentClassName } from "../../utilities";
 import { Items } from "./Items";
 import { Pager } from "./Pager";

--- a/packages/canopee-react/src/distributeur/Table/TBody.tsx
+++ b/packages/canopee-react/src/distributeur/Table/TBody.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 type Props = ComponentPropsWithoutRef<"tbody"> & {

--- a/packages/canopee-react/src/distributeur/Table/THead.tsx
+++ b/packages/canopee-react/src/distributeur/Table/THead.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 type Props = ComponentPropsWithoutRef<"thead"> & {

--- a/packages/canopee-react/src/distributeur/Table/Table.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Table.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../utilities";
 import { TBody } from "./TBody";
 import { THead } from "./THead";

--- a/packages/canopee-react/src/distributeur/Table/Td.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Td.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 type Props = ComponentPropsWithoutRef<"td"> & {

--- a/packages/canopee-react/src/distributeur/Table/Th.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Th.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 type Props = ComponentPropsWithoutRef<"th"> & {

--- a/packages/canopee-react/src/distributeur/Table/Tr.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Tr.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import { type ComponentPropsWithoutRef } from "react";
 import { getComponentClassName } from "../utilities";
 
 type Props = ComponentPropsWithoutRef<"tr"> & {

--- a/packages/canopee-react/src/distributeur/Tabs/Tabs.tsx
+++ b/packages/canopee-react/src/distributeur/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Tab, TabProps } from "./components/Tab";
-import { TabsCore, TabsCoreProps } from "./components/TabsCore";
+import { Tab, type TabProps } from "./components/Tab";
+import { TabsCore, type TabsCoreProps } from "./components/TabsCore";
 
 type TTabs = React.ComponentType<TabsCoreProps> & {
   Tab: React.ComponentType<TabProps>;

--- a/packages/canopee-react/src/distributeur/Tabs/components/Tab.tsx
+++ b/packages/canopee-react/src/distributeur/Tabs/components/Tab.tsx
@@ -1,5 +1,5 @@
 import "@axa-fr/canopee-css/distributeur/Tabs/Tabs.css";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export type TabProps = {
   title: ReactNode;

--- a/packages/canopee-react/src/distributeur/Tabs/components/TabsCore.tsx
+++ b/packages/canopee-react/src/distributeur/Tabs/components/TabsCore.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { TabsStateless, TabsStatelessProps } from "./TabsStateless";
+import { TabsStateless, type TabsStatelessProps } from "./TabsStateless";
 
 const DEFAULT_ACTIVE_INDEX = "0";
 

--- a/packages/canopee-react/src/distributeur/Tag/Tag.tsx
+++ b/packages/canopee-react/src/distributeur/Tag/Tag.tsx
@@ -1,5 +1,9 @@
 import "@axa-fr/canopee-css/distributeur/Tag/Tag.css";
-import { ComponentPropsWithRef, PropsWithChildren, forwardRef } from "react";
+import {
+  type ComponentPropsWithRef,
+  type PropsWithChildren,
+  forwardRef,
+} from "react";
 import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
 
 export type TagVariants =

--- a/packages/canopee-react/src/distributeur/Tag/__tests__/Tag.test.tsx
+++ b/packages/canopee-react/src/distributeur/Tag/__tests__/Tag.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { ComponentProps } from "react";
+import type { ComponentProps } from "react";
 import { describe, expect, it } from "vitest";
-import { Tag, TagVariants } from "../Tag";
+import { Tag, type TagVariants } from "../Tag";
 
 const classModifiers: ComponentProps<typeof Tag>["classModifier"][] = [
   "success",

--- a/packages/canopee-react/src/distributeur/Title/Title.tsx
+++ b/packages/canopee-react/src/distributeur/Title/Title.tsx
@@ -1,9 +1,9 @@
 import "@axa-fr/canopee-css/distributeur/Title/Title.css";
 import {
-  ComponentPropsWithRef,
-  PropsWithChildren,
-  ReactElement,
-  ReactNode,
+  type ComponentPropsWithRef,
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
   forwardRef,
 } from "react";
 

--- a/packages/canopee-react/src/prospect-client/CardMessage/CardMessageCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/CardMessage/CardMessageCommon.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, useMemo } from "react";
+import { type ComponentPropsWithoutRef, useMemo } from "react";
 import { getComponentClassName } from "../utilities/getComponentClassName";
 
 export const cardMessageVariants = {

--- a/packages/canopee-react/src/prospect-client/ClickIcon/ClickIconCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/ClickIcon/ClickIconCommon.tsx
@@ -1,9 +1,9 @@
 import { type ComponentPropsWithRef } from "react";
 import {
   Icon,
-  IconVariants,
-  IconSizeVariants,
+  type IconSizeVariants,
   iconSizeVariants,
+  type IconVariants,
 } from "../Icon/IconCommon";
 import { getClassName } from "../utilities/getClassName";
 

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCommon.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, ComponentType } from "react";
-import { Icon, IconProps } from "../Icon/IconCommon";
 import { BasePicture } from "../BasePicture/BasePicture";
+import { Icon, type IconProps } from "../Icon/IconCommon";
 import {
   type ContentItemCoreProps,
   ContentItemMonoCore,

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/ContentItemMonoCore.tsx
@@ -1,8 +1,7 @@
-import type { ElementType } from "react";
-import { ReactNode } from "react";
+import type { ElementType, ReactNode } from "react";
 
-import { AtLeastOne } from "../utilities/types/AtLeastOne";
 import { getClassName } from "../utilities/getClassName";
+import type { AtLeastOne } from "../utilities/types/AtLeastOne";
 
 export type ContentMonoItemSize = "medium" | "large";
 

--- a/packages/canopee-react/src/prospect-client/ContentItemMono/__tests__/ContentItemMonoCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/ContentItemMono/__tests__/ContentItemMonoCommon.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { Icon } from "../../Icon/IconCommon";
 import {
-  ContentItemCommonProps,
+  type ContentItemCommonProps,
   ContentItemMonoCommon,
   getContentItemCoreProps,
 } from "../ContentItemMonoCommon";
-import { Icon } from "../../Icon/IconCommon";
 
 describe("getContentItemCoreProps", () => {
   it("returns correct props for type 'icon'", () => {

--- a/packages/canopee-react/src/prospect-client/DataAgent/DataAgentCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/DataAgent/DataAgentCommon.tsx
@@ -1,15 +1,20 @@
-import { type ComponentProps, ComponentType, Fragment, useMemo } from "react";
-import { getComponentClassName } from "../utilities/getComponentClassName";
-import { useIsSmallScreen } from "../utilities/hook/useIsSmallScreen";
-import { BREAKPOINT } from "../utilities/constants";
-import { Divider } from "../Divider/DividerCommon";
+import {
+  type ComponentProps,
+  type ComponentType,
+  Fragment,
+  useMemo,
+} from "react";
 import type {
   ContentItemProps,
   ContentMonoItemIconProps,
   ContentMonoItemPictureProps,
   ContentMonoItemStickProps,
 } from "../ContentItemMono/ContentItemMonoCommon";
+import { Divider } from "../Divider/DividerCommon";
 import type { ClickItemProps } from "../List/ClickItem/types";
+import { BREAKPOINT } from "../utilities/constants";
+import { getComponentClassName } from "../utilities/getComponentClassName";
+import { useIsSmallScreen } from "../utilities/hook/useIsSmallScreen";
 
 export type TupleMax3<T> = [T] | [T, T] | [T, T, T];
 

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
@@ -1,13 +1,13 @@
 import {
   useId,
-  type ComponentType,
-  type ReactNode,
   useRef,
   type ChangeEvent,
+  type ComponentType,
+  type ReactNode,
 } from "react";
+import type { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 import type { ItemMessageProps } from "../../ItemMessage/ItemMessageCommon";
 import type { CardCheckboxOptionProps } from "../CardCheckboxOption/CardCheckboxOptionCommon";
-import { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 
 type CheckboxOption = Omit<CardCheckboxOptionProps, "name" | "type">;
 

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CheckboxText/CheckboxTextCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CheckboxText/CheckboxTextCommon.tsx
@@ -1,7 +1,7 @@
-import { type ReactNode, useId, type ComponentType, forwardRef } from "react";
+import { type ComponentType, forwardRef, type ReactNode, useId } from "react";
+import type { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 import type { ItemMessageProps } from "../../ItemMessage/ItemMessageCommon";
 import type { CheckboxProps } from "../Checkbox/CheckboxCommon";
-import { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 
 export type CheckboxTextProps = {
   label: string | ReactNode;

--- a/packages/canopee-react/src/prospect-client/Form/Dropdown/DropdownCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Dropdown/DropdownCommon.tsx
@@ -6,6 +6,7 @@ import {
   forwardRef,
   useId,
 } from "react";
+import type { GridContainerProps } from "../../utilities/types/GridContainerProps";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -14,7 +15,6 @@ import {
   ItemMessage,
   type ItemMessageProps,
 } from "../ItemMessage/ItemMessageCommon";
-import { GridContainerProps } from "../../utilities/types/GridContainerProps";
 
 export type DropdownProps = ComponentPropsWithRef<"select"> & {
   id?: string;

--- a/packages/canopee-react/src/prospect-client/Form/FileUpload/InputFile/InputFileCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/FileUpload/InputFile/InputFileCommon.tsx
@@ -1,3 +1,4 @@
+import addCircleIcon from "@material-symbols/svg-400/rounded/add_circle-fill.svg";
 import {
   type ComponentPropsWithRef,
   type ComponentType,
@@ -6,12 +7,11 @@ import {
   type ReactNode,
   useId,
 } from "react";
-import addCircleIcon from "@material-symbols/svg-400/rounded/add_circle-fill.svg";
 import { Svg } from "../../../Svg/Svg";
 import { getClassName } from "../../../utilities/getClassName";
+import type { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 import { type ItemLabelProps } from "../../ItemLabel/ItemLabelCommon";
 import { type ItemMessageProps } from "../../ItemMessage/ItemMessageCommon";
-import { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 
 type LabelProps = Partial<
   Omit<

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
@@ -6,6 +6,7 @@ import {
   useId,
 } from "react";
 import { getClassName } from "../../utilities/getClassName";
+import type { GridContainerProps } from "../../utilities/types/GridContainerProps";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -16,7 +17,6 @@ import {
 } from "../ItemMessage/ItemMessageCommon";
 import { InputDateAtom, type InputDateAtomProps } from "./InputDateAtom";
 import { InputDateTextAtom } from "./InputDateTextAtom";
-import { GridContainerProps } from "../../utilities/types/GridContainerProps";
 
 export type InputDateProps = Omit<
   ComponentPropsWithRef<"input">,

--- a/packages/canopee-react/src/prospect-client/Form/InputPhone/CountryCodeSelect.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputPhone/CountryCodeSelect.tsx
@@ -1,7 +1,7 @@
-import { ComponentProps, ComponentType, useState } from "react";
-import Select, { SingleValue } from "react-select";
-import { OptionType } from "./InputPhone.types";
+import { type ComponentProps, type ComponentType, useState } from "react";
+import Select, { type SingleValue } from "react-select";
 import { Icon } from "../../Icon/IconCommon";
+import type { OptionType } from "./InputPhone.types";
 
 const CountryCodeSelect = ({
   options,

--- a/packages/canopee-react/src/prospect-client/Form/InputPhone/InputPhoneCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputPhone/InputPhoneCommon.tsx
@@ -6,8 +6,9 @@ import {
   forwardRef,
   useId,
 } from "react";
-import { SingleValue } from "react-select";
+import type { SingleValue } from "react-select";
 import { Icon } from "../../Icon/IconCommon";
+import type { GridContainerProps } from "../../utilities/types/GridContainerProps";
 import { InputTextAtom } from "../InputTextAtom/InputTextAtomCommon";
 import {
   ItemLabelCommon,
@@ -20,7 +21,6 @@ import {
 import { CountryCodeSelect } from "./CountryCodeSelect";
 import { type OptionType } from "./InputPhone.types";
 import { maskFrenchPhoneNumber } from "./maskFrenchPhoneNumber";
-import { GridContainerProps } from "../../utilities/types/GridContainerProps";
 
 export type InputPhoneProps = ComponentPropsWithRef<"input"> & {
   classModifier?: string;

--- a/packages/canopee-react/src/prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupCommon.tsx
@@ -5,12 +5,12 @@ import {
   type ReactNode,
   useId,
 } from "react";
+import type { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 import {
   ItemMessage,
   type ItemMessageProps,
 } from "../../ItemMessage/ItemMessageCommon";
 import { type CardRadioOptionProps } from "../CardRadioOption/CardRadioOptionCommon";
-import { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 
 type RadioOption = Omit<CardRadioOptionProps, "name" | "type" | "isInvalid">;
 

--- a/packages/canopee-react/src/prospect-client/Form/TextArea/TextAreaCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/TextArea/TextAreaCommon.tsx
@@ -1,10 +1,11 @@
 import {
   type ComponentProps,
-  ComponentPropsWithRef,
+  type ComponentPropsWithRef,
   type ComponentType,
   forwardRef,
   useId,
 } from "react";
+import type { GridContainerProps } from "../../utilities/types/GridContainerProps";
 import {
   ItemLabelCommon,
   type ItemLabelProps,
@@ -13,7 +14,6 @@ import {
   ItemMessage,
   type ItemMessageProps,
 } from "../ItemMessage/ItemMessageCommon";
-import { GridContainerProps } from "../../utilities/types/GridContainerProps";
 
 export type TextAreaProps = ComponentPropsWithRef<"textarea"> & {
   label?: ItemLabelProps["children"];

--- a/packages/canopee-react/src/prospect-client/Heading/HeadingApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Heading/HeadingApollo.tsx
@@ -1,8 +1,8 @@
 import "@axa-fr/canopee-css/prospect/Heading/HeadingApollo.css";
 
-import { DEFAULT_TAG_PROPS, HeadingCommon } from "./HeadingCommon";
 import { Tag } from "../Tag/TagApollo";
-import { HeadingProps } from "./types";
+import { DEFAULT_TAG_PROPS, HeadingCommon } from "./HeadingCommon";
+import type { HeadingProps } from "./types";
 
 export type { HeadingLevel, HeadingProps } from "./types";
 

--- a/packages/canopee-react/src/prospect-client/Heading/HeadingLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Heading/HeadingLF.tsx
@@ -1,8 +1,8 @@
 import "@axa-fr/canopee-css/client/Heading/HeadingLF.css";
 
-import { DEFAULT_TAG_PROPS, HeadingCommon } from "./HeadingCommon";
 import { Tag } from "../Tag/TagLF";
-import { HeadingProps } from "./types";
+import { DEFAULT_TAG_PROPS, HeadingCommon } from "./HeadingCommon";
+import type { HeadingProps } from "./types";
 
 export type { HeadingLevel, HeadingProps } from "./types";
 

--- a/packages/canopee-react/src/prospect-client/Heading/__tests__/Heading.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Heading/__tests__/Heading.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react";
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { DEFAULT_TAG_PROPS, HeadingCommon } from "../HeadingCommon";
 import { Tag } from "../../Tag/TagCommon";
-import { HeadingLevel } from "../types";
+import { DEFAULT_TAG_PROPS, HeadingCommon } from "../HeadingCommon";
+import type { HeadingLevel } from "../types";
 
 describe("Heading", () => {
   it("should render correctly h1 by default", () => {

--- a/packages/canopee-react/src/prospect-client/Icon/IconCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Icon/IconCommon.tsx
@@ -1,6 +1,6 @@
-import { ComponentProps, useMemo } from "react";
-import { getComponentClassName } from "../utilities/getComponentClassName";
+import { type ComponentProps, useMemo } from "react";
 import { Svg } from "../Svg/Svg";
+import { getComponentClassName } from "../utilities/getComponentClassName";
 
 export const iconVariants = {
   primary: "primary",

--- a/packages/canopee-react/src/prospect-client/ItemTabBar/ItemTabBarCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/ItemTabBar/ItemTabBarCommon.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { type ComponentPropsWithRef, forwardRef } from "react";
 import { getComponentClassName } from "../utilities/getComponentClassName";
 
 export type ItemTabBarProps = ComponentPropsWithRef<"button"> & {

--- a/packages/canopee-react/src/prospect-client/Layout/ExitLayout/ExitLayoutCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Layout/ExitLayout/ExitLayoutCommon.tsx
@@ -1,14 +1,14 @@
 import "@axa-fr/canopee-css/prospect/Layout/ExitLayout/ExitLayoutAll.css";
 import {
   Children,
-  ComponentType,
+  type ComponentType,
   isValidElement,
   type PropsWithChildren,
 } from "react";
-import { useIsSmallScreen } from "../../utilities/hook/useIsSmallScreen";
-import { BREAKPOINT } from "../../utilities/constants";
 import { type HeadingProps } from "../../Heading/types";
 import { type IconProps } from "../../Icon/IconCommon";
+import { BREAKPOINT } from "../../utilities/constants";
+import { useIsSmallScreen } from "../../utilities/hook/useIsSmallScreen";
 
 export type ExitLayoutProps = PropsWithChildren & {
   headingProps?: HeadingProps;

--- a/packages/canopee-react/src/prospect-client/Layout/Footer/FooterCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Layout/Footer/FooterCommon.tsx
@@ -1,9 +1,9 @@
 import expandMore from "@material-symbols/svg-400/outlined/keyboard_arrow_down.svg";
 import classNames from "classnames";
 import { useCallback, useState } from "react";
-import { MenuIcons, SocialMedia } from "./MenuIcons";
-import { Link, MenuLink } from "./MenuLink";
 import { Svg } from "../../Svg/Svg";
+import { MenuIcons, type SocialMedia } from "./MenuIcons";
+import { type Link, MenuLink } from "./MenuLink";
 
 export type FooterProps = {
   links: Link[];

--- a/packages/canopee-react/src/prospect-client/Layout/FormLayout/__tests__/FormLayout.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Layout/FormLayout/__tests__/FormLayout.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import type { GridContainerProps } from "../../../../client";
 import { FormLayout } from "../FormLayout";
-import { GridContainerProps } from "../../../../client";
 
 describe("FormLayout", () => {
   describe("Rendering", () => {

--- a/packages/canopee-react/src/prospect-client/LevelSelector/LevelSelectorCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/LevelSelector/LevelSelectorCommon.tsx
@@ -1,8 +1,8 @@
 import add from "@material-symbols/svg-400/rounded/add-fill.svg";
 import remove from "@material-symbols/svg-400/rounded/remove-fill.svg";
-import { ComponentProps, ComponentType, useId } from "react";
-import { ClickIcon } from "../ClickIcon/ClickIconCommon";
+import { type ComponentProps, type ComponentType, useId } from "react";
 import { CardCommon } from "../Card/CardCommon";
+import { ClickIcon } from "../ClickIcon/ClickIconCommon";
 
 export type LevelSelectorProps = {
   title: string;

--- a/packages/canopee-react/src/prospect-client/Link/LinkCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Link/LinkCommon.tsx
@@ -1,8 +1,8 @@
 import openInNew from "@material-symbols/svg-400/outlined/open_in_new.svg";
-import {
+import type {
   ComponentPropsWithoutRef,
   PropsWithChildren,
-  type ReactNode,
+  ReactNode,
 } from "react";
 import { Svg } from "../Svg/Svg";
 import { getClassName } from "../utilities/getClassName";

--- a/packages/canopee-react/src/prospect-client/List/ClickItem/ClickItemWrapper.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ClickItem/ClickItemWrapper.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import type { HTMLAttributes } from "react";
 
 type ClickItemWrapperProps = HTMLAttributes<HTMLElement> & {
   isClickable?: boolean;

--- a/packages/canopee-react/src/prospect-client/List/ClickItem/components/ClickItemContentCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ClickItem/components/ClickItemContentCommon.tsx
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import type { ComponentType } from "react";
 import type { TagProps } from "../../../Tag/TagCommon";
 
 export type ClickItemContentProps = {

--- a/packages/canopee-react/src/prospect-client/List/ClickItem/components/ClickItemSuffixCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/ClickItem/components/ClickItemSuffixCommon.tsx
@@ -1,8 +1,8 @@
-import { ComponentProps, ComponentType } from "react";
 import keyboardArrowRight from "@material-symbols/svg-400/rounded/keyboard_arrow_right-fill.svg";
+import type { ComponentProps, ComponentType } from "react";
 import type { IconProps } from "../../../Icon/IconCommon";
-import { ClickItemStates, ClickItemVariants } from "../ClickItemCommon";
 import { Spinner } from "../../../Spinner/SpinnerCommon";
+import type { ClickItemStates, ClickItemVariants } from "../ClickItemCommon";
 
 export type ClickItemSuffixProps = {
   state: ClickItemStates;

--- a/packages/canopee-react/src/prospect-client/List/List/ListCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/List/List/ListCommon.tsx
@@ -1,4 +1,4 @@
-import { Children, ComponentProps, ComponentType } from "react";
+import { Children, type ComponentProps, type ComponentType } from "react";
 import {
   CardCommon as Card,
   type CardCommonProps,

--- a/packages/canopee-react/src/prospect-client/Pagination/PaginationCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Pagination/PaginationCommon.tsx
@@ -1,15 +1,15 @@
-import {
-  ComponentProps,
-  ComponentType,
-  type ComponentPropsWithoutRef,
-} from "react";
 import chevronBackward from "@material-symbols/svg-400/rounded/chevron_backward.svg";
 import chevronForward from "@material-symbols/svg-400/rounded/chevron_forward.svg";
-import { getClassName } from "../utilities/getClassName";
+import type {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  ComponentType,
+} from "react";
 import { ClickIcon } from "../ClickIcon/ClickIconCommon";
+import { getClassName } from "../utilities/getClassName";
 import {
-  ItemPaginationCommon,
   ELLIPSIS,
+  ItemPaginationCommon,
 } from "./ItemPagination/ItemPaginationCommon";
 import { getItems, type getItemsProps } from "./Pagination.helper";
 

--- a/packages/canopee-react/src/prospect-client/ProgressBarGroup/ProgressBarGroupApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/ProgressBarGroup/ProgressBarGroupApollo.tsx
@@ -2,7 +2,7 @@ import "@axa-fr/canopee-css/prospect/ProgressBarGroup/ProgressBarGroupApollo.css
 import { ProgressBar } from "../ProgressBar/ProgressBarApollo";
 import {
   ProgressBarGroupCommon,
-  ProgressBarGroupProps,
+  type ProgressBarGroupProps,
 } from "./ProgressBarGroupCommon";
 
 export const ProgressBarGroup = (props: ProgressBarGroupProps) => (

--- a/packages/canopee-react/src/prospect-client/ProgressBarGroup/ProgressBarGroupLF.tsx
+++ b/packages/canopee-react/src/prospect-client/ProgressBarGroup/ProgressBarGroupLF.tsx
@@ -2,7 +2,7 @@ import "@axa-fr/canopee-css/client/ProgressBarGroup/ProgressBarGroupLF.css";
 import { ProgressBar } from "../ProgressBar/ProgressBarLF";
 import {
   ProgressBarGroupCommon,
-  ProgressBarGroupProps,
+  type ProgressBarGroupProps,
 } from "./ProgressBarGroupCommon";
 
 export const ProgressBarGroup = (props: ProgressBarGroupProps) => (

--- a/packages/canopee-react/src/prospect-client/Spinner/SpinnerCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Spinner/SpinnerCommon.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 
 export const spinnerVariants = {
   blue: "blue",

--- a/packages/canopee-react/src/prospect-client/Stepper/StepperCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/StepperCommon.tsx
@@ -1,5 +1,5 @@
 import {
-  ComponentType,
+  type ComponentType,
   type ElementType,
   type HTMLAttributes,
   useId,

--- a/packages/canopee-react/src/prospect-client/Stepper/__tests__/StepperCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/__tests__/StepperCommon.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { ItemMessageProps } from "../../Form/ItemMessage/ItemMessageCommon";
+import type { ItemMessageProps } from "../../Form/ItemMessage/ItemMessageCommon";
 import { ProgressBarGroup } from "../../ProgressBarGroup/ProgressBarGroupApollo";
 import { StepperCommon } from "../StepperCommon";
 

--- a/packages/canopee-react/src/prospect-client/TabBar/TabBarCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/TabBar/TabBarCommon.tsx
@@ -1,12 +1,12 @@
+import classNames from "classnames";
 import {
-  ComponentProps,
-  ComponentType,
-  ReactNode,
+  type ComponentProps,
+  type ComponentType,
+  type ReactNode,
   useCallback,
   useRef,
   useState,
 } from "react";
-import classNames from "classnames";
 import {
   ItemTabBar,
   type ItemTabBarProps,

--- a/packages/canopee-react/src/prospect-client/Table/TBody.tsx
+++ b/packages/canopee-react/src/prospect-client/Table/TBody.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 import { getClassName } from "../utilities/getClassName";
 
 export type BodyColorVariants = "white" | "blue" | "alternate";

--- a/packages/canopee-react/src/prospect-client/Table/Td.tsx
+++ b/packages/canopee-react/src/prospect-client/Table/Td.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 import { getClassName } from "../utilities/getClassName";
 
 export type CellContentPositionVariants = "left" | "center" | "right";

--- a/packages/canopee-react/src/prospect-client/Tag/__test__/Tag.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Tag/__test__/Tag.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { Tag, TagVariants } from "../TagCommon";
+import { Tag, type TagVariants } from "../TagCommon";
 
 describe("Tag", () => {
   it("should render children correctly", () => {

--- a/packages/canopee-react/src/prospect-client/TimelineVertical/TimelineVerticalCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/TimelineVertical/TimelineVerticalCommon.tsx
@@ -1,5 +1,5 @@
-import { PropsWithChildren, ReactNode } from "react";
 import classNames from "classnames";
+import type { PropsWithChildren, ReactNode } from "react";
 
 export type TimelineVerticalProps = PropsWithChildren<{
   title: string;

--- a/packages/canopee-react/src/prospect-client/TimelineVertical/types.ts
+++ b/packages/canopee-react/src/prospect-client/TimelineVertical/types.ts
@@ -1,4 +1,4 @@
-import { TagProps } from "../Tag/TagCommon";
+import type { TagProps } from "../Tag/TagCommon";
 import type { TimelineVerticalProps as TimelineVerticalCommonProps } from "./TimelineVerticalCommon";
 
 export type TimelineVerticalProps = TimelineVerticalCommonProps & {

--- a/packages/canopee-react/src/prospect-client/utilities/types/GridContainerProps.ts
+++ b/packages/canopee-react/src/prospect-client/utilities/types/GridContainerProps.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, ElementType } from "react";
+import type { ComponentProps, ElementType } from "react";
 
 type Cols = `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12}`;
 

--- a/packages/canopee-react/tsconfig.json
+++ b/packages/canopee-react/tsconfig.json
@@ -31,7 +31,7 @@
     // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+    "moduleDetection": "force", /* Control what method is used to detect module-format JS files. */
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
     "moduleResolution": "Bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
@@ -83,7 +83,7 @@
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
     /* Interop Constraints */
     "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "verbatimModuleSyntax": true, /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */


### PR DESCRIPTION
Now, we get a build error if a type is imported without using `import type`