### PR TITLE
fix(client): size checkbox check icon to 16x16 with 4px padding

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -15,6 +15,10 @@
 
   &:checked {
     --checkbox-background-color: var(--blue-1000);
+
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: var(--rem-16) var(--rem-16);
   }
 
   &[aria-invalid="true"]:not(:checked) {

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -1,7 +1,7 @@
 @import "./CheckboxCommon.css";
 
 .af-checkbox {
-  --checkbox-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' viewBox='0 -960 960 960'%3E%3Cpath d='m378-332 363-363q9.27-9 21.64-9 12.36 0 21.36 9.05 9 9.06 9 21.5 0 12.45-9 21.45L399-267q-9 9-21 9t-21-9L175-449q-9-9.07-8.5-21.53.5-12.47 9.55-21.47 9.06-9 21.5-9 12.45 0 21.45 9l159 160Z'/%3E%3C/svg%3E");
+  --checkbox-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' viewBox='0 -960 960 960'%3E%3Cpath d='m400-402 250-250q9-9 21-9t21 9q9 9 9 21t-9 21L421-339q-9 9-21 9t-21-9L268-450q-9-9-9-21t9-21q9-9 21-9t21 9l90 90Z'/%3E%3C/svg%3E");
   --checkbox-border-radius: var(--rem-4);
   --checkbox-background-color: var(--white-1000);
   --checkbox-border-color: var(--gray-500);


### PR DESCRIPTION
Display the Material check icon at 16×16 centered within the 24×24 checkbox, giving a 4px padding around the icon (Client/LF only).

Closes #1749