### PR TITLE
feat(client, prospect): add iconPosition top variant to Heading (#1705)

### DIFF
--- a/apps/apollo-stories/src/components/Heading/Heading.mdx
+++ b/apps/apollo-stories/src/components/Heading/Heading.mdx
@@ -27,3 +27,15 @@ The heading accepts all icon props (the `iconProps` props key) except for the `s
 <Canvas of={HeadingStories.Playground} />
 
 <Controls of={HeadingStories.Playground} />
+
+## Icon on top
+
+Set `iconPosition="top"` to stack the icon above the title instead of aligning it to the start. Default is `"start"`.
+
+```tsx
+<Heading icon={bank} iconPosition="top">
+  Titre de la page
+</Heading>
+```
+
+<Canvas of={HeadingStories.IconOnTop} />

--- a/apps/apollo-stories/src/components/Heading/Heading.stories.tsx
+++ b/apps/apollo-stories/src/components/Heading/Heading.stories.tsx
@@ -49,3 +49,20 @@ export const All: Story = {
   },
   render: renderAllHeading,
 };
+
+export const IconOnTop: Story = {
+  args: {
+    ...Playground.args,
+    iconPosition: "top",
+  },
+  argTypes: {
+    iconPosition: {
+      options: ["start", "top"] as const,
+      control: "inline-radio",
+    },
+    level: {
+      options: [1, 2, 3, 4] as HeadingLevel[],
+      control: "inline-radio",
+    },
+  },
+};

--- a/apps/apollo-stories/src/components/Heading/Heading.stories.tsx
+++ b/apps/apollo-stories/src/components/Heading/Heading.stories.tsx
@@ -21,6 +21,10 @@ const meta: Meta<typeof Heading> = {
     tagProps: {
       control: "object",
     },
+    iconPosition: {
+      options: ["start", "top"] as const,
+      control: "inline-radio",
+    },
   },
 };
 
@@ -56,10 +60,6 @@ export const IconOnTop: Story = {
     iconPosition: "top",
   },
   argTypes: {
-    iconPosition: {
-      options: ["start", "top"] as const,
-      control: "inline-radio",
-    },
     level: {
       options: [1, 2, 3, 4] as HeadingLevel[],
       control: "inline-radio",

--- a/apps/look-and-feel-stories/src/components/Heading/Heading.mdx
+++ b/apps/look-and-feel-stories/src/components/Heading/Heading.mdx
@@ -27,3 +27,15 @@ The heading accepts all icon props (the `iconProps` props key) except for the `s
 <Canvas of={HeadingStories.Playground} />
 
 <Controls of={HeadingStories.Playground} />
+
+## Icon on top
+
+Set `iconPosition="top"` to stack the icon above the title instead of aligning it to the start. Default is `"start"`.
+
+```tsx
+<Heading icon={bank} iconPosition="top">
+  Titre de la page
+</Heading>
+```
+
+<Canvas of={HeadingStories.IconOnTop} />

--- a/apps/look-and-feel-stories/src/components/Heading/Heading.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Heading/Heading.stories.tsx
@@ -21,6 +21,10 @@ const meta: Meta<typeof Heading> = {
     tagProps: {
       control: "object",
     },
+    iconPosition: {
+      options: ["start", "top"] as const,
+      control: "inline-radio",
+    },
   },
 };
 
@@ -54,10 +58,6 @@ export const IconOnTop: Story = {
     iconPosition: "top",
   },
   argTypes: {
-    iconPosition: {
-      options: ["start", "top"] as const,
-      control: "inline-radio",
-    },
     level: {
       options: [1, 2, 3, 4] as HeadingLevel[],
       control: "inline-radio",

--- a/apps/look-and-feel-stories/src/components/Heading/Heading.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Heading/Heading.stories.tsx
@@ -47,3 +47,20 @@ export const All: Story = {
   args: { ...Playground.args },
   render: renderAllHeading,
 };
+
+export const IconOnTop: Story = {
+  args: {
+    ...Playground.args,
+    iconPosition: "top",
+  },
+  argTypes: {
+    iconPosition: {
+      options: ["start", "top"] as const,
+      control: "inline-radio",
+    },
+    level: {
+      options: [1, 2, 3, 4] as HeadingLevel[],
+      control: "inline-radio",
+    },
+  },
+};

--- a/packages/canopee-css/src/prospect-client/Heading/HeadingCommon.css
+++ b/packages/canopee-css/src/prospect-client/Heading/HeadingCommon.css
@@ -12,6 +12,12 @@
   &:has(.af-heading__icon) {
     grid-template-columns: auto 1fr;
   }
+
+  &.af-heading--icon-top:has(.af-heading__icon) {
+    --heading-grid-column: 1;
+
+    grid-template-columns: 1fr;
+  }
 }
 
 .af-heading__title-container {
@@ -47,6 +53,11 @@
   grid-column: 1;
   grid-row: 1/3;
   box-shadow: 0 0.125rem 0.5rem 0 rgba(var(--blue-1000), 0.15);
+}
+
+.af-heading--icon-top .af-heading__icon {
+  grid-row: auto;
+  justify-self: start;
 }
 
 .af-heading__label {

--- a/packages/canopee-react/src/prospect-client/Heading/HeadingCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Heading/HeadingCommon.tsx
@@ -43,9 +43,8 @@ export const HeadingCommon = ({
   return (
     <div
       className={getClassName({
-        baseClassName: `af-heading${
-          iconPosition === "top" ? " af-heading--icon-top" : ""
-        }`,
+        baseClassName: "af-heading",
+        modifiers: [iconPosition === "top" && "icon-top"],
         className,
       })}
       {...props}

--- a/packages/canopee-react/src/prospect-client/Heading/HeadingCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Heading/HeadingCommon.tsx
@@ -15,6 +15,7 @@ export type HeadingCommonProps = PropsWithChildren<{
   level?: HeadingLevel;
   icon?: string;
   iconProps?: Omit<IconProps, "src">;
+  iconPosition?: "start" | "top";
   tag?: ReactNode;
   firstSubtitle?: ReactNode;
   secondSubtitle?: ReactNode;
@@ -34,6 +35,7 @@ export const HeadingCommon = ({
   level = 1,
   icon,
   iconProps = {},
+  iconPosition = "start",
   tag,
   ...props
 }: HeadingCommonProps) => {
@@ -41,7 +43,9 @@ export const HeadingCommon = ({
   return (
     <div
       className={getClassName({
-        baseClassName: "af-heading",
+        baseClassName: `af-heading${
+          iconPosition === "top" ? " af-heading--icon-top" : ""
+        }`,
         className,
       })}
       {...props}

--- a/packages/canopee-react/src/prospect-client/Heading/__tests__/Heading.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Heading/__tests__/Heading.test.tsx
@@ -136,6 +136,34 @@ describe("Heading", () => {
     );
   });
 
+  it("should apply the icon-top modifier when iconPosition is 'top'", () => {
+    render(
+      <HeadingCommon
+        icon={bank}
+        iconProps={{ "aria-label": "icon" }}
+        iconPosition="top"
+      >
+        Title
+      </HeadingCommon>,
+    );
+
+    expect(screen.getByText("Title").parentElement?.parentElement).toHaveClass(
+      "af-heading--icon-top",
+    );
+  });
+
+  it("should not apply the icon-top modifier by default", () => {
+    render(
+      <HeadingCommon icon={bank} iconProps={{ "aria-label": "icon" }}>
+        Title
+      </HeadingCommon>,
+    );
+
+    expect(
+      screen.getByText("Title").parentElement?.parentElement,
+    ).not.toHaveClass("af-heading--icon-top");
+  });
+
   it.each([{ level: 1 }, { level: 2 }, { level: 3 }] as {
     level: HeadingLevel;
   }[])(


### PR DESCRIPTION
Ajoute un variant de Heading avec l'icône positionnée au-dessus du titre (nouvelle prop `iconPosition: "start" | "top"`, valeur par défaut `start`).

Quand `iconPosition="top"`, la classe `af-heading--icon-top` bascule la grille sur une seule colonne et replace l'icône en haut (`grid-row: auto`, `justify-self: start`). Le comportement existant (icône à gauche) reste inchangé.

Closes #1705

[Branche Figma](https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/NZ2dU0WW1vRrrb37xmk9m8/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17288-59067)
