### PR TITLE
feat(prospect): apply 4px gap to CardRadioOption content in all variants

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Radio/CardRadioOption/CardRadioOptionApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/CardRadioOption/CardRadioOptionApollo.css
@@ -8,6 +8,10 @@
   --radio-option-border-radius: var(--radius-8);
   --radio-option-background-color: var(--white-1000);
 
+  & .af-card-radio-option__content {
+    --radio-option-gap: var(--rem-4);
+  }
+
   &:hover,
   &:focus-visible,
   &:focus-within {
@@ -21,12 +25,6 @@
 }
 
 .af-card-radio-option--horizontal {
-  --radio-option-gap: var(--rem-8);
-
-  & .af-card-radio-option__content {
-    --radio-option-gap: var(--rem-4);
-  }
-
   & .af-radio {
     margin-right: var(--rem-8);
   }


### PR DESCRIPTION
Prospect: CardRadioOption content gap reduit de 8px a 4px dans toutes les variantes (spec issue).

Deplacement de l override `--radio-option-gap: var(--rem-4)` sur `__content` du bloc `.af-card-radio-option--horizontal` vers la base `.af-card-radio-option`, et suppression du `--radio-option-gap: var(--rem-8)` redondant sur la variante horizontale (identique au defaut).

Refs #1784 (partie Prospect uniquement - Client necessite clarification cote gaps / restructuration radio).

Lien Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/iy2nZ5MsIt2GmPtMIKOsrv/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17278-55391

## Note visuelle

Change verifie via inspection DOM: `getComputedStyle(.af-card-radio-option__content).gap` passe de `8px` a `4px`. Le rendu visuel des stories par defaut (Playground, CardRadioGroup) reste pixel-identique car `__content` utilise `justify-content: space-between` avec `flex-grow: 1` — le `gap` joue comme espacement minimum, et dans les stories courantes l espace vertical disponible excede celui necessaire aux items. La difference devient visible sur des contenus plus denses ou des cards contraintes.

---
*Made with [Claude](https://claude.ai)*
