### PR TITLE
fix(distributeur): keep Card selected state blue on hover/focus

### DIFF
--- a/packages/canopee-css/src/distributeur/Card/Card.css
+++ b/packages/canopee-css/src/distributeur/Card/Card.css
@@ -87,17 +87,20 @@
   --card-text-color: var(--white);
   --card-icon-color: var(--white);
   --card-background-color: var(--axablue80);
+  --card-border-color: transparent;
 
   &:focus {
     --card-text-color: var(--white);
     --card-icon-color: var(--white);
     --card-background-color: var(--axablue80);
+    --card-border-color: transparent;
   }
 
   &:hover {
-    --card-text-color: var(--gray80);
-    --card-icon-color: var(--axablue80);
-    --card-background-color: var(--white);
+    --card-text-color: var(--white);
+    --card-icon-color: var(--white);
+    --card-background-color: var(--axablue80);
+    --card-border-color: transparent;
   }
 
   &:disabled:hover {


### PR DESCRIPTION
Le variant sélectionné (.af-card--active) de la Card Distributeur conserve désormais un fond bleu, un texte blanc, une icône blanche et aucune bordure visible dans les états rest, hover et focus.

La règle .af-card--active:hover basculait précédemment vers un fond blanc + texte gris + icône bleue, et le :hover de base ajoutait une bordure bleue. Les overrides explicites de --card-border-color (transparent) et des couleurs en :hover/:focus préviennent ces régressions.

Closes #1689