### PR TITLE
feat(client,prospect): use ChexkboxText in CardCheckbox

### DIFF
--- a/apps/apollo-stories/src/components/CardCheckbox/CardCheckbox.mdx
+++ b/apps/apollo-stories/src/components/CardCheckbox/CardCheckbox.mdx
@@ -44,9 +44,49 @@ const MyComponent = () => (
 
 ## Playground
 
-The CardCheckbox component has 2 modes: `vertical` (default) and `horizontal`.
+The CardCheckbox component has 2 types: `vertical` (default) and `horizontal`.
 You can see them in action in the stories below.
 
 <Canvas of={CardCheckboxStories.CardCheckboxStory} />
 
 <Controls of={CardCheckboxStories.CardCheckboxStory} />
+
+## CardCheckbox with CheckboxText
+
+The CardCheckbox component can also use the CheckboxText for the options.
+You have to set the `mode` prop to `text` and provide the options with the `description` and `subtitle` properties.
+
+```tsx
+import { CardCheckbox } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <CardCheckbox
+    type="vertical"
+    name="city"
+    label="Choisissez des villes"
+    mode="text"
+    options={[
+      {
+        label: "Paris",
+        value: "paris",
+        description: "Capitale de la France",
+        subtitle: "Nord",
+      },
+      {
+        label: "Bruxelles",
+        value: "bruxelles",
+        description: "Capitale de la Belgique",
+      },
+      {
+        label: "Lille",
+        value: "lille",
+        checked: true,
+      },
+    ]}
+  />
+);
+```
+
+<Canvas of={CardCheckboxStories.CardCheckboxTextStory} />
+
+<Controls of={CardCheckboxStories.CardCheckboxTextStory} />

--- a/apps/apollo-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
+++ b/apps/apollo-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
@@ -90,7 +90,7 @@ const meta: Meta = {
     name: "name",
     options: optionsDefault,
     required: false,
-    error: "",
+    messageType: "",
     message: "",
   },
 };
@@ -100,13 +100,45 @@ export default meta;
 export const CardCheckboxStory: StoryObj<ComponentProps<typeof CardCheckbox>> =
   {
     name: "Playground",
-    render: ({ description, error, name, type, ...args }) => (
+    render: ({ description, name, type, ...args }) => (
       <CardCheckbox
         {...args}
         description={description !== "" ? description : undefined}
-        error={error !== "" ? error : undefined}
         name={name !== "" ? name : undefined}
         type={type === "horizontal" ? type : undefined}
       />
     ),
   };
+
+const optionsCheckboxText = [
+  {
+    label: "option 1",
+    description: "description 1",
+    subtitle: "subtitle 1",
+    value: "1",
+  },
+  {
+    label: "option 2",
+    value: "2",
+  },
+  {
+    label: "option 3",
+    value: "3",
+  },
+];
+
+export const CardCheckboxTextStory: StoryObj<
+  ComponentProps<typeof CardCheckbox>
+> = {
+  name: "Card CheckboxText",
+  render: ({ description, name, type, ...args }) => (
+    <CardCheckbox
+      {...args}
+      description={description !== "" ? description : undefined}
+      name={name !== "" ? name : undefined}
+      type={type === "horizontal" ? type : undefined}
+      mode="text"
+      options={optionsCheckboxText}
+    />
+  ),
+};

--- a/apps/look-and-feel-stories/src/components/CardCheckbox/CardCheckbox.mdx
+++ b/apps/look-and-feel-stories/src/components/CardCheckbox/CardCheckbox.mdx
@@ -3,14 +3,14 @@ import * as CardCheckboxStories from "./CardCheckbox.stories";
 
 <Meta of={CardCheckboxStories} name="CardCheckbox" />
 
-## CardCheckbox components
+# CardCheckbox components
 
 ## How to use
 
 To use the `CardCheckbox`component import it like this:
 
 ```tsx
-import { CardCheckbox } from "@axa-fr/canopee-react/client";
+import { CardCheckbox } from "@axa-fr/canopee-react/prospect";
 
 const MyComponent = () => (
   <CardCheckbox
@@ -44,9 +44,49 @@ const MyComponent = () => (
 
 ## Playground
 
-The CardCheckbox component has 2 modes: `vertical` (default) and `horizontal`.
+The CardCheckbox component has 2 types: `vertical` (default) and `horizontal`.
 You can see them in action in the stories below.
 
 <Canvas of={CardCheckboxStories.CardCheckboxStory} />
 
 <Controls of={CardCheckboxStories.CardCheckboxStory} />
+
+## CardCheckbox with CheckboxText
+
+The CardCheckbox component can also use the CheckboxText for the options.
+You have to set the `mode` prop to `text` and provide the options with the `description` and `subtitle` properties.
+
+```tsx
+import { CardCheckbox } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <CardCheckbox
+    type="vertical"
+    name="city"
+    label="Choisissez des villes"
+    mode="text"
+    options={[
+      {
+        label: "Paris",
+        value: "paris",
+        description: "Capitale de la France",
+        subtitle: "Nord",
+      },
+      {
+        label: "Bruxelles",
+        value: "bruxelles",
+        description: "Capitale de la Belgique",
+      },
+      {
+        label: "Lille",
+        value: "lille",
+        checked: true,
+      },
+    ]}
+  />
+);
+```
+
+<Canvas of={CardCheckboxStories.CardCheckboxTextStory} />
+
+<Controls of={CardCheckboxStories.CardCheckboxTextStory} />

--- a/apps/look-and-feel-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
@@ -1,7 +1,7 @@
 import {
   CardCheckbox,
   itemMessageVariants,
-} from "@axa-fr/canopee-react/client";
+} from "@axa-fr/canopee-react/prospect";
 import homeIcon from "@material-symbols/svg-400/outlined/home.svg";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
@@ -90,7 +90,7 @@ const meta: Meta = {
     name: "name",
     options: optionsDefault,
     required: false,
-    error: "",
+    messageType: "",
     message: "",
   },
 };
@@ -100,13 +100,45 @@ export default meta;
 export const CardCheckboxStory: StoryObj<ComponentProps<typeof CardCheckbox>> =
   {
     name: "Playground",
-    render: ({ description, error, name, type, ...args }) => (
+    render: ({ description, name, type, ...args }) => (
       <CardCheckbox
         {...args}
         description={description !== "" ? description : undefined}
-        error={error !== "" ? error : undefined}
         name={name !== "" ? name : undefined}
         type={type === "horizontal" ? type : undefined}
       />
     ),
   };
+
+const optionsCheckboxText = [
+  {
+    label: "option 1",
+    description: "description 1",
+    subtitle: "subtitle 1",
+    value: "1",
+  },
+  {
+    label: "option 2",
+    value: "2",
+  },
+  {
+    label: "option 3",
+    value: "3",
+  },
+];
+
+export const CardCheckboxTextStory: StoryObj<
+  ComponentProps<typeof CardCheckbox>
+> = {
+  name: "Card CheckboxText",
+  render: ({ description, name, type, ...args }) => (
+    <CardCheckbox
+      {...args}
+      description={description !== "" ? description : undefined}
+      name={name !== "" ? name : undefined}
+      type={type === "horizontal" ? type : undefined}
+      mode="text"
+      options={optionsCheckboxText}
+    />
+  ),
+};

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo.tsx
@@ -1,5 +1,6 @@
 import { ItemMessage } from "../../ItemMessage/ItemMessageApollo";
 import { CardCheckboxOption } from "../CardCheckboxOption/CardCheckboxOptionApollo";
+import { CheckboxText } from "../CheckboxText/CheckboxTextApollo";
 import {
   CardCheckboxCommon,
   type CardCheckboxProps,
@@ -11,6 +12,7 @@ export const CardCheckbox = (props: CardCheckboxProps) => (
   <CardCheckboxCommon
     {...props}
     CardCheckboxItemComponent={CardCheckboxOption}
+    CheckboxTextComponent={CheckboxText}
     ItemMessageComponent={ItemMessage}
   />
 );

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.tsx
@@ -8,6 +8,7 @@ import {
 import type { GridContainerProps } from "../../../utilities/types/GridContainerProps";
 import type { ItemMessageProps } from "../../ItemMessage/ItemMessageCommon";
 import type { CardCheckboxOptionProps } from "../CardCheckboxOption/CardCheckboxOptionCommon";
+import type { CheckboxTextProps } from "../CheckboxText/CheckboxTextCommon";
 
 type CheckboxOption = Omit<CardCheckboxOptionProps, "name" | "type">;
 
@@ -16,6 +17,7 @@ export type CardCheckboxProps = Omit<
   "value" | "label" | "type" | "icon" | "description" | "subtitle" | "children"
 > & {
   type?: "vertical" | "horizontal";
+  mode?: "text";
   /**
    * @deprecated Use `label` instead.
    */
@@ -39,6 +41,7 @@ export type CardCheckboxProps = Omit<
 } & Partial<ItemMessageProps>;
 
 type CardCheckboxCommonProps = CardCheckboxProps & {
+  CheckboxTextComponent: ComponentType<CheckboxTextProps>;
   CardCheckboxItemComponent: ComponentType<CardCheckboxOptionProps>;
   ItemMessageComponent: ComponentType<ItemMessageProps>;
 };
@@ -58,15 +61,20 @@ export const CardCheckboxCommon = ({
   id,
   onChange = () => {},
   CardCheckboxItemComponent,
+  CheckboxTextComponent,
   ItemMessageComponent,
   message,
   messageType = "error",
   containerProps,
+  mode,
   ...inputProps
 }: CardCheckboxCommonProps) => {
   const generatedId = useId();
   const cardCheckboxId = id || generatedId;
   const messageId = `${cardCheckboxId}-error`;
+
+  const CheckboxItemComponent =
+    mode === "text" ? CheckboxTextComponent : CardCheckboxItemComponent;
 
   const cardCheckboxOptionsRef = useRef<HTMLDivElement>(null);
 
@@ -122,7 +130,7 @@ export const CardCheckboxCommon = ({
         ref={cardCheckboxOptionsRef}
       >
         {options.map((cardCheckboxItemProps) => (
-          <CardCheckboxItemComponent
+          <CheckboxItemComponent
             key={`${name ?? cardCheckboxId}-${cardCheckboxItemProps.label}`}
             id={`${cardCheckboxId}-${cardCheckboxItemProps.value}`}
             required={required}

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF.tsx
@@ -1,5 +1,6 @@
 import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
 import { CardCheckboxOption } from "../CardCheckboxOption/CardCheckboxOptionLF";
+import { CheckboxText } from "../CheckboxText/CheckboxTextLF";
 import {
   CardCheckboxCommon,
   type CardCheckboxProps,
@@ -11,6 +12,7 @@ export const CardCheckbox = (props: CardCheckboxProps) => (
   <CardCheckboxCommon
     {...props}
     CardCheckboxItemComponent={CardCheckboxOption}
+    CheckboxTextComponent={CheckboxText}
     ItemMessageComponent={ItemMessage}
   />
 );

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/__tests__/CardCheckbox.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/__tests__/CardCheckbox.test.tsx
@@ -11,6 +11,10 @@ import {
 } from "../../CardCheckboxOption/CardCheckboxOptionCommon";
 import { Checkbox } from "../../Checkbox/CheckboxCommon";
 import {
+  CheckboxTextCommon,
+  type CheckboxTextProps,
+} from "../../CheckboxText/CheckboxTextCommon";
+import {
   CardCheckboxCommon,
   type CardCheckboxProps,
 } from "../CardCheckboxCommon";
@@ -24,10 +28,20 @@ const CardCheckboxOption = (props: CardCheckboxOptionProps) => (
 );
 
 // eslint-disable-next-line react/no-multi-comp
+const CheckboxText = (props: CheckboxTextProps) => (
+  <CheckboxTextCommon
+    {...props}
+    CheckboxComponent={Checkbox}
+    ItemMessageComponent={ItemMessage}
+  />
+);
+
+// eslint-disable-next-line react/no-multi-comp
 const CardCheckbox = (props: CardCheckboxProps) => (
   <CardCheckboxCommon
     {...props}
     CardCheckboxItemComponent={CardCheckboxOption}
+    CheckboxTextComponent={CheckboxText}
     ItemMessageComponent={ItemMessage}
   />
 );
@@ -81,13 +95,45 @@ describe("CardCheckbox", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("should display error message when error prop is provided", () => {
+  it("should display error message when error prop is provided (deprecated)", () => {
     render(<CardCheckbox {...defaultArgs} error="Erreur obligatoire" />);
 
     const checkboxInput = screen.getByRole("checkbox", { name: /Paris/ });
 
     expect(checkboxInput).toHaveAccessibleErrorMessage("Erreur obligatoire");
     expect(checkboxInput).not.toBeValid();
+  });
+
+  it("should display error message when message prop is provided with error type", () => {
+    render(
+      <CardCheckbox
+        {...defaultArgs}
+        message="Champ obligatoire"
+        messageType="error"
+      />,
+    );
+
+    const parisCheckbox = screen.getByRole("checkbox", { name: /Paris/ });
+    const londresCheckbox = screen.getByRole("checkbox", { name: /Londres/ });
+
+    expect(parisCheckbox).toHaveAccessibleErrorMessage("Champ obligatoire");
+    expect(parisCheckbox).not.toBeValid();
+    expect(londresCheckbox).toHaveAccessibleErrorMessage("Champ obligatoire");
+    expect(londresCheckbox).not.toBeValid();
+  });
+
+  it("should not mark checkboxes as invalid when messageType is not error", () => {
+    render(
+      <CardCheckbox
+        {...defaultArgs}
+        message="Information"
+        messageType="success"
+      />,
+    );
+
+    const parisCheckbox = screen.getByRole("checkbox", { name: /Paris/ });
+
+    expect(parisCheckbox).toBeValid();
   });
 
   it("should display description and label when provided", () => {
@@ -141,6 +187,16 @@ describe("CardCheckbox", () => {
     ).not.toBeRequired();
   });
 
+  it("should render CheckboxText components when mode is text", () => {
+    render(<CardCheckbox {...defaultArgs} mode="text" />);
+
+    expect(screen.getByRole("checkbox", { name: /Paris/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: /Londres/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+  });
+
   it("should display message with error type by default", () => {
     render(<CardCheckbox {...defaultArgs} message="Error message" />);
 
@@ -150,5 +206,20 @@ describe("CardCheckbox", () => {
     expect(
       screen.getByRole("checkbox", { name: /Londres/ }),
     ).toHaveAccessibleErrorMessage("Error message");
+  });
+
+  it("should set aria-invalid and aria-errormessage directly on checkboxes", () => {
+    render(
+      <CardCheckbox
+        {...defaultArgs}
+        message="Erreur directe"
+        messageType="error"
+      />,
+    );
+
+    const parisCheckbox = screen.getByRole("checkbox", { name: /Paris/ });
+
+    expect(parisCheckbox).toHaveAttribute("aria-invalid", "true");
+    expect(parisCheckbox).toHaveAttribute("aria-errormessage");
   });
 });

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckboxOption/__tests__/CardCheckboxOption.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckboxOption/__tests__/CardCheckboxOption.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import userEvent from "@testing-library/user-event";
 import { Icon } from "../../../../Icon/IconCommon";
 import { Checkbox } from "../../Checkbox/CheckboxCommon";
 import {
@@ -34,10 +36,104 @@ describe("CardCheckboxOptionCommon", () => {
     expect(screen.getByText("Test Description")).toBeInTheDocument();
   });
 
+  it("should not render the description if not provided", () => {
+    const { container } = render(
+      <CardCheckboxOption label="Label" name="test" />,
+    );
+    expect(
+      container.querySelector(".af-card-checkbox-option__description"),
+    ).not.toBeInTheDocument();
+  });
+
   it("should render the subtitle if provided", () => {
     render(
       <CardCheckboxOption label="Label" subtitle="Test Subtitle" name="test" />,
     );
     expect(screen.getByText("Test Subtitle")).toBeInTheDocument();
+  });
+
+  it("should not render the subtitle if not provided", () => {
+    const { container } = render(
+      <CardCheckboxOption label="Label" name="test" />,
+    );
+    expect(
+      container.querySelector(".af-card-checkbox-option__subtitle"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render an icon when icon prop is provided", () => {
+    render(<CardCheckboxOption label="Label" icon="check" name="test" />);
+    expect(screen.getByRole("presentation")).toBeInTheDocument();
+  });
+
+  it("should not render an icon when icon prop is not provided", () => {
+    render(<CardCheckboxOption label="Label" name="test" />);
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+  });
+
+  it("should apply horizontal class when type is horizontal", () => {
+    const { container } = render(
+      <CardCheckboxOption label="Label" type="horizontal" name="test" />,
+    );
+    expect(container.firstChild).toHaveClass(
+      "af-card-checkbox-option--horizontal",
+    );
+  });
+
+  it("should not apply horizontal class when type is vertical", () => {
+    const { container } = render(
+      <CardCheckboxOption label="Label" type="vertical" name="test" />,
+    );
+    expect(container.firstChild).not.toHaveClass(
+      "af-card-checkbox-option--horizontal",
+    );
+  });
+
+  it("should merge custom className", () => {
+    const { container } = render(
+      <CardCheckboxOption label="Label" className="custom" name="test" />,
+    );
+    expect(container.firstChild).toHaveClass("af-card-checkbox-option");
+    expect(container.firstChild).toHaveClass("custom");
+  });
+
+  it("should forward ref to the input element", () => {
+    const ref = createRef<HTMLInputElement>();
+    render(
+      <CardCheckboxOptionCommon
+        ref={ref}
+        label="Label"
+        name="test"
+        CheckboxComponent={Checkbox}
+        IconComponent={Icon}
+      />,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current?.type).toBe("checkbox");
+  });
+
+  it("should toggle checked state on click", async () => {
+    const user = userEvent.setup();
+    render(<CardCheckboxOption label="Label" name="test" />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should pass input props to the checkbox", () => {
+    render(
+      <CardCheckboxOption
+        label="Label"
+        name="test"
+        defaultChecked
+        aria-describedby="help-text"
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toHaveAttribute("aria-describedby", "help-text");
   });
 });


### PR DESCRIPTION
let use CheckboxText in CardCheckbox

<img width="162" height="184" alt="image" src="https://github.com/user-attachments/assets/787c717c-44c2-4a51-9158-02d4a7ecbeb6" />
