### PR TITLE
fix(prospect): card radio option title color in error state (#1712)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Radio/CardRadioOption/CardRadioOptionApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/CardRadioOption/CardRadioOptionApollo.css
@@ -39,4 +39,5 @@
 .af-card-radio-option--invalid:not(:has(input:checked)) {
   --radio-option-border-color: var(--red-alert-1000);
   --radio-option-background-color: var(--red-040);
+  --radio-option-color-title: var(--gray-800);
 }


### PR DESCRIPTION
Pour le statut Error, la couleur du titre du Card Radio Option passe de `var(--blue-1000)` (#00008F) à `var(--gray-800)` (#5C5C5C). Prospect uniquement, le reste du composant est inchangé.

Closes #1712

*Made with [Claude](https://claude.ai)*
