### PR TITLE
feat(prospect, client): add isDesktopCompact prop to DataAgent for desktop compact variant

### DIFF
--- a/apps/apollo-stories/src/components/DataAgent/DataAgent.mdx
+++ b/apps/apollo-stories/src/components/DataAgent/DataAgent.mdx
@@ -74,3 +74,24 @@ const MyComponent = () => (
 <Canvas of={DataAgentStories.Default} />
 
 <Controls of={DataAgentStories.Default} />
+
+## Compact
+
+Use `variant="compact"` to force the compact layout (header only — avatar + name + subtitle) regardless of screen size.
+This is useful when the DataAgent is embedded in a constrained layout such as a desktop sidebar.
+
+```tsx
+<DataAgent
+  agentProps={{
+    picture: "https://dummyimage.com/48/48/fff&text=A",
+    subtitle: "AXA Assurance & Banque",
+    title: "Michel Lhote",
+    type: "picture",
+  }}
+  variant="compact"
+/>
+```
+
+<Canvas of={DataAgentStories.DesktopCompact} />
+
+<Controls of={DataAgentStories.DesktopCompact} />

--- a/apps/apollo-stories/src/components/DataAgent/DataAgent.stories.tsx
+++ b/apps/apollo-stories/src/components/DataAgent/DataAgent.stories.tsx
@@ -68,3 +68,17 @@ export const Default: Story = {
     isCompact: true,
   },
 };
+
+export const DesktopCompact: Story = {
+  name: "DataAgent Desktop Compact",
+  render: ({ ...args }) => <DataAgent {...args} />,
+  args: {
+    agentProps: {
+      picture: "https://dummyimage.com/48/48/fff&text=A",
+      title: "Michel Lhote",
+      subtitle: "AXA Assurance & Banque",
+      type: "picture",
+    },
+    isDesktopCompact: true,
+  },
+};

--- a/apps/apollo-stories/src/components/DataAgent/DataAgent.stories.tsx
+++ b/apps/apollo-stories/src/components/DataAgent/DataAgent.stories.tsx
@@ -79,6 +79,6 @@ export const DesktopCompact: Story = {
       subtitle: "AXA Assurance & Banque",
       type: "picture",
     },
-    isDesktopCompact: true,
+    variant: "compact",
   },
 };

--- a/apps/look-and-feel-stories/src/components/DataAgent/DataAgent.mdx
+++ b/apps/look-and-feel-stories/src/components/DataAgent/DataAgent.mdx
@@ -74,3 +74,24 @@ const MyComponent = () => (
 <Canvas of={DataAgentStories.Default} />
 
 <Controls of={DataAgentStories.Default} />
+
+## Compact
+
+Use `variant="compact"` to force the compact layout (header only — avatar + name + subtitle) regardless of screen size.
+This is useful when the DataAgent is embedded in a constrained layout such as a desktop sidebar.
+
+```tsx
+<DataAgent
+  agentProps={{
+    picture: "https://dummyimage.com/48/48/fff&text=A",
+    subtitle: "AXA Assurance & Banque",
+    title: "Michel Lhote",
+    type: "picture",
+  }}
+  variant="compact"
+/>
+```
+
+<Canvas of={DataAgentStories.DesktopCompact} />
+
+<Controls of={DataAgentStories.DesktopCompact} />

--- a/apps/look-and-feel-stories/src/components/DataAgent/DataAgent.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/DataAgent/DataAgent.stories.tsx
@@ -83,6 +83,6 @@ export const DesktopCompact: Story = {
       subtitle: "AXA Assurance & Banque",
       type: "picture",
     },
-    isDesktopCompact: true,
+    variant: "compact",
   },
 };

--- a/apps/look-and-feel-stories/src/components/DataAgent/DataAgent.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/DataAgent/DataAgent.stories.tsx
@@ -72,3 +72,17 @@ export const Default: Story = {
     isCompact: true,
   },
 };
+
+export const DesktopCompact: Story = {
+  name: "DataAgent Desktop Compact",
+  render: ({ ...args }) => <DataAgent {...args} />,
+  args: {
+    agentProps: {
+      picture: "https://dummyimage.com/48/48/fff&text=A",
+      title: "Michel Lhote",
+      subtitle: "AXA Assurance & Banque",
+      type: "picture",
+    },
+    isDesktopCompact: true,
+  },
+};

--- a/packages/canopee-react/src/prospect-client/DataAgent/DataAgentCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/DataAgent/DataAgentCommon.tsx
@@ -27,7 +27,7 @@ export type DataAgentProps = {
   texteOrias?: string;
   isCompact?: boolean;
   /** Display the compact layout (header only) regardless of screen size */
-  isDesktopCompact?: boolean;
+  variant?: "default" | "compact";
 };
 
 type DataAgentCommonProps = DataAgentProps & {
@@ -47,7 +47,7 @@ export const DataAgentCommon = ({
   ContentItemMonoComponent,
   ClickItemComponent,
   isCompact = true,
-  isDesktopCompact = false,
+  variant = "default",
 }: DataAgentCommonProps) => {
   const componentClassName = useMemo(
     () => getComponentClassName("af-data-agent", className),
@@ -106,7 +106,7 @@ export const DataAgentCommon = ({
 
   return (
     <section className={componentClassName}>
-      {(isMobile && isCompact) || isDesktopCompact
+      {(isMobile && isCompact) || variant === "compact"
         ? renderForMobileLayout()
         : renderForDefaultLayout()}
     </section>

--- a/packages/canopee-react/src/prospect-client/DataAgent/DataAgentCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/DataAgent/DataAgentCommon.tsx
@@ -26,6 +26,8 @@ export type DataAgentProps = {
   clickContents?: TupleMax3<ClickItemProps>;
   texteOrias?: string;
   isCompact?: boolean;
+  /** Display the compact layout (header only) regardless of screen size */
+  isDesktopCompact?: boolean;
 };
 
 type DataAgentCommonProps = DataAgentProps & {
@@ -45,6 +47,7 @@ export const DataAgentCommon = ({
   ContentItemMonoComponent,
   ClickItemComponent,
   isCompact = true,
+  isDesktopCompact = false,
 }: DataAgentCommonProps) => {
   const componentClassName = useMemo(
     () => getComponentClassName("af-data-agent", className),
@@ -103,7 +106,7 @@ export const DataAgentCommon = ({
 
   return (
     <section className={componentClassName}>
-      {isMobile && isCompact
+      {(isMobile && isCompact) || isDesktopCompact
         ? renderForMobileLayout()
         : renderForDefaultLayout()}
     </section>


### PR DESCRIPTION
Add `variant` prop to DataAgent to force compact (header-only) layout regardless of screen size.

Closes #1691

## Visuel

| Avant | Après |
|-------|-------|
| ![default](https://raw.githubusercontent.com/AxaFrance/design-system/feat/data-agent-desktop-compact-1691/.github/screenshots/data-agent-default.png) | ![compact](https://raw.githubusercontent.com/AxaFrance/design-system/feat/data-agent-desktop-compact-1691/.github/screenshots/data-agent-compact.png) |

---

*Made with [Claude](https://claude.ai)*