### PR TITLE
fix(client): radio inner dot size 10px to 12px (#1748)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
@@ -2,7 +2,6 @@
 
 .af-radio {
   --radio-border-color: var(--gray-800);
-  --radio-ckecked-width: var(--rem-10);
 
   &:hover,
   &:focus-within,


### PR DESCRIPTION
Aligns the Client radio inner dot with the default size: 10px to 12px (the LF override is removed, so the common 12px default applies). As a side effect, the implicit padding between the border and the dot becomes 6px (was 7px), matching the spec.

Closes #1748

https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/USvFnTQXMGTqQ0ySvqVNMI/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=141-18703

---
*Made with [Claude](https://claude.ai)*