### PR TITLE
fix(prospect): card checkbox option title color in error state (#1713)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css
@@ -22,6 +22,7 @@
   &:has(input[aria-invalid="true"]):not(:has(input:checked)) {
     --checkbox-option-border-color: var(--red-alert-1000);
     --checkbox-option-background-color: var(--red-040);
+    --checkbox-option-color-title: var(--gray-800);
   }
 }
 


### PR DESCRIPTION
Fixe la couleur du titre du CardCheckboxOption en état erreur sur le thème Prospect : passe de var(--blue-1000) à var(--gray-800) via la surcharge du token --checkbox-option-color-title dans le selecteur aria-invalid.

Closes #1713

Figma : https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea

---
*Made with [Claude](https://claude.ai)*