### PR TITLE
chore(canopee): add autoAcceptChanges to Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,6 +27,7 @@ jobs:
           workingDir: "apps/slash-stories"
           onlyChanged: true
           skip: "@(renovate/**|dependabot/**)"
+          autoAcceptChanges: "main"
 
       - uses: chromaui/action@4c20b95e9d3209ecfdf9cd6aace6bbde71ba1694 # v13.3.4
         name: Run Chromatic for design-system-lookandfeel-react
@@ -37,6 +38,7 @@ jobs:
           workingDir: "apps/look-and-feel-stories"
           onlyChanged: true
           skip: "@(renovate/**|dependabot/**)"
+          autoAcceptChanges: "main"
       - uses: chromaui/action@4c20b95e9d3209ecfdf9cd6aace6bbde71ba1694 # v13.3.4
         name: Run Chromatic for design-system-apollo-react
         with:
@@ -46,3 +48,4 @@ jobs:
           workingDir: "apps/apollo-stories"
           onlyChanged: true
           skip: "@(renovate/**|dependabot/**)"
+          autoAcceptChanges: "main"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,6 +27,7 @@ jobs:
           workingDir: "apps/slash-stories"
           onlyChanged: true
           skip: "@(renovate/**|dependabot/**)"
+          autoAcceptChanges: "main"
 
       - uses: chromaui/action@1db61b73b7919508ee8e62336f04bd0aed6da756 # v17.4.1
         name: Run Chromatic for design-system-lookandfeel-react
@@ -37,6 +38,7 @@ jobs:
           workingDir: "apps/look-and-feel-stories"
           onlyChanged: true
           skip: "@(renovate/**|dependabot/**)"
+          autoAcceptChanges: "main"
       - uses: chromaui/action@1db61b73b7919508ee8e62336f04bd0aed6da756 # v17.4.1
         name: Run Chromatic for design-system-apollo-react
         with:
@@ -46,3 +48,4 @@ jobs:
           workingDir: "apps/apollo-stories"
           onlyChanged: true
           skip: "@(renovate/**|dependabot/**)"
+          autoAcceptChanges: "main"


### PR DESCRIPTION
This pull request updates the Chromatic workflow configuration to automatically accept visual changes on the `main` branch for multiple Storybook applications. This streamlines the process of updating visual snapshots, reducing manual intervention when changes are merged to `main`.

Workflow configuration improvements:

* Added the `autoAcceptChanges: "main"` option to the Chromatic steps for the following Storybook applications, ensuring visual changes are auto-accepted on the `main` branch: `slash-stories` [[1]](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bR30) `look-and-feel-stories` [[2]](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bR41) and `apollo-stories` [[3]](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bR51).