### PR TITLE
feat(canopee): add warning variant to input text (#1693)

### DIFF
--- a/apps/apollo-stories/src/components/InputText/InputText.mdx
+++ b/apps/apollo-stories/src/components/InputText/InputText.mdx
@@ -31,3 +31,18 @@ const MyComponent = () => (
 <Canvas of={InputTextStories.InputTextPlaygroundStory} />
 
 <Controls of={InputTextStories.InputTextPlaygroundStory} />
+
+## Warning
+
+Use `message` with `messageType="warning"` to display a warning state with orange border and ⚠️ icon.
+
+```tsx
+<InputText
+  value="John Doe"
+  label="Label"
+  message="Warning Message"
+  messageType="warning"
+/>
+```
+
+<Canvas of={InputTextStories.InputTextWarningStory} />

--- a/apps/apollo-stories/src/components/InputText/InputText.stories.tsx
+++ b/apps/apollo-stories/src/components/InputText/InputText.stories.tsx
@@ -55,3 +55,13 @@ export const InputTextPlaygroundStory: Story = {
   name: "Playground",
   render,
 };
+
+export const InputTextWarningStory: Story = {
+  name: "Warning",
+  render,
+  args: {
+    error: "",
+    message: "Warning Message",
+    messageType: "warning",
+  },
+};

--- a/apps/look-and-feel-stories/src/components/InputText/InputText.mdx
+++ b/apps/look-and-feel-stories/src/components/InputText/InputText.mdx
@@ -29,3 +29,18 @@ const MyComponent = () => (
 <Canvas of={InputTextStories.InputTextPlaygroundStory}></Canvas>
 
 <Controls of={InputTextStories.InputTextPlaygroundStory} />
+
+## Warning
+
+Use `message` with `messageType="warning"` to display a warning state with orange border and ⚠️ icon.
+
+```tsx
+<InputText
+  value="John Doe"
+  label="Label"
+  message="Warning Message"
+  messageType="warning"
+/>
+```
+
+<Canvas of={InputTextStories.InputTextWarningStory} />

--- a/apps/look-and-feel-stories/src/components/InputText/InputText.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/InputText/InputText.stories.tsx
@@ -49,3 +49,13 @@ export const InputTextPlaygroundStory: Story = {
   name: "Playground",
   render,
 };
+
+export const InputTextWarningStory: Story = {
+  name: "Warning",
+  render,
+  args: {
+    error: "",
+    message: "Warning Message",
+    messageType: "warning",
+  },
+};

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomApollo.css
@@ -17,6 +17,10 @@
     --input-border-color: var(--red-alert-1000);
   }
 
+  &:has(> input[class*="--warning"]) {
+    --input-border-color: var(--orange-1050);
+  }
+
   &:has(> input:disabled),
   &:has(> input:disabled):is(:hover, :focus, :active) {
     --input-border-color: var(--gray-500);
@@ -29,7 +33,14 @@
     }
   }
 
-  &:has(> input[value]:not([value=""], [class*="--error"], :disabled)) {
+  &:has(
+    > input[value]:not(
+        [value=""],
+        [class*="--error"],
+        [class*="--warning"],
+        :disabled
+      )
+  ) {
     --input-border-color: var(--blue-1000);
     --input-text-color: var(--blue-1000);
   }

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.css
@@ -54,13 +54,26 @@
   }
 
   &:has(
-    > input:is(:hover, :focus, :active, [class*="--error"]):not(:disabled)
+    > input:is(
+        :hover,
+        :focus,
+        :active,
+        [class*="--error"],
+        [class*="--warning"]
+      ):not(:disabled)
   ) {
     --input-box-shadow-width: 2px;
   }
 
   &:has(
     > input[class*="--error"]:not(:disabled):is(:hover, :focus-visible, :active)
+  ),
+  &:has(
+    > input[class*="--warning"]:not(:disabled):is(
+        :hover,
+        :focus-visible,
+        :active
+      )
   ) {
     --input-box-shadow-width: 3px;
   }

--- a/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputTextAtom/InputTextAtomLF.css
@@ -18,6 +18,10 @@
     --input-border-color: var(--red-alert-1200);
   }
 
+  &:has(> input[class*="--warning"]) {
+    --input-border-color: var(--orange-1050);
+  }
+
   &:has(> input:disabled),
   &:has(> input:disabled):is(:hover, :focus, :active) {
     --input-border-color: var(--gray-140);
@@ -30,7 +34,14 @@
     }
   }
 
-  &:has(> input[value]:not([value=""], [class*="--error"], :disabled)) {
+  &:has(
+    > input[value]:not(
+        [value=""],
+        [class*="--error"],
+        [class*="--warning"],
+        :disabled
+      )
+  ) {
     --input-border-color: var(--blue-1000);
   }
 }

--- a/packages/canopee-react/src/prospect-client/Form/InputText/InputTextCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputText/InputTextCommon.tsx
@@ -112,6 +112,9 @@ const InputTextCommon = forwardRef<HTMLInputElement, InputTextCommonProps>(
               ? messageType || error
               : undefined
           }
+          warning={
+            message && messageType === "warning" ? messageType : undefined
+          }
           required={required}
           idMessage={message || error ? idMessage : undefined}
           idHelp={

--- a/packages/canopee-react/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputTextAtom/InputTextAtomCommon.tsx
@@ -11,6 +11,7 @@ type InputTextAtomProps = ComponentPropsWithRef<"input"> & {
   unit?: ReactNode;
   classModifier?: string;
   error?: string;
+  warning?: string;
   idMessage?: string;
   idHelp?: string;
 };
@@ -22,6 +23,7 @@ const InputTextAtom = forwardRef<HTMLInputElement, InputTextAtomProps>(
       className,
       classModifier = "",
       error,
+      warning,
       required,
       idMessage,
       idHelp,
@@ -34,7 +36,11 @@ const InputTextAtom = forwardRef<HTMLInputElement, InputTextAtomProps>(
   ) => {
     const componentClassName = getClassName({
       baseClassName: "af-form__input-text",
-      modifiers: [classModifier, error || ariaErrormessage ? "error" : ""],
+      modifiers: [
+        classModifier,
+        error || ariaErrormessage ? "error" : "",
+        !error && !ariaErrormessage && warning ? "warning" : "",
+      ],
       className,
     });
 


### PR DESCRIPTION
Adds Warning and Hover_Warning variants to Input Text for Prospect (Apollo) and Client (LF) themes, mirroring the Error pattern. Border color uses --orange-1050 per spec.

Impl: new [class*="--warning"] selector on InputTextAtom, warning prop added to the React atom (ignored when error is present).

Closes #1693

Figma: https://www.figma.com/design/tbetvGVjmXSGdbMJWKqa6l/%E2%9C%85-Input_Text-%E2%80%A2-%7BEn-Dev%7D---Ajout-du-variant-Warning?node-id=26245-6196