### PR TITLE
[Distributeur] fix(distributeur): add padding-left 3.5rem to accordion light content

### DIFF
--- a/packages/canopee-css/src/distributeur/Accordion/Accordion.css
+++ b/packages/canopee-css/src/distributeur/Accordion/Accordion.css
@@ -78,7 +78,7 @@
 
 .af-accordion--light {
   .af-accordion__content {
-    padding: 0;
+    padding: 1rem 1.25rem 1.25rem 3.5rem;
     box-shadow: none;
   }
 

--- a/packages/canopee-css/src/distributeur/Accordion/Accordion.css
+++ b/packages/canopee-css/src/distributeur/Accordion/Accordion.css
@@ -9,7 +9,6 @@
 
 .af-accordion__item-header {
   display: flex;
-  min-height: 3rem;
   padding: 0 1.25rem;
   align-items: center;
   justify-content: space-between;
@@ -78,12 +77,13 @@
 
 .af-accordion--light {
   .af-accordion__content {
-    padding: 0;
+    padding: 1rem 1.25rem 1.25rem 3.5rem;
     box-shadow: none;
   }
 
   .af-accordion__details {
     position: relative;
+    min-height: 3rem;
   }
 }
 

--- a/packages/canopee-css/src/distributeur/Accordion/Accordion.css
+++ b/packages/canopee-css/src/distributeur/Accordion/Accordion.css
@@ -10,7 +10,6 @@
 
   .af-accordion__item-header {
     display: flex;
-    min-height: 3rem;
     padding: 0 1.25rem;
     align-items: center;
     justify-content: space-between;
@@ -79,12 +78,13 @@
 
   .af-accordion--light {
     .af-accordion__content {
-      padding: 0;
+      padding: 1rem 1.25rem 1.25rem 3.5rem;
       box-shadow: none;
     }
 
     .af-accordion__details {
       position: relative;
+      min-height: 3rem;
     }
   }
 


### PR DESCRIPTION
Add padding-left 3.5rem to accordion light content to align text under the title header.

Closes #1710