### PR TITLE
fix(client,prospect): update blue-80 color tokens to blue-080

### DIFF
--- a/packages/canopee-css/src/prospect-client/Button/ButtonApollo.css
+++ b/packages/canopee-css/src/prospect-client/Button/ButtonApollo.css
@@ -129,7 +129,7 @@
 }
 
 .af-btn-client--tertiary {
-  --button-bg-color: var(--blue-80);
+  --button-bg-color: var(--blue-080);
   --button-text-color: var(--blue-1000);
 
   &:hover,

--- a/packages/canopee-css/src/prospect-client/Button/ButtonLF.css
+++ b/packages/canopee-css/src/prospect-client/Button/ButtonLF.css
@@ -132,7 +132,7 @@
 }
 
 .af-btn-client--tertiary {
-  --button-bg-color: var(--blue-80);
+  --button-bg-color: var(--blue-080);
   --button-text-color: var(--blue-1000);
 
   &:hover {

--- a/packages/canopee-css/src/prospect-client/CardMessage/CardMessageLF.css
+++ b/packages/canopee-css/src/prospect-client/CardMessage/CardMessageLF.css
@@ -6,7 +6,7 @@
 }
 
 .af-card-message--info {
-  --card-message-background-color: var(--blue-80);
+  --card-message-background-color: var(--blue-080);
   --card-message-text-color: var(--blue-1000);
   --card-message-border-color: var(--blue-1000);
 }

--- a/packages/canopee-css/src/prospect-client/ClickIcon/ClickIconApollo.css
+++ b/packages/canopee-css/src/prospect-client/ClickIcon/ClickIconApollo.css
@@ -1,7 +1,7 @@
 @import "./ClickIconCommon.css";
 
 .af-click-icon {
-  --click-icon-background-color: var(--blue-80);
+  --click-icon-background-color: var(--blue-080);
 
   &:hover {
     --click-icon-background-color: var(--blue-1200);

--- a/packages/canopee-css/src/prospect-client/ClickIcon/ClickIconLF.css
+++ b/packages/canopee-css/src/prospect-client/ClickIcon/ClickIconLF.css
@@ -1,7 +1,7 @@
 @import "./ClickIconCommon.css";
 
 .af-click-icon {
-  --click-icon-background-color: var(--blue-80);
+  --click-icon-background-color: var(--blue-080);
 
   &:hover {
     --click-icon-background-color: var(--blue-100);

--- a/packages/canopee-css/src/prospect-client/Toggle/ToggleLF.css
+++ b/packages/canopee-css/src/prospect-client/Toggle/ToggleLF.css
@@ -1,7 +1,7 @@
 @import "./ToggleCommon.css";
 
 .af-toggle {
-  --toggle-bg-color: var(--blue-80);
+  --toggle-bg-color: var(--blue-080);
   --toggle-border-color: var(--gray-800);
   --toggle-focus-outline-color: var(--blue-1000);
   --toggle-border-radius: var(--radius-32);

--- a/packages/canopee-css/src/prospect-client/common/tokens.css
+++ b/packages/canopee-css/src/prospect-client/common/tokens.css
@@ -71,8 +71,8 @@
   --axa-blue-20: var(--blue-200);
   --color-blue-400: var(--blue-200);
   --color-btn-tertiary-bg-darker: var(--blue-100);
-  --color-blue-200: var(--blue-80);
-  --color-btn-tertiary-bg: var(--blue-80);
+  --color-blue-200: var(--blue-080);
+  --color-btn-tertiary-bg: var(--blue-080);
   --axa-blue-8: var(--blue-080);
   --axa-blue-4: var(--blue-040);
   --color-blue-2: var(--blue-040);


### PR DESCRIPTION
This pull request updates several CSS files to use the corrected `--blue-080` variable instead of `--blue-80` for background colors and related tokens. The main goal is to ensure consistency in color naming and usage across the codebase.

**Color variable corrections:**

* Updated the background color variable in `.af-btn-client--tertiary` for both `ButtonApollo.css` and `ButtonLF.css` to use `--blue-080` instead of `--blue-80`. [[1]](diffhunk://#diff-b88ad7e3d6dd2a587b1ced95e3b9cc69e2d01343144f750d4207eac8693fc9d2L132-R132) [[2]](diffhunk://#diff-48abeb954ae854a2beaf483e233b444161d455075e8340df55da7a1d1ed74157L135-R135)
* Changed `.af-card-message--info` background color in `CardMessageLF.css` to use `--blue-080`.
* Updated `.af-click-icon` background color in both `ClickIconApollo.css` and `ClickIconLF.css` to use `--blue-080`. [[1]](diffhunk://#diff-cbbd66f6a470f42ef55a46936799f0f851727cea0fc953b720118d5c43c1a4a3L4-R4) [[2]](diffhunk://#diff-6cd76036d6d7d3a2824017a7c0f02db408dffb3b5f2868074462e5a57443cfc8L4-R4)
* Modified `.af-toggle` background color in `ToggleLF.css` to use `--blue-080`.

**Token variable updates:**

* Changed `--color-blue-200` and `--color-btn-tertiary-bg` in `tokens.css` to use `--blue-080`, ensuring consistent token values.