### PR TITLE
fix(client): remove modal footer divider when body scrolls

### DIFF
--- a/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalLF.css
@@ -18,7 +18,6 @@
   --modal-footer-gap: var(--modal-default-padding);
 
   :has(.af-modal__body-vertical-scroll) {
-    --modal-footer-border-top: 1px solid var(--blue-200);
     --modal-footer-vertical-padding: var(--rem-12);
     --modal-footer-horizontal-padding: var(--rem-16);
   }


### PR DESCRIPTION
Supprime le divider horizontal au-dessus du footer de la Modal Client (thème LF) lorsque le body est scrollable. Aligne le visuel sur la spec Figma référencée dans l'issue.

Closes #1707

Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/OSIamZPeDGVoOw5xiM5Wng/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17288-59570