### PR TITLE
feat(client,prospect): add missing body 1-4 typography tokens

### DIFF
--- a/packages/canopee-css/src/prospect-client/common/tokens.css
+++ b/packages/canopee-css/src/prospect-client/common/tokens.css
@@ -222,6 +222,7 @@
   --rem-12: calc(12 / var(--font-size-base) * 1rem);
   --rem-13: calc(13 / var(--font-size-base) * 1rem);
   --rem-14: calc(14 / var(--font-size-base) * 1rem);
+  --rem-15: calc(15 / var(--font-size-base) * 1rem);
   --rem-16: calc(16 / var(--font-size-base) * 1rem);
   --rem-18: calc(18 / var(--font-size-base) * 1rem);
   --rem-20: calc(20 / var(--font-size-base) * 1rem);
@@ -244,6 +245,33 @@
   --rem-64: calc(64 / var(--font-size-base) * 1rem);
   --rem-80: calc(80 / var(--font-size-base) * 1rem);
   --rem-120: calc(120 / var(--font-size-base) * 1rem);
+
+  /* *************************************************************************/
+
+  /* BODY TYPOGRAPHY                                                          */
+
+  /* *************************************************************************/
+  --font-weight-regular: 400;
+  --font-weight-semibold: 600;
+  --body-1-font-size: var(--rem-18);
+  --body-1-line-height: var(--rem-23);
+  --body-2-font-size: var(--rem-16);
+  --body-2-line-height: var(--rem-20);
+  --body-3-font-size: var(--rem-14);
+  --body-3-line-height: var(--rem-18);
+  --body-4-font-size: var(--rem-12);
+  --body-4-line-height: var(--rem-15);
+
+  @media (--desktop-small) {
+    --body-1-font-size: var(--rem-20);
+    --body-1-line-height: var(--rem-25);
+    --body-2-font-size: var(--rem-18);
+    --body-2-line-height: var(--rem-23);
+    --body-3-font-size: var(--rem-16);
+    --body-3-line-height: var(--rem-20);
+    --body-4-font-size: var(--rem-14);
+    --body-4-line-height: var(--rem-18);
+  }
 
   /* *************************************************************************/
 

--- a/packages/canopee-css/src/prospect-client/common/tokens.css
+++ b/packages/canopee-css/src/prospect-client/common/tokens.css
@@ -222,7 +222,6 @@
   --rem-12: calc(12 / var(--font-size-base) * 1rem);
   --rem-13: calc(13 / var(--font-size-base) * 1rem);
   --rem-14: calc(14 / var(--font-size-base) * 1rem);
-  --rem-15: calc(15 / var(--font-size-base) * 1rem);
   --rem-16: calc(16 / var(--font-size-base) * 1rem);
   --rem-18: calc(18 / var(--font-size-base) * 1rem);
   --rem-20: calc(20 / var(--font-size-base) * 1rem);
@@ -259,8 +258,8 @@
   --body-2-line-height: var(--rem-20);
   --body-3-font-size: var(--rem-14);
   --body-3-line-height: var(--rem-18);
-  --body-4-font-size: var(--rem-12);
-  --body-4-line-height: var(--rem-15);
+  --body-4-font-size: var(--rem-14);
+  --body-4-line-height: var(--rem-18);
 
   @media (--desktop-small) {
     --body-1-font-size: var(--rem-20);
@@ -269,8 +268,6 @@
     --body-2-line-height: var(--rem-23);
     --body-3-font-size: var(--rem-16);
     --body-3-line-height: var(--rem-20);
-    --body-4-font-size: var(--rem-14);
-    --body-4-line-height: var(--rem-18);
   }
 
   /* *************************************************************************/


### PR DESCRIPTION
Ajoute les tokens manquants Body 1 → Body 4 (font-size + line-height + font-weight) dans `prospect-client/common/tokens.css`, mobile-first avec override desktop via `@media (--desktop-small)`.

Ces tokens auraient dû être livrés avec #1549 mais la PR #1586 n'avait shippé que la partie H1 → H4. Débloque #1750 et #1753 qui ont besoin de Body 2 / Body 3 / Body 3 SB.

Closes #1764
Refs #1549, #1586