### PR TITLE
fix(distributeur): add 8px spacing between TextInput and HelpButton

### DIFF
--- a/apps/slash-stories/src/Form/TextInput.stories.tsx
+++ b/apps/slash-stories/src/Form/TextInput.stories.tsx
@@ -3,7 +3,6 @@ import {
   MessageTypes,
   TextInput,
 } from "@axa-fr/canopee-react/distributeur";
-import { InputUnit } from "@axa-fr/canopee-react/distributeur/experimental";
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 import { inputTypes } from "./inputTypes";
@@ -172,28 +171,5 @@ export const TextInputWithAppendChildren: Story = {
     type: "text",
     helpMessage: "Aide à la saisie",
     label: "Your name",
-  },
-};
-
-export const TextInputWithUnit: Story = {
-  name: "TextInput with unit",
-  render: ({ onChange, ...args }) => (
-    <TextInput onChange={onChange} {...args}>
-      <InputUnit>€</InputUnit>
-    </TextInput>
-  ),
-  args: {
-    required: true,
-    value: "150",
-    placeholder: "Montant",
-    name: "amount",
-    id: "amountid",
-    readOnly: false,
-    disabled: false,
-    autoFocus: false,
-    className: "",
-    type: "text",
-    helpMessage: "Saisissez un montant",
-    label: "Montant",
   },
 };

--- a/apps/slash-stories/src/Form/TextInput.stories.tsx
+++ b/apps/slash-stories/src/Form/TextInput.stories.tsx
@@ -3,6 +3,7 @@ import {
   MessageTypes,
   TextInput,
 } from "@axa-fr/canopee-react/distributeur";
+import { InputUnit } from "@axa-fr/canopee-react/distributeur/experimental";
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 import { inputTypes } from "./inputTypes";
@@ -171,5 +172,28 @@ export const TextInputWithAppendChildren: Story = {
     type: "text",
     helpMessage: "Aide à la saisie",
     label: "Your name",
+  },
+};
+
+export const TextInputWithUnit: Story = {
+  name: "TextInput with unit",
+  render: ({ onChange, ...args }) => (
+    <TextInput onChange={onChange} {...args}>
+      <InputUnit>€</InputUnit>
+    </TextInput>
+  ),
+  args: {
+    required: true,
+    value: "150",
+    placeholder: "Montant",
+    name: "amount",
+    id: "amountid",
+    readOnly: false,
+    disabled: false,
+    autoFocus: false,
+    className: "",
+    type: "text",
+    helpMessage: "Saisissez un montant",
+    label: "Montant",
   },
 };

--- a/packages/canopee-css/src/distributeur/Form/Text/Text.css
+++ b/packages/canopee-css/src/distributeur/Form/Text/Text.css
@@ -102,6 +102,7 @@
   padding-top: 0;
 }
 
-.af-form__text > .af-popover__wrapper {
+.af-form__text > .af-popover__wrapper,
+.af-form__text > .af-input__unit {
   margin-left: 0.5rem;
 }

--- a/packages/canopee-css/src/distributeur/Form/Text/Text.css
+++ b/packages/canopee-css/src/distributeur/Form/Text/Text.css
@@ -101,3 +101,7 @@
   height: 100%;
   padding-top: 0;
 }
+
+.af-form__text > .af-popover__wrapper {
+  margin-left: 0.5rem;
+}


### PR DESCRIPTION
Ajoute un espace de 8px entre le champ TextInput et le HelpButton sur le theme Distributeur, conformement aux conventions du DS.

Regle CSS ajoutee sur le wrapper Popover enfant direct de .af-form__text (selecteur restreint au cas HelpButton - pas de regression sur les autres variantes).

Closes #1690

## Story de reference

Composant visible dans Storybook : `Components > Form > Input > Text > TextInput with help button`
Story ID : `components-form-input-text--text-input-with-append-children`
