### PR TITLE
fix(prospect, client): center ClickItem leading icon on medium variant

### DIFF
--- a/packages/canopee-css/src/prospect-client/List/ClickItem/ClickItemCommon.css
+++ b/packages/canopee-css/src/prospect-client/List/ClickItem/ClickItemCommon.css
@@ -84,7 +84,7 @@
 }
 
 .af-apollo-click-item--medium {
-  align-items: flex-start;
+  align-items: center;
 
   .af-apollo-click-item {
     .af-apollo-click-item__secondary,

--- a/packages/canopee-css/src/prospect-client/List/ClickItem/ClickItemCommon.css
+++ b/packages/canopee-css/src/prospect-client/List/ClickItem/ClickItemCommon.css
@@ -84,8 +84,6 @@
 }
 
 .af-apollo-click-item--medium {
-  align-items: center;
-
   .af-apollo-click-item {
     .af-apollo-click-item__secondary,
     .af-apollo-click-item__tertiary,


### PR DESCRIPTION
Fix the leading icon vertical alignment on the Click Item medium variant (was top-aligned, now centered).

Closes #1678

Figma: https://www.figma.com/design/ekq0Lj2QPMGCyHL5LEAFrI/%F0%9F%94%84-Click_Item-%E2%80%A2-%7BValidation-tech%7D-%E2%80%A2-Ajout-d-un-chevron-sur-le-m%C3%A9dium---correction-ferrage-ic%C3%B4nes?node-id=17278-52931

## Visuel

| Avant | Apres |
|-------|-------|
| ![avant](https://raw.githubusercontent.com/AxaFrance/design-system/screenshots/pr-1776-1767/.github/screenshots/pr-1776-before.png) | ![apres](https://raw.githubusercontent.com/AxaFrance/design-system/screenshots/pr-1776-1767/.github/screenshots/pr-1776-after.png) |

---
*Made with [Claude](https://claude.ai)*