### PR TITLE
chore(canopee): update release candidate workflow and documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*-RC.*'
+      - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 permissions:
@@ -16,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.gitversion.outputs.fullSemVer }}
-      isStableRelease: ${{ steps.gitversion.outputs.preReleaseTag == '' }}
+      isStableRelease: ${{ steps.gitversion.outputs.preReleaseTag == '' && github.ref_type == 'tag' }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -62,7 +65,7 @@ jobs:
           npm config set provenance=true
 
       - name: Publish latest packages
-        if: steps.gitversion.outputs.preReleaseTag == ''
+        if: steps.gitversion.outputs.preReleaseTag == '' && github.ref_type == 'tag'
         run: npm publish -w packages/canopee-css -w packages/canopee-react -w client/apollo/css -w client/apollo/react -w slash/css -w slash/react --tag latest;
 
       - name: Publish rc packages

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -2,11 +2,13 @@
 
 This documentation explains the process to release the design system.
 
-## Create a release candidate
+## Create a release candidate (RC)
 
-First of all, before releasing a new version, you need to create a release candidate. A RC is not stable yet but can be tested by the users.
+A release candidate is a pre-release version that can be tested before the final release.
 
-To create a release candidate, you need to create a new branch from the `main` branch. The branch name should be `release/X.Y.Z` where `X.Y.Z` is the version number you want.
+### Step 1: Create a release branch
+
+Create a new branch from `main` with the naming convention `release/X.Y.Z`:
 
 ```bash
 git switch main
@@ -14,27 +16,49 @@ git pull
 git switch -c release/1.0.0
 ```
 
-If it's the first time you release candidate this new version, you don't need to commit anything. But you can still commit some changes on this branch, for example, after testing the first release candidate and realizing that you need to fix something.
-When you are ready to candidate release the version, you can create a tag.
+### Step 2: Make fixes if needed
+
+If this is the first RC for this version, you typically won't make any commits. However, if you find issues during RC testing and need to fix them, commit changes to this branch.
+
+### Step 3: Tag and publish
+
+When ready to publish the RC, create and push a tag with the format `X.Y.Z-RC.N`:
 
 ```bash
 git tag 1.0.0-RC.1
+git push origin release/1.0.0
+git push --tags
 ```
 
-After that, you can push the tag, then the branch.
+**The GitHub Actions workflow will automatically trigger** and publish the RC to npm with the `rc` tag.
+
+### Step 4: Test the RC
+
+Users can test the RC version:
 
 ```bash
-git push --tags
-git push release/1.0.0
+npm install @axa-fr/canopee-react@1.0.0-RC.1
 ```
 
-The Github Actions will then be launched and will publish the release candidate on the npm registry. If the Github Actions doesn't launch on itself you have the option to launch it manually.
+### Step 5: Create additional RCs if needed
 
-## Create a release
+If bugs are found and fixes are made on the release branch, increment the RC number:
 
-Your release candidate has been tested and everything looks good, you are now ready to release the version.
+```bash
+git tag 1.0.0-RC.2
+git push origin release/1.0.0
+git push --tags
+```
 
-You need to be on the `main` branch and merge the changes that occurred on the `release` branch.
+If you need to publish multiple RCs, the workflow will handle each one independently.
+
+## Create a release (stable version)
+
+Once the release candidate has been thoroughly tested and approved, you're ready to release the stable version.
+
+### Step 1: Merge to main
+
+The release branch should be merged back to `main`:
 
 ```bash
 git switch main
@@ -42,18 +66,43 @@ git pull
 git merge release/1.0.0
 ```
 
-Then you can create a tag for the release.
+### Step 2: Tag and publish
+
+Create and push a tag with the format `X.Y.Z`:
 
 ```bash
 git tag 1.0.0
-```
-
-And push the tag and the branch.
-
-```bash
 git push --tags
 git push
 ```
 
-The Github Actions will then be launched and will publish the release on the npm registry. If the Github Actions doesn't launch on itself you have the option to launch it manually.
-Once everything is done, you can communicate on this new release.
+**The GitHub Actions workflow will automatically trigger** and publish the release to npm with the `latest` tag.
+
+### Step 3: Distribute
+
+Users can now use the stable version:
+
+```bash
+npm install @axa-fr/canopee-react@1.0.0
+```
+
+## Troubleshooting
+
+### Workflow didn't trigger automatically
+
+The workflow triggers on:
+
+- Push of tags matching `X.Y.Z-RC.*` (RC versions)
+- Push of tags matching `X.Y.Z` (stable versions)
+- Push to `main` branch
+
+If the workflow doesn't trigger, you can manually trigger it via the GitHub Actions UI by selecting the `Publish Packages` workflow and clicking "Run workflow", then choosing the appropriate ref (branch or tag).
+
+### Incorrect version calculated
+
+Ensure you're on the correct branch when creating tags:
+
+- For RC: push tag from or merge back to `release/X.Y.Z` branch
+- For stable: push tag from or merge back to `main` branch
+
+The workflow automatically checks out the correct branch based on the tag format.


### PR DESCRIPTION
⚠️ before merging this PR we must fix the GitVersion problem : actually if we run the publish workflow on a tag, Git Version will generate a 2.0.6 version instead of the wanted version

This pull request updates both the release workflow and documentation to clarify and automate the process for publishing release candidates (RCs) and stable releases. The changes ensure that only tagged releases (RC or stable) trigger publishing to npm, and the documentation now provides a step-by-step guide for both RC and stable release processes, including troubleshooting tips.

**Workflow automation and conditions:**
- The GitHub Actions workflow (`.github/workflows/publish.yml`) is updated to trigger on tags matching RC and stable release patterns, not just branch pushes. This ensures that publishing only occurs when appropriate tags are pushed.
- The workflow logic is improved so that stable releases are only published if the current ref is a tag and not a pre-release, preventing accidental publishing from branch pushes. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L19-R22) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L65-R68)

**Documentation improvements:**
- The `RELEASE-GUIDE.md` is rewritten for clarity, providing a detailed, step-by-step guide for creating RCs and stable releases, including branch and tag naming conventions, publishing instructions, and troubleshooting.