### PR TITLE
fix(client,prospect): remove min-width on input atom

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.css
@@ -17,6 +17,7 @@
 
   > input {
     all: unset;
+    min-width: 0;
     padding: var(--rem-16);
     font-size: var(--rem-16);
     font-weight: 600;


### PR DESCRIPTION
This pull request makes a minor update to the input styling in `InputTextAtomCommon.css` by setting a minimum width of 0 on input elements. This helps prevent responsive issue because by default the input has a default min-width.

Before : 

<img width="491" height="221" alt="image" src="https://github.com/user-attachments/assets/edb37784-6c84-4249-8688-9aae360464ae" />

After : 

<img width="476" height="231" alt="image" src="https://github.com/user-attachments/assets/f795dfcd-30a2-46c6-8dfe-47f0e6d178a4" />
