### PR TITLE
fix(client): remove focus ring on mouse click for ItemTabBar

### DIFF
--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
@@ -21,6 +21,10 @@
     outline-offset: 2px;
   }
 
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
   &[aria-selected="true"] {
     --item-tab-bar-font-weight: 600;
   }

--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
@@ -16,13 +16,13 @@
     --item-tab-bar-box-shadow-width: -4px;
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     outline: 2px solid var(--item-tab-bar-outline-color);
     outline-offset: 2px;
-  }
-
-  &:focus:not(:focus-visible) {
-    outline: none;
   }
 
   &[aria-selected="true"] {


### PR DESCRIPTION
Remove the native OS focus ring (orange outline) that appears on mouse click for ItemTabBar buttons in the Client theme.

The fix uses `:focus:not(:focus-visible)` to target mouse-click focus only, while preserving the keyboard navigation ring (`:focus-visible`) for accessibility.

Closes #1601