### PR TITLE
fix(prospect): align button mobile height to 56px

### DIFF
--- a/packages/canopee-css/src/prospect-client/Button/ButtonApollo.css
+++ b/packages/canopee-css/src/prospect-client/Button/ButtonApollo.css
@@ -5,11 +5,12 @@
   --button-text-color: var(--white-1000);
   --button-radius: var(--radius-32);
   --button-shadow-color: var(--blue-1000);
-  --button-padding: var(--rem-12) var(--rem-24);
+  --button-padding: var(--rem-16) var(--rem-24);
   --button-line-height: var(--rem-24);
   --button-font-size: var(--rem-16);
 
   @media (--desktop-small) {
+    --button-padding: var(--rem-12) var(--rem-24);
     --button-line-height: var(--rem-32);
     --button-font-size: var(--rem-18);
   }


### PR DESCRIPTION
Align the Prospect Button mobile height with the Client theme (48px → 56px), as part of the Button convergence effort.

Implementation: bump mobile `--button-padding` from `12/24` to `16/24`, and add an explicit desktop override to keep the existing 56px desktop height (padding 12/24 + line-height 32).

Closes #1756

🤖 Generated with [Claude Code](https://claude.com/claude-code)