### PR TITLE
fix(client,prospect): input text disabled placeholder, icon and helper color

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomApollo.css
@@ -22,10 +22,11 @@
     --input-border-color: var(--gray-500);
     --input-text-color: var(--gray-500);
     --input-bg-color: var(--gray-050);
-    --input-text-icon-color: var(--gray-500);
+    --input-text-icon-color: var(--gray-800);
+    --input-text-placeholder-color: var(--gray-800);
 
     + .af-form__input-helper {
-      --input-helper-color: var(--gray-500);
+      --input-helper-color: var(--gray-800);
     }
   }
 

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomLF.css
@@ -23,10 +23,10 @@
     --input-border-color: var(--gray-140);
     --input-text-color: var(--gray-500);
     --input-bg-color: var(--gray-050);
-    --input-text-icon-color: var(--gray-500);
+    --input-text-icon-color: var(--gray-800);
 
     + .af-form__input-helper {
-      --input-helper-color: var(--gray-500);
+      --input-helper-color: var(--gray-800);
     }
   }
 


### PR DESCRIPTION
Switch the Input Text disabled variant `placeholder`, `icon` and `helper` colors from `gray-500` to `gray-800`, improving the contrast of disabled content and aligning the atom with the existing sidebutton wrapper which already uses `gray-800`.

Closes #1736

Figma: https://www.figma.com/design/weJ6VMBN22GHmBn5GFkXAN/%F0%9F%94%84Input-Text-%E2%80%A2-%7BEn-Dev%7D-%E2%80%A2-Changement-de-la-couleur--Place-holder--icon-et-helper-du-variant-disabled?node-id=8-4323

🤖 Generated with [Claude Code](https://claude.com/claude-code)