### PR TITLE
fix(prospect): change icon padding to 8px (#1747)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Icon/IconApollo.css
+++ b/packages/canopee-css/src/prospect-client/Icon/IconApollo.css
@@ -5,7 +5,7 @@
 }
 
 .af-icon--small.af-icon--has-background {
-  --icon-padding: var(--rem-12);
+  --icon-padding: var(--rem-8);
 }
 
 .af-icon--secondary.af-icon--has-background {


### PR DESCRIPTION
Cette PR concerne l'ajustement apporté sur la taille et le padding du composant Icon, comme mentionné dans l'issue #1747 .

- Fichier concerné par cet ajustement : IconApollo.css 

Passer à une taille d'icon de 40x40px -> ajustement du padding à 8px comme ci dessous :

`
.af-icon--small.af-icon--has-background {
  --icon-padding: var(--rem-8);
}
`