### PR TITLE
feat(client, prospect): converge ItemFile to ContentItemMono (#1752)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/FileUpload/ItemFile/ItemFileApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/FileUpload/ItemFile/ItemFileApollo.css
@@ -3,15 +3,13 @@
 .af-item-file {
   --item-file-border-radius: var(--radius-8);
   --item-file-border-color: var(--blue-1000);
-  --item-file-file-name-color: var(--gray-1000);
-  --item-file-file-size-color: var(--gray-800);
   --item-file-bg-color: var(--white-1000);
   --item-file-gap: var(--rem-8);
   --item-file-body-padding-vertical: var(--rem-16);
   --item-file-body-padding-horizontal: var(--rem-16);
-  --item-file-action-buttons-gap: var(--rem-24);
+  --item-file-action-buttons-gap: var(--rem-16);
 
-  > .af-item-file__body > .af-icon {
+  .af-item-file__body .af-content-item-mono .af-icon {
     --icon-fill: var(--green-1000);
   }
 }
@@ -19,7 +17,7 @@
 .af-item-file--error {
   --item-file-border-color: var(--red-alert-1000);
 
-  > .af-item-file__body > .af-icon {
+  .af-item-file__body .af-content-item-mono .af-icon {
     --icon-fill: var(--red-alert-1000);
   }
 }

--- a/packages/canopee-css/src/prospect-client/Form/FileUpload/ItemFile/ItemFileCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/FileUpload/ItemFile/ItemFileCommon.css
@@ -1,59 +1,25 @@
 .af-item-file {
-  --af-item-file-file-name-font-size: var(--rem-16);
-  --af-item-file-file-size-font-size: var(--rem-14);
-
   display: flex;
   flex-direction: column;
   gap: var(--item-file-gap);
-
-  @media (--desktop-small) {
-    --af-item-file-file-name-font-size: var(--rem-18);
-    --af-item-file-file-size-font-size: var(--rem-16);
-  }
-
-  .af-icon:first-of-type,
-  .af-spinner {
-    grid-area: icon;
-  }
 }
 
 .af-item-file__body {
-  display: grid;
+  display: flex;
   padding: var(--item-file-body-padding-vertical)
     var(--item-file-body-padding-horizontal);
   border: 1px solid var(--item-file-border-color);
   border-radius: var(--item-file-border-radius);
-  grid-template-areas:
-    "icon file-name actions"
-    "icon file-size actions";
-  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: start;
-  gap: 0 var(--rem-12);
+  justify-content: space-between;
+  gap: var(--rem-12);
   font: var(--font-family-base);
   font-weight: 400;
   line-height: 125%;
 }
 
-.af-item-file__file-name {
-  margin: 0;
-  padding: 0;
-  grid-area: file-name;
-  font-size: var(--af-item-file-file-name-font-size);
-  color: var(--item-file-file-name-color);
-}
-
-.af-item-file__file-size {
-  margin: 0;
-  padding: 0;
-  grid-area: file-size;
-  font-size: var(--af-item-file-file-size-font-size);
-  color: var(--item-file-file-size-color);
-}
-
 .af-item-file__actions {
   display: flex;
-  grid-area: actions;
-  align-items: end;
+  align-items: center;
   gap: var(--item-file-action-buttons-gap);
 }

--- a/packages/canopee-css/src/prospect-client/Form/FileUpload/ItemFile/ItemFileLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/FileUpload/ItemFile/ItemFileLF.css
@@ -3,14 +3,12 @@
 .af-item-file {
   --item-file-border-radius: var(--radius-4);
   --item-file-border-color: var(--gray-800);
-  --item-file-file-name-color: var(--gray-1000);
-  --item-file-file-size-color: var(--gray-800);
   --item-file-gap: var(--rem-8);
   --item-file-body-padding-vertical: var(--rem-16);
   --item-file-body-padding-horizontal: var(--rem-16);
   --item-file-action-buttons-gap: var(--rem-16);
 
-  > .af-item-file__body > .af-icon {
+  .af-item-file__body .af-content-item-mono .af-icon {
     --icon-fill: var(--green-1000);
   }
 
@@ -24,7 +22,7 @@
 .af-item-file--error {
   --item-file-border-color: var(--red-alert-1200);
 
-  > .af-item-file__body > .af-icon {
+  .af-item-file__body .af-content-item-mono .af-icon {
     --icon-fill: var(--red-alert-1200);
   }
 }

--- a/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/ItemFileApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/ItemFileApollo.tsx
@@ -5,7 +5,7 @@ import { Icon } from "../../../Icon/IconApollo";
 import { Spinner } from "../../../Spinner/SpinnerApollo";
 import { ItemMessage } from "../../ItemMessage/ItemMessageApollo";
 import { ItemFileCommon, type ItemFileProps } from "./ItemFileCommon";
-
+import "@axa-fr/canopee-css/prospect/ContentItemMono/ContentItemMonoApollo.css";
 import "@axa-fr/canopee-css/prospect/Form/FileUpload/ItemFile/ItemFileApollo.css";
 
 export const ItemFile = (props: ItemFileProps) => (

--- a/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/ItemFileCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/ItemFileCommon.tsx
@@ -4,8 +4,10 @@ import {
   type ComponentPropsWithoutRef,
   type ComponentType,
   type MouseEvent,
+  useMemo,
 } from "react";
 import type { ClickIconProps } from "../../../ClickIcon/ClickIconCommon";
+import { ContentItemMonoCore } from "../../../ContentItemMono/ContentItemMonoCore";
 import type { IconProps } from "../../../Icon/IconCommon";
 import type { SpinnerProps } from "../../../Spinner/SpinnerCommon";
 import { getClassName } from "../../../utilities/getClassName";
@@ -63,6 +65,7 @@ export type ItemFileCommonProps = ItemFileProps & {
 
 const BASE_UNIT = 1000;
 const BYTE_UNITS = ["Ko", "Mo", "Go"];
+
 const getReadableFileSizeString = (fileSizeInBytes: number) => {
   let i = -1;
   let fileSizeInBytesCopy = fileSizeInBytes;
@@ -99,6 +102,19 @@ export const ItemFileCommon = ({
       callback(file, e);
     };
 
+  const statusIndicator = useMemo(
+    () =>
+      isLoading && !hasError ? (
+        <ItemSpinnerComponent size={24} />
+      ) : (
+        <ItemIconComponent
+          size="S"
+          src={hasError ? errorIcon : validationIcon}
+        />
+      ),
+    [ItemIconComponent, ItemSpinnerComponent, hasError, isLoading],
+  );
+
   return (
     <section
       className={getClassName({
@@ -111,18 +127,11 @@ export const ItemFileCommon = ({
       {...props}
     >
       <div className="af-item-file__body">
-        {isLoading && !hasError ? (
-          <ItemSpinnerComponent size={24} />
-        ) : (
-          <ItemIconComponent
-            size="S"
-            src={hasError ? errorIcon : validationIcon}
-          />
-        )}
-        <p className="af-item-file__file-name">{file.name}</p>
-        <p className="af-item-file__file-size">
-          {getReadableFileSizeString(file.size)}
-        </p>
+        <ContentItemMonoCore
+          leftComponent={statusIndicator}
+          primarySubtitle={file.name}
+          subtitle={getReadableFileSizeString(file.size)}
+        />
         <div className="af-item-file__actions">
           {!isLoading && !hasError && (
             <ClickIconComponent

--- a/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/ItemFileLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/ItemFileLF.tsx
@@ -5,7 +5,7 @@ import { Icon } from "../../../Icon/IconLF";
 import { Spinner } from "../../../Spinner/SpinnerLF";
 import { ItemMessage } from "../../ItemMessage/ItemMessageLF";
 import { ItemFileCommon, type ItemFileProps } from "./ItemFileCommon";
-
+import "@axa-fr/canopee-css/client/ContentItemMono/ContentItemMonoLF.css";
 import "@axa-fr/canopee-css/client/Form/FileUpload/ItemFile/ItemFileLF.css";
 
 export const ItemFile = (props: ItemFileProps) => (

--- a/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/__tests__/ItemFile.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/FileUpload/ItemFile/__tests__/ItemFile.test.tsx
@@ -32,8 +32,12 @@ describe("<ItemFile />", () => {
   it("should render file item with file name and size", () => {
     render(<ItemFile file={mockFile} />);
 
-    expect(screen.getByText("test-document.pdf")).toBeInTheDocument();
-    expect(screen.getByText("0.1 Ko")).toBeInTheDocument();
+    expect(screen.getByText("test-document.pdf")).toHaveClass(
+      "af-content-item-mono__subtitle-primary",
+    );
+    expect(screen.getByText("0.1 Ko")).toHaveClass(
+      "af-content-item-mono__subtitle",
+    );
   });
 
   it("should display readable file sizes correctly", () => {


### PR DESCRIPTION
Align `ItemFile` with the latest Figma spec by delegating title/subtitle rendering to `ContentItemMono` on both Prospect (Apollo) and Client (LF) themes.

- Replace the legacy `.af-item-file__file-name` / `.af-item-file__file-size` markup with a `ContentItemMonoCore` that receives the status indicator as `leftComponent`, the file name as `title` and the readable file size as `subtitle`.
- Switch `.af-item-file__body` from grid-template-areas to a simple flex row (status/text on the left, actions on the right) now that the inner typography is owned by `ContentItemMono`.
- Apollo: bring `--item-file-action-buttons-gap` down from 24 to 16 to match the spec (LF was already 16).
- Apollo / LF: import the matching `ContentItemMono` theme stylesheet so the typography tokens resolve.

Public API of `ItemFile`/`ItemFileProps` is unchanged. All 954 canopee-react tests pass, including the 17 `ItemFile` tests.

Closes #1752

Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/1MOnNa2aF3auSqVZpdtrDn/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17278-56194

---
*Made with [Claude](https://claude.ai)*
