### PR TITLE
feat(client,prospect): update ContentItemMono picture large title and subtitle sizes

### DIFF
--- a/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoApollo.css
+++ b/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoApollo.css
@@ -75,11 +75,16 @@
       --title-line-height: var(--rem-20);
     }
 
-    &.af-content-item-mono--large
-      .af-content-item-mono__text-content
+    &.af-content-item-mono--large .af-content-item-mono__text-content {
       .af-content-item-mono__title {
-      --title-font-size: var(--rem-24);
-      --title-line-height: var(--rem-30);
+        --title-font-size: var(--rem-24);
+        --title-line-height: var(--rem-30);
+      }
+
+      .af-content-item-mono__subtitle {
+        --subtitle-font-size: var(--rem-18);
+        --subtitle-line-height: var(--rem-23);
+      }
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoApollo.css
+++ b/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoApollo.css
@@ -36,13 +36,18 @@
     --title-line-height: var(--rem-18);
   }
 
-  &.af-content-item-mono--large
-    .af-content-item-mono__text-content
+  &.af-content-item-mono--large .af-content-item-mono__text-content {
     .af-content-item-mono__title {
-    --title-font-family: var(--font-family-publico-headline);
-    --title-font-weight: 300;
-    --title-font-size: var(--rem-22);
-    --title-line-height: var(--rem-28);
+      --title-font-family: var(--font-family-publico-headline);
+      --title-font-weight: 300;
+      --title-font-size: var(--rem-20);
+      --title-line-height: var(--rem-25);
+    }
+
+    .af-content-item-mono__subtitle {
+      --subtitle-font-size: var(--rem-16);
+      --subtitle-line-height: var(--rem-20);
+    }
   }
 
   @media (--desktop-small) {
@@ -73,8 +78,8 @@
     &.af-content-item-mono--large
       .af-content-item-mono__text-content
       .af-content-item-mono__title {
-      --title-font-size: var(--rem-28);
-      --title-line-height: var(--rem-35);
+      --title-font-size: var(--rem-24);
+      --title-line-height: var(--rem-30);
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoApollo.css
+++ b/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoApollo.css
@@ -40,13 +40,6 @@
     .af-content-item-mono__title {
       --title-font-family: var(--font-family-publico-headline);
       --title-font-weight: 300;
-      --title-font-size: var(--rem-20);
-      --title-line-height: var(--rem-25);
-    }
-
-    .af-content-item-mono__subtitle {
-      --subtitle-font-size: var(--rem-16);
-      --subtitle-line-height: var(--rem-20);
     }
   }
 
@@ -73,13 +66,6 @@
       .af-content-item-mono__title {
       --title-font-size: var(--rem-16);
       --title-line-height: var(--rem-20);
-    }
-
-    &.af-content-item-mono--large
-      .af-content-item-mono__text-content
-      .af-content-item-mono__title {
-      --title-font-size: var(--rem-24);
-      --title-line-height: var(--rem-30);
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoCommon.css
+++ b/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoCommon.css
@@ -39,4 +39,30 @@
       color: var(--subtitle-color);
     }
   }
+
+  &.af-content-item-mono--large .af-content-item-mono__text-content {
+    .af-content-item-mono__title {
+      --title-font-size: var(--rem-20);
+      --title-line-height: var(--rem-25);
+    }
+
+    .af-content-item-mono__subtitle {
+      --subtitle-font-size: var(--rem-16);
+      --subtitle-line-height: var(--rem-20);
+    }
+  }
+
+  @media (--desktop-small) {
+    &.af-content-item-mono--large .af-content-item-mono__text-content {
+      .af-content-item-mono__title {
+        --title-font-size: var(--rem-24);
+        --title-line-height: var(--rem-30);
+      }
+
+      .af-content-item-mono__subtitle {
+        --subtitle-font-size: var(--rem-18);
+        --subtitle-line-height: var(--rem-23);
+      }
+    }
+  }
 }

--- a/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoLF.css
+++ b/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoLF.css
@@ -37,7 +37,7 @@
   }
 
   &.af-content-item-mono--large .af-content-item-mono__text-content {
-    .title {
+    .af-content-item-mono__title {
       --title-font-family: var(--font-family-publico);
       --title-font-weight: 700;
       --title-font-size: var(--rem-20);
@@ -76,7 +76,7 @@
     }
 
     &.af-content-item-mono--large .af-content-item-mono__text-content {
-      .title {
+      .af-content-item-mono__title {
         --title-font-size: var(--rem-24);
         --title-line-height: var(--rem-30);
       }

--- a/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoLF.css
+++ b/packages/canopee-css/src/prospect-client/ContentItemMono/ContentItemMonoLF.css
@@ -40,13 +40,6 @@
     .af-content-item-mono__title {
       --title-font-family: var(--font-family-publico);
       --title-font-weight: 700;
-      --title-font-size: var(--rem-20);
-      --title-line-height: var(--rem-25);
-    }
-
-    .af-content-item-mono__subtitle {
-      --subtitle-font-size: var(--rem-16);
-      --subtitle-line-height: var(--rem-20);
     }
   }
 
@@ -73,18 +66,6 @@
       .af-content-item-mono__title {
       --title-font-size: var(--rem-16);
       --title-line-height: var(--rem-20);
-    }
-
-    &.af-content-item-mono--large .af-content-item-mono__text-content {
-      .af-content-item-mono__title {
-        --title-font-size: var(--rem-24);
-        --title-line-height: var(--rem-30);
-      }
-
-      .af-content-item-mono__subtitle {
-        --subtitle-font-size: var(--rem-18);
-        --subtitle-line-height: var(--rem-23);
-      }
     }
   }
 }


### PR DESCRIPTION
Align ContentItemMono picture large title/subtitle typography on Apollo and LF with the latest Figma specs.

- Apollo `--large`: title goes from 22/28 → 20/25 on mobile and 28/35 → 24/30 on desktop; subtitle mobile bumps to Body 2 (16/20) to match desktop.
- LF `--large`: fix the broken `.title` selector so the Publico Bold title overrides are actually applied (`.af-content-item-mono__title`).

Closes #1786

https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/sMSyN01lwNwvhFSQzYvAi2/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17278-53102

---
*Made with [Claude](https://claude.ai)*
