### PR TITLE
fix(client): delete modal-client divider (#1707)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Modal/ModalApollo.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalApollo.css
@@ -9,7 +9,6 @@
   --modal-default-padding: var(--rem-24);
   --modal-header-gap: var(--rem-16);
   --modal-header-bottom-padding: var(--rem-24);
-  --modal-header-border-bottom: none;
   --modal-body-padding-top: var(--modal-default-padding);
   --modal-body-padding-bottom: var(--modal-default-padding);
   --modal-body-gap: var(--modal-default-padding);

--- a/packages/canopee-css/src/prospect-client/Modal/ModalCommon.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalCommon.css
@@ -1,6 +1,7 @@
 .af-modal {
   --modal-transition-duration: 0.2s;
   --modal-max-height: calc(100vh - 5rem);
+  --modal-footer-border-top: none;
 
   width: 100%;
   max-width: 100vw;

--- a/packages/canopee-css/src/prospect-client/Modal/ModalCommon.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalCommon.css
@@ -1,7 +1,6 @@
 .af-modal {
   --modal-transition-duration: 0.2s;
   --modal-max-height: calc(100vh - 5rem);
-  --modal-footer-border-top: none;
 
   width: 100%;
   max-width: 100vw;
@@ -89,7 +88,6 @@
   display: grid;
   padding: var(--modal-default-padding);
   padding-block-end: var(--modal-header-bottom-padding);
-  border-bottom: var(--modal-header-border-bottom);
   grid-template-areas: "headertitle closebtn";
   grid-template-columns: 1fr auto;
   gap: var(--modal-header-gap);

--- a/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
@@ -32,6 +32,7 @@
     --modal-body-padding-bottom: var(--rem-16);
 
     :has(.af-modal__body-vertical-scroll) {
+      --modal-footer-border-top: none;
       --modal-footer-vertical-padding: var(--rem-16);
       --modal-footer-horizontal-padding: var(--rem-16);
     }

--- a/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
@@ -10,7 +10,6 @@
   --modal-default-padding: var(--rem-16);
   --modal-header-gap: var(--rem-24);
   --modal-header-bottom-padding: var(--modal-default-padding);
-  --modal-header-border-bottom: none;
   --modal-body-padding-top: var(--rem-24);
   --modal-body-padding-bottom: var(--modal-default-padding);
   --modal-body-gap: var(--rem-32);
@@ -19,7 +18,6 @@
   --modal-footer-gap: var(--modal-default-padding);
 
   :has(.af-modal__body-vertical-scroll) {
-    --modal-footer-border-top: none;
     --modal-footer-vertical-padding: var(--rem-12);
     --modal-footer-horizontal-padding: var(--rem-16);
   }
@@ -33,7 +31,6 @@
     --modal-body-padding-bottom: var(--rem-16);
 
     :has(.af-modal__body-vertical-scroll) {
-      --modal-footer-border-top: none;
       --modal-footer-vertical-padding: var(--rem-16);
       --modal-footer-horizontal-padding: var(--rem-16);
     }

--- a/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
@@ -10,7 +10,7 @@
   --modal-default-padding: var(--rem-16);
   --modal-header-gap: var(--rem-24);
   --modal-header-bottom-padding: var(--modal-default-padding);
-  --modal-header-border-bottom: 1px solid var(--blue-200);
+  --modal-header-border-bottom: none;
   --modal-body-padding-top: var(--rem-24);
   --modal-body-padding-bottom: var(--modal-default-padding);
   --modal-body-gap: var(--rem-32);
@@ -19,7 +19,7 @@
   --modal-footer-gap: var(--modal-default-padding);
 
   :has(.af-modal__body-vertical-scroll) {
-    --modal-footer-border-top: 1px solid var(--blue-200);
+    --modal-footer-border-top: none;
     --modal-footer-vertical-padding: var(--rem-12);
     --modal-footer-horizontal-padding: var(--rem-16);
   }

--- a/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
@@ -18,6 +18,7 @@
   --modal-footer-gap: var(--modal-default-padding);
 
   :has(.af-modal__body-vertical-scroll) {
+    --modal-footer-border-top: 1px solid var(--blue-200);
     --modal-footer-vertical-padding: var(--rem-12);
     --modal-footer-horizontal-padding: var(--rem-16);
   }


### PR DESCRIPTION
Cette PR concerne le retrait du divider de la Modal Client comme mentionné dans l'issue #1707 

Les fichiers concernés par cet ajustement sont les suivants :

- packages/canopee-css/src/prospect-client/Modal/ModalLF.css
- packages/canopee-css/src/prospect-client/Modal/ModalApollo.css
- packages/canopee-css/src/prospect-client/Modal/ModalCommon.css