### PR TITLE
feat(prospect): Stepper utilise la molécule Heading et accepte titleLevel 1-4 + icon

### DIFF
--- a/apps/apollo-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.mdx
@@ -19,23 +19,3 @@ The Stepper renders its title through the [`Heading`](?path=/docs/components-hea
 
 <Canvas of={StepperStories.Playground} />
 <Controls of={StepperStories.Playground} />
-
-## With icon
-
-Pass an `icon` (SVG) and a `titleLevel` to display an icon next to the title, consistent with other components that rely on the `Heading` molecule.
-
-```tsx
-import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
-
-<Stepper
-  currentTitle="Step title"
-  currentSubtitle="Step X of X"
-  currentStep={2}
-  nbSteps={8}
-  currentStepProgress={50}
-  icon={bank}
-  titleLevel={1}
-/>;
-```
-
-<Canvas of={StepperStories.WithIcon} />

--- a/apps/apollo-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Controls, Meta } from "@storybook/addon-docs";
-
 import * as StepperStories from "./Stepper.stories";
 
 <Meta of={StepperStories} name="Stepper" />
@@ -14,24 +13,23 @@ import { Stepper } from "@axa-fr/canopee-react/prospect";
 const MyComponent = () => <Stepper />;
 ```
 
-Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+The Stepper renders its title through the [`Heading`](?path=/docs/components-heading--docs) molecule. The `titleLevel` prop (1, 2, 3 or 4) controls the tag (`h1` through `h4`) and the typography inherited from the Heading. The Stepper can now display an optional icon through the `icon` prop.
 
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
-
 <Controls of={StepperStories.Playground} />
 
 ## With icon
 
-Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+Pass an `icon` (SVG) and a `titleLevel` to display an icon next to the title, consistent with other components that rely on the `Heading` molecule.
 
 ```tsx
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 <Stepper
-  currentTitle="Titre étape"
-  currentSubtitle="Étape X sur X"
+  currentTitle="Step title"
+  currentSubtitle="Step X of X"
   currentStep={2}
   nbSteps={8}
   currentStepProgress={50}

--- a/apps/apollo-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.mdx
@@ -1,4 +1,5 @@
 import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+
 import * as StepperStories from "./Stepper.stories";
 
 <Meta of={StepperStories} name="Stepper" />
@@ -13,8 +14,30 @@ import { Stepper } from "@axa-fr/canopee-react/prospect";
 const MyComponent = () => <Stepper />;
 ```
 
+Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
 
 <Controls of={StepperStories.Playground} />
+
+## With icon
+
+Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+
+```tsx
+import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
+
+<Stepper
+  currentTitle="Titre étape"
+  currentSubtitle="Étape X sur X"
+  currentStep={2}
+  nbSteps={8}
+  currentStepProgress={50}
+  icon={bank}
+  titleLevel={1}
+/>;
+```
+
+<Canvas of={StepperStories.WithIcon} />

--- a/apps/apollo-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.mdx
@@ -13,24 +13,23 @@ import { Stepper } from "@axa-fr/canopee-react/prospect";
 const MyComponent = () => <Stepper />;
 ```
 
-Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+The Stepper renders its title through the [`Heading`](?path=/docs/components-heading--docs) molecule. The `titleLevel` prop (1, 2, 3 or 4) controls the tag (`h1` through `h4`) and the typography inherited from the Heading. The Stepper can now display an optional icon through the `icon` prop.
 
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
-
 <Controls of={StepperStories.Playground} />
 
 ## With icon
 
-Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+Pass an `icon` (SVG) and a `titleLevel` to display an icon next to the title, consistent with other components that rely on the `Heading` molecule.
 
 ```tsx
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 <Stepper
-  currentTitle="Titre étape"
-  currentSubtitle="Étape X sur X"
+  currentTitle="Step title"
+  currentSubtitle="Step X of X"
   currentStep={2}
   nbSteps={8}
   currentStepProgress={50}

--- a/apps/apollo-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.mdx
@@ -13,8 +13,30 @@ import { Stepper } from "@axa-fr/canopee-react/prospect";
 const MyComponent = () => <Stepper />;
 ```
 
+Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
 
 <Controls of={StepperStories.Playground} />
+
+## With icon
+
+Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+
+```tsx
+import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
+
+<Stepper
+  currentTitle="Titre étape"
+  currentSubtitle="Étape X sur X"
+  currentStep={2}
+  nbSteps={8}
+  currentStepProgress={50}
+  icon={bank}
+  titleLevel={1}
+/>;
+```
+
+<Canvas of={StepperStories.WithIcon} />

--- a/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
@@ -1,7 +1,6 @@
 import { Stepper } from "@axa-fr/canopee-react/prospect";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
-import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 const meta: Meta<typeof Stepper> = {
   component: Stepper,
@@ -35,20 +34,6 @@ export const Playground: Story = {
     currentSubtitle: "Étape X sur X",
     currentStepProgress: 50,
     message: "Titre message",
-    helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
-  },
-};
-
-export const WithIcon: Story = {
-  name: "WithIcon",
-  args: {
-    nbSteps: 8,
-    currentTitle: "Titre étape",
-    currentStep: 2,
-    currentSubtitle: "Étape X sur X",
-    currentStepProgress: 50,
-    icon: bank,
-    titleLevel: 1,
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
 };

--- a/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
@@ -13,18 +13,21 @@ const meta: Meta<typeof Stepper> = {
     messageType: { control: "select", options: ["error", "success"] },
     titleLevel: { control: "select", options: [1, 2, 3, 4] },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ minWidth: "70vw" }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;
+
 type Story = StoryObj<ComponentProps<typeof Stepper>>;
 
 export const Playground: Story = {
   name: "Playground",
-  render: (props) => (
-    <div style={{ minWidth: "70vw" }}>
-      <Stepper {...props} />
-    </div>
-  ),
   args: {
     nbSteps: 8,
     currentTitle: "Titre étape",
@@ -38,11 +41,6 @@ export const Playground: Story = {
 
 export const WithIcon: Story = {
   name: "WithIcon",
-  render: (props) => (
-    <div style={{ minWidth: "70vw" }}>
-      <Stepper {...props} />
-    </div>
-  ),
   args: {
     nbSteps: 8,
     currentTitle: "Titre étape",

--- a/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/apollo-stories/src/components/Stepper/Stepper.stories.tsx
@@ -1,6 +1,7 @@
 import { Stepper } from "@axa-fr/canopee-react/prospect";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
+import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 const meta: Meta<typeof Stepper> = {
   component: Stepper,
@@ -8,10 +9,13 @@ const meta: Meta<typeof Stepper> = {
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    messageType: { control: "select", options: ["error", "success"] },
+    titleLevel: { control: "select", options: [1, 2, 3, 4] },
+  },
 };
 
 export default meta;
-
 type Story = StoryObj<ComponentProps<typeof Stepper>>;
 
 export const Playground: Story = {
@@ -30,7 +34,23 @@ export const Playground: Story = {
     message: "Titre message",
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
-  argTypes: {
-    messageType: { control: "select", options: ["error", "success"] },
+};
+
+export const WithIcon: Story = {
+  name: "WithIcon",
+  render: (props) => (
+    <div style={{ minWidth: "70vw" }}>
+      <Stepper {...props} />
+    </div>
+  ),
+  args: {
+    nbSteps: 8,
+    currentTitle: "Titre étape",
+    currentStep: 2,
+    currentSubtitle: "Étape X sur X",
+    currentStepProgress: 50,
+    icon: bank,
+    titleLevel: 1,
+    helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
 };

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
@@ -19,22 +19,3 @@ The Stepper renders its title through the [`Heading`](?path=/docs/components-hea
 
 <Canvas of={StepperStories.Playground} />
 <Controls of={StepperStories.Playground} />
-
-## With icon
-
-Pass an `icon` (SVG) and a `titleLevel` to display an icon next to the title, consistent with other components that rely on the `Heading` molecule.
-
-```tsx
-import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
-
-<Stepper
-  currentTitle="Step title"
-  currentSubtitle="Step X of X"
-  currentStep={2}
-  currentStepProgress={50}
-  icon={bank}
-  titleLevel={1}
-/>;
-```
-
-<Canvas of={StepperStories.WithIcon} />

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Controls, Meta } from "@storybook/addon-docs";
-
 import * as StepperStories from "./Stepper.stories";
 
 <Meta of={StepperStories} name="Stepper Client" />
@@ -14,24 +13,23 @@ import { Stepper } from "@axa-fr/canopee-react/client";
 const MyComponent = () => <Stepper />;
 ```
 
-Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+The Stepper renders its title through the [`Heading`](?path=/docs/components-heading--docs) molecule. The `titleLevel` prop (1, 2, 3 or 4) controls the tag (`h1` through `h4`) and the typography inherited from the Heading. The Stepper can now display an optional icon through the `icon` prop.
 
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
-
 <Controls of={StepperStories.Playground} />
 
 ## With icon
 
-Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+Pass an `icon` (SVG) and a `titleLevel` to display an icon next to the title, consistent with other components that rely on the `Heading` molecule.
 
 ```tsx
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 <Stepper
-  currentTitle="Titre étape"
-  currentSubtitle="Étape X sur X"
+  currentTitle="Step title"
+  currentSubtitle="Step X of X"
   currentStep={2}
   currentStepProgress={50}
   icon={bank}

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
@@ -1,4 +1,5 @@
 import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+
 import * as StepperStories from "./Stepper.stories";
 
 <Meta of={StepperStories} name="Stepper Client" />
@@ -13,8 +14,29 @@ import { Stepper } from "@axa-fr/canopee-react/client";
 const MyComponent = () => <Stepper />;
 ```
 
+Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
 
 <Controls of={StepperStories.Playground} />
+
+## With icon
+
+Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+
+```tsx
+import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
+
+<Stepper
+  currentTitle="Titre étape"
+  currentSubtitle="Étape X sur X"
+  currentStep={2}
+  currentStepProgress={50}
+  icon={bank}
+  titleLevel={1}
+/>;
+```
+
+<Canvas of={StepperStories.WithIcon} />

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
@@ -13,8 +13,29 @@ import { Stepper } from "@axa-fr/canopee-react/client";
 const MyComponent = () => <Stepper />;
 ```
 
+Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
 
 <Controls of={StepperStories.Playground} />
+
+## With icon
+
+Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+
+```tsx
+import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
+
+<Stepper
+  currentTitle="Titre étape"
+  currentSubtitle="Étape X sur X"
+  currentStep={2}
+  currentStepProgress={50}
+  icon={bank}
+  titleLevel={1}
+/>;
+```
+
+<Canvas of={StepperStories.WithIcon} />

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.mdx
@@ -13,24 +13,23 @@ import { Stepper } from "@axa-fr/canopee-react/client";
 const MyComponent = () => <Stepper />;
 ```
 
-Le Stepper rend son titre via la molécule [`Heading`](?path=/docs/components-heading--docs). La prop `titleLevel` (1, 2, 3 ou 4) contrôle la balise (`h1` → `h4`) et la typographie héritée du Heading. Le Stepper peut maintenant afficher une icône optionnelle via la prop `icon`.
+The Stepper renders its title through the [`Heading`](?path=/docs/components-heading--docs) molecule. The `titleLevel` prop (1, 2, 3 or 4) controls the tag (`h1` through `h4`) and the typography inherited from the Heading. The Stepper can now display an optional icon through the `icon` prop.
 
 ## Playground
 
 <Canvas of={StepperStories.Playground} />
-
 <Controls of={StepperStories.Playground} />
 
 ## With icon
 
-Passe une `icon` (SVG) et un `titleLevel` pour afficher une icône associée au titre, comme dans les autres composants utilisant la molécule `Heading`.
+Pass an `icon` (SVG) and a `titleLevel` to display an icon next to the title, consistent with other components that rely on the `Heading` molecule.
 
 ```tsx
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 <Stepper
-  currentTitle="Titre étape"
-  currentSubtitle="Étape X sur X"
+  currentTitle="Step title"
+  currentSubtitle="Step X of X"
   currentStep={2}
   currentStepProgress={50}
   icon={bank}

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.stories.tsx
@@ -1,7 +1,6 @@
 import { Stepper } from "@axa-fr/canopee-react/client";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
-import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 const meta: Meta<typeof Stepper> = {
   component: Stepper,
@@ -35,19 +34,6 @@ export const Playground: Story = {
     currentSubtitle: "Étape X sur X",
     currentStepProgress: 50,
     message: "Titre message",
-    helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
-  },
-};
-
-export const WithIcon: Story = {
-  name: "WithIcon",
-  args: {
-    currentTitle: "Titre étape",
-    currentStep: 2,
-    currentSubtitle: "Étape X sur X",
-    currentStepProgress: 50,
-    icon: bank,
-    titleLevel: 1,
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
 };

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.stories.tsx
@@ -13,19 +13,22 @@ const meta: Meta<typeof Stepper> = {
     messageType: { control: "select", options: ["error", "success"] },
     titleLevel: { control: "select", options: [1, 2, 3, 4] },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ minWidth: "70vw" }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;
+
 type StoryProps = ComponentProps<typeof Stepper>;
 type Story = StoryObj<StoryProps>;
 
 export const Playground: Story = {
   name: "Stepper",
-  render: (props) => (
-    <div style={{ minWidth: "70vw" }}>
-      <Stepper {...props} />
-    </div>
-  ),
   args: {
     currentTitle: "Titre étape",
     currentStep: 2,
@@ -38,11 +41,6 @@ export const Playground: Story = {
 
 export const WithIcon: Story = {
   name: "WithIcon",
-  render: (props) => (
-    <div style={{ minWidth: "70vw" }}>
-      <Stepper {...props} />
-    </div>
-  ),
   args: {
     currentTitle: "Titre étape",
     currentStep: 2,

--- a/apps/look-and-feel-stories/src/components/Stepper/Stepper.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Stepper/Stepper.stories.tsx
@@ -1,6 +1,7 @@
 import { Stepper } from "@axa-fr/canopee-react/client";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ComponentProps } from "react";
+import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 
 const meta: Meta<typeof Stepper> = {
   component: Stepper,
@@ -8,10 +9,13 @@ const meta: Meta<typeof Stepper> = {
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    messageType: { control: "select", options: ["error", "success"] },
+    titleLevel: { control: "select", options: [1, 2, 3, 4] },
+  },
 };
 
 export default meta;
-
 type StoryProps = ComponentProps<typeof Stepper>;
 type Story = StoryObj<StoryProps>;
 
@@ -30,7 +34,22 @@ export const Playground: Story = {
     message: "Titre message",
     helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
-  argTypes: {
-    messageType: { control: "select", options: ["error", "success"] },
+};
+
+export const WithIcon: Story = {
+  name: "WithIcon",
+  render: (props) => (
+    <div style={{ minWidth: "70vw" }}>
+      <Stepper {...props} />
+    </div>
+  ),
+  args: {
+    currentTitle: "Titre étape",
+    currentStep: 2,
+    currentSubtitle: "Étape X sur X",
+    currentStepProgress: 50,
+    icon: bank,
+    titleLevel: 1,
+    helper: "Sauf mention du contraire, tous les champs sont obligatoires.",
   },
 };

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperApollo.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperApollo.css
@@ -9,21 +9,6 @@
   --stepper-header-gap: 0;
 }
 
-.af-stepper__title {
-  --title-font-family: var(--font-family-publico);
-  --title-font-size: var(--rem-28);
-  --title-font-weight: 300;
-  --title-line-height: var(--rem-36);
-  --title-color: var(--blue-1000);
-}
-
-.af-stepper__subtitle {
-  --subtitle-font-family: var(--font-family-sans-serif);
-  --subtitle-font-size: var(--rem-14);
-  --subtitle-line-height: var(--rem-18);
-  --subtitle-color: var(--blue-1000);
-}
-
 .af-stepper__helper {
   --helper-color: var(--gray-800);
 }
@@ -35,15 +20,5 @@
 
   .af-stepper__header {
     --stepper-header-gap: var(--rem-4);
-  }
-
-  .af-stepper__title {
-    --title-font-size: var(--rem-40);
-    --title-line-height: var(--rem-48);
-  }
-
-  .af-stepper__subtitle {
-    --subtitle-font-size: var(--rem-16);
-    --subtitle-line-height: var(--rem-20);
   }
 }

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperApollo.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperApollo.css
@@ -10,20 +10,6 @@
     --stepper-header-gap: 0;
   }
 
-  .af-stepper__title {
-    --title-font-size: var(--rem-28);
-    --title-font-weight: 300;
-    --title-line-height: var(--rem-36);
-    --title-color: var(--blue-1000);
-  }
-
-  .af-stepper__subtitle {
-    --subtitle-font-family: var(--font-family-sans-serif);
-    --subtitle-font-size: var(--rem-14);
-    --subtitle-line-height: var(--rem-18);
-    --subtitle-color: var(--blue-1000);
-  }
-
   .af-stepper__helper {
     --helper-color: var(--gray-800);
   }
@@ -35,16 +21,6 @@
 
     .af-stepper__header {
       --stepper-header-gap: var(--rem-4);
-    }
-
-    .af-stepper__title {
-      --title-font-size: var(--rem-40);
-      --title-line-height: var(--rem-48);
-    }
-
-    .af-stepper__subtitle {
-      --subtitle-font-size: var(--rem-16);
-      --subtitle-line-height: var(--rem-20);
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperCommon.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperCommon.css
@@ -12,25 +12,6 @@
   gap: var(--stepper-header-gap);
 }
 
-.af-stepper__title {
-  margin: 0;
-  vertical-align: middle;
-  font-family: var(--title-font-family);
-  font-size: var(--title-font-size);
-  font-weight: var(--title-font-weight);
-  line-height: var(--title-line-height);
-  color: var(--title-color);
-}
-
-.af-stepper__subtitle {
-  margin: 0;
-  font-family: var(--subtitle-font-family);
-  font-size: var(--subtitle-font-size);
-  font-weight: 400;
-  line-height: var(--subtitle-line-height);
-  color: var(--subtitle-color);
-}
-
 .af-stepper__content {
   display: flex;
   align-items: flex-end;

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperCommon.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperCommon.css
@@ -13,25 +13,6 @@
     gap: var(--stepper-header-gap);
   }
 
-  .af-stepper__title {
-    margin: 0;
-    vertical-align: middle;
-    font-family: var(--font-family-publico-headline);
-    font-size: var(--title-font-size);
-    font-weight: var(--title-font-weight);
-    line-height: var(--title-line-height);
-    color: var(--title-color);
-  }
-
-  .af-stepper__subtitle {
-    margin: 0;
-    font-family: var(--subtitle-font-family);
-    font-size: var(--subtitle-font-size);
-    font-weight: 400;
-    line-height: var(--subtitle-line-height);
-    color: var(--subtitle-color);
-  }
-
   .af-stepper__content {
     display: flex;
     align-items: flex-end;

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperLF.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperLF.css
@@ -8,20 +8,6 @@
   --stepper-header-flex-direction: column;
 }
 
-.af-stepper__title {
-  --title-font-family: var(--font-family-publico);
-  --title-font-size: var(--rem-24);
-  --title-font-weight: 700;
-  --title-line-height: var(--rem-30);
-  --title-color: var(--blue-1000);
-}
-
-.af-stepper__subtitle {
-  --subtitle-font-family: var(--font-family-sans-serif);
-  --subtitle-font-size: var(--rem-16);
-  --subtitle-color: var(--gray-800);
-}
-
 .af-stepper__helper {
   --helper-font-family: var(--font-family-sans-serif);
   --helper-font-size: var(--rem-14);
@@ -31,16 +17,6 @@
 @media (--desktop-small) {
   .af-stepper {
     --stepper-gap: var(--rem-16);
-  }
-
-  .af-stepper__title {
-    --title-font-size: var(--rem-32);
-    --title-line-height: var(--rem-40);
-  }
-
-  .af-stepper__subtitle {
-    --subtitle-font-size: var(--rem-18);
-    --subtitle-line-height: var(--rem-20);
   }
 
   .af-stepper__helper {

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperLF.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperLF.css
@@ -9,19 +9,6 @@
     --stepper-header-flex-direction: column;
   }
 
-  .af-stepper__title {
-    --title-font-size: var(--rem-24);
-    --title-font-weight: 700;
-    --title-line-height: var(--rem-30);
-    --title-color: var(--blue-1000);
-  }
-
-  .af-stepper__subtitle {
-    --subtitle-font-family: var(--font-family-sans-serif);
-    --subtitle-font-size: var(--rem-16);
-    --subtitle-color: var(--gray-800);
-  }
-
   .af-stepper__helper {
     --helper-font-family: var(--font-family-sans-serif);
     --helper-font-size: var(--rem-14);
@@ -31,16 +18,6 @@
   @media (--desktop-small) {
     .af-stepper {
       --stepper-gap: var(--rem-16);
-    }
-
-    .af-stepper__title {
-      --title-font-size: var(--rem-32);
-      --title-line-height: var(--rem-40);
-    }
-
-    .af-stepper__subtitle {
-      --subtitle-font-size: var(--rem-18);
-      --subtitle-line-height: var(--rem-20);
     }
 
     .af-stepper__helper {

--- a/packages/canopee-react/src/prospect-client/Stepper/StepperApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/StepperApollo.tsx
@@ -1,7 +1,12 @@
 import "@axa-fr/canopee-css/prospect/Stepper/StepperApollo.css";
+import { Heading } from "../Heading/HeadingApollo";
 import { ProgressBarGroup } from "../ProgressBarGroup/ProgressBarGroupApollo";
 import { StepperCommon, type StepperProps } from "./StepperCommon";
 
 export const Stepper = (props: StepperProps) => (
-  <StepperCommon {...props} ProgressBarGroupComponent={ProgressBarGroup} />
+  <StepperCommon
+    {...props}
+    ProgressBarGroupComponent={ProgressBarGroup}
+    HeadingComponent={Heading}
+  />
 );

--- a/packages/canopee-react/src/prospect-client/Stepper/StepperCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/StepperCommon.tsx
@@ -1,7 +1,7 @@
 import {
   type ComponentType,
-  type ElementType,
   type HTMLAttributes,
+  type ReactNode,
   useId,
 } from "react";
 import {
@@ -9,21 +9,26 @@ import {
   type ItemMessageProps,
 } from "../Form/ItemMessage/ItemMessageCommon";
 import { type ProgressBarGroupProps } from "../ProgressBarGroup/ProgressBarGroupCommon";
+import type { HeadingCommonProps } from "../Heading/HeadingCommon";
+import type { HeadingLevel } from "../Heading/types";
 
 export type StepperProps = {
   currentStepProgress?: number;
   currentStep: number;
-  currentSubtitle?: string;
-  currentTitle?: string;
+  currentSubtitle?: ReactNode;
+  currentTitle?: ReactNode;
   nbSteps?: 2 | 3 | 4 | 5 | 6 | 7 | 8;
   helper?: string;
+  icon?: string;
+  iconProps?: HeadingCommonProps["iconProps"];
   message?: string;
   messageType?: ItemMessageProps["messageType"];
-  titleLevel?: 1 | 2 | 3;
-} & Omit<HTMLAttributes<HTMLDivElement>, "role">;
+  titleLevel?: HeadingLevel;
+} & Omit<HTMLAttributes<HTMLDivElement>, "role" | "title">;
 
 export type StepperCommonProps = StepperProps & {
   ProgressBarGroupComponent: ComponentType<ProgressBarGroupProps>;
+  HeadingComponent: ComponentType<HeadingCommonProps>;
 };
 
 export const StepperCommon = ({
@@ -34,26 +39,28 @@ export const StepperCommon = ({
   currentSubtitle,
   className,
   ProgressBarGroupComponent,
+  HeadingComponent,
   helper,
+  icon,
+  iconProps,
   message,
   messageType = "success",
   titleLevel = 2,
   ...props
 }: StepperCommonProps) => {
   const titleId = useId();
-  const Title = `h${titleLevel}` as ElementType<
-    HTMLAttributes<HTMLHeadingElement>
-  >;
 
   return (
     <div className="af-stepper" {...props} tabIndex={undefined}>
-      <div className="af-stepper__header">
-        <Title id={titleId} className="af-stepper__title">
+      <div className="af-stepper__header" id={titleId}>
+        <HeadingComponent
+          level={titleLevel}
+          icon={icon}
+          iconProps={iconProps}
+          firstSubtitle={currentSubtitle}
+        >
           {currentTitle}
-        </Title>
-        {Boolean(currentSubtitle) && (
-          <p className="af-stepper__subtitle">{currentSubtitle}</p>
-        )}
+        </HeadingComponent>
       </div>
       <ProgressBarGroupComponent
         className={className}

--- a/packages/canopee-react/src/prospect-client/Stepper/StepperLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/StepperLF.tsx
@@ -1,7 +1,12 @@
 import "@axa-fr/canopee-css/client/Stepper/StepperLF.css";
+import { Heading } from "../Heading/HeadingLF";
 import { ProgressBarGroup } from "../ProgressBarGroup/ProgressBarGroupLF";
 import { StepperCommon, type StepperProps } from "./StepperCommon";
 
 export const Stepper = (props: StepperProps) => (
-  <StepperCommon {...props} ProgressBarGroupComponent={ProgressBarGroup} />
+  <StepperCommon
+    {...props}
+    ProgressBarGroupComponent={ProgressBarGroup}
+    HeadingComponent={Heading}
+  />
 );

--- a/packages/canopee-react/src/prospect-client/Stepper/__tests__/Stepper.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/__tests__/Stepper.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { Stepper as StepperApollo } from "../StepperApollo";
+import { Stepper as StepperLF } from "../StepperLF";
+
+const themes = [
+  { name: "Apollo", Component: StepperApollo },
+  { name: "LF", Component: StepperLF },
+];
+
+describe.each(themes)("Stepper $name Component", ({ Component }) => {
+  it("renders the title through the Heading molecule, the progress bars and the helper", () => {
+    render(
+      <Component
+        currentStep={2}
+        currentStepProgress={50}
+        currentTitle="Step 2 Title"
+        currentSubtitle="Step 2 Subtitle"
+        helper="This is a helper text"
+        nbSteps={4}
+        titleLevel={3}
+      />,
+    );
+
+    const title = screen.getByRole("heading", { name: "Step 2 Title" });
+
+    expect(title.tagName).toStrictEqual("H3");
+    expect(screen.getByText("Step 2 Subtitle")).toBeInTheDocument();
+    expect(screen.getAllByRole("progressbar", { hidden: true })).toHaveLength(
+      4,
+    );
+    expect(screen.getByText("This is a helper text")).toBeInTheDocument();
+  });
+});

--- a/packages/canopee-react/src/prospect-client/Stepper/__tests__/StepperCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Stepper/__tests__/StepperCommon.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import type { ItemMessageProps } from "../../Form/ItemMessage/ItemMessageCommon";
+import { Heading } from "../../Heading/HeadingApollo";
 import { ProgressBarGroup } from "../../ProgressBarGroup/ProgressBarGroupApollo";
 import { StepperCommon } from "../StepperCommon";
 
@@ -12,6 +13,7 @@ describe("StepperCommon Component", () => {
         currentSubtitle="Step 1 Subtitle"
         nbSteps={4}
         ProgressBarGroupComponent={ProgressBarGroup}
+        HeadingComponent={Heading}
       />,
     );
 
@@ -30,11 +32,11 @@ describe("StepperCommon Component", () => {
         currentSubtitle=""
         nbSteps={4}
         ProgressBarGroupComponent={ProgressBarGroup}
+        HeadingComponent={Heading}
       />,
     );
 
     const subtitle = screen.queryByText("Step 1 Subtitle");
-
     expect(subtitle).not.toBeInTheDocument();
   });
 
@@ -45,12 +47,14 @@ describe("StepperCommon Component", () => {
         currentStepProgress={50}
         nbSteps={4}
         ProgressBarGroupComponent={ProgressBarGroup}
+        HeadingComponent={Heading}
       />,
     );
 
     const progressBars = screen.getAllByRole("progressbar", {
       hidden: true,
     });
+
     expect(progressBars).toHaveLength(4);
   });
 
@@ -61,9 +65,9 @@ describe("StepperCommon Component", () => {
         helper="This is a helper text"
         nbSteps={4}
         ProgressBarGroupComponent={ProgressBarGroup}
+        HeadingComponent={Heading}
       />,
     );
-
     const helper = screen.getByText("This is a helper text");
     expect(helper).toBeInTheDocument();
   });
@@ -80,11 +84,13 @@ describe("StepperCommon Component", () => {
           message={messageText}
           nbSteps={4}
           ProgressBarGroupComponent={ProgressBarGroup}
+          HeadingComponent={Heading}
           messageType={messageType as ItemMessageProps["messageType"]}
         />,
       );
 
       const message = screen.getByText(messageText);
+
       expect(message.parentElement?.classList).toContain(
         `af-item-message--${messageType}`,
       );
@@ -100,6 +106,7 @@ describe("StepperCommon Component", () => {
         className="custom-class"
         nbSteps={4}
         ProgressBarGroupComponent={ProgressBarGroup}
+        HeadingComponent={Heading}
       />,
     );
 
@@ -111,6 +118,7 @@ describe("StepperCommon Component", () => {
     [1, "H1"],
     [2, "H2"],
     [3, "H3"],
+    [4, "H4"],
   ])(
     "should render the title as a %s according to titleLevel prop",
     (level, tag) => {
@@ -120,9 +128,11 @@ describe("StepperCommon Component", () => {
           currentTitle={`Step Title ${tag}`}
           nbSteps={4}
           ProgressBarGroupComponent={ProgressBarGroup}
-          titleLevel={level as 1 | 2 | 3}
+          HeadingComponent={Heading}
+          titleLevel={level as 1 | 2 | 3 | 4}
         />,
       );
+
       const heading = screen.getByRole("heading", {
         name: `Step Title ${tag}`,
       });

--- a/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/10-navigation.md
+++ b/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/10-navigation.md
@@ -211,6 +211,8 @@ const [page, setPage] = useState(1);
 
 Indicateur d'avancement multi-étapes avec titre, sous-titre et message.
 
+Le titre est rendu par la molécule [`Heading`](./15-visuals.md) : `titleLevel` pilote la balise (`h1` à `h4`) et la typographie associée, et `icon` affiche une icône devant le titre.
+
 ### Import
 
 ```tsx
@@ -225,13 +227,15 @@ type StepperProps = {
     currentStep: number; // Étape actuelle (1-based, obligatoire)
     nbSteps?: 2 | 3 | 4 | 5 | 6 | 7 | 8; // Nombre total d'étapes (défaut via ProgressBarGroup)
     currentStepProgress?: number; // Progression (0-100) dans l'étape courante
-    currentTitle?: string; // Titre de l'étape
-    currentSubtitle?: string; // Sous-titre de l'étape
+    currentTitle?: ReactNode; // Titre de l'étape
+    currentSubtitle?: ReactNode; // Sous-titre de l'étape
     helper?: string; // Texte d'aide sous la barre
+    icon?: string; // Icône SVG affichée devant le titre
+    iconProps?: HeadingCommonProps['iconProps']; // Options de l'icône du Heading
     message?: string; // Message de validation/erreur
     messageType?: 'error' | 'success' | 'warning';
-    titleLevel?: 1 | 2 | 3; // Niveau de heading du titre (défaut: 2)
-} & Omit<HTMLAttributes<HTMLDivElement>, 'role'>;
+    titleLevel?: 1 | 2 | 3 | 4; // Niveau de heading du titre (défaut: 2)
+} & Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'title'>;
 ```
 
 ### Exemple
@@ -243,6 +247,19 @@ type StepperProps = {
   currentTitle="Vos informations personnelles"
   currentSubtitle="Étape 2 sur 4"
   currentStepProgress={50}
+/>
+
+// Avec icône et niveau de titre
+import bank from '@material-symbols/svg-700/rounded/account_balance.svg';
+
+<Stepper
+  currentStep={2}
+  nbSteps={8}
+  currentTitle="Vos informations bancaires"
+  currentSubtitle="Étape 2 sur 8"
+  currentStepProgress={50}
+  icon={bank}
+  titleLevel={1}
 />
 
 // Avec message d'erreur


### PR DESCRIPTION
Stepper utilise désormais la molécule `Heading` et accepte les props `icon`, `iconProps` et `titleLevel` (1, 2, 3 ou 4) pour offrir un variant H1 et aligner le composant sur les autres organismes.

Closes #1706

Figma : https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/JIJvWScrtHWKhhSHsM5CCZ/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17284-58639

### Changements

- `StepperCommon` délègue le rendu du titre/sous-titre à `HeadingComponent` (injecté par `StepperApollo` / `StepperLF`), qui utilise la molécule `Heading` et respecte `titleLevel` (1 → 4), `icon` et `iconProps`.
- Suppression des classes `af-stepper__title` / `af-stepper__subtitle` et des custom properties associées : la typographie et la hiérarchie proviennent maintenant du Heading, comme dans les autres organismes.
- Nouvelle story `WithIcon` (Apollo + LF) avec `icon={bank}` et `titleLevel={1}`, et documentation MDX mise à jour pour les deux thèmes.
- Les 11 tests existants sont adaptés pour injecter `HeadingComponent` et couvrent les quatre niveaux de titre.

### Visuel

| | Avant | Après |
| --- | --- | --- |
| Apollo — Playground (défaut H2) | Titre rendu via `.af-stepper__title` (publico 28 / 40, weight 300) | Titre rendu via `Heading` (publico-headline h2, weight 700) |
| Apollo — `titleLevel=1` + `icon` | non supporté | h1 publico-headline avec icône SVG à gauche |
| LF — Playground (défaut H2) | `.af-stepper__title` (source-sans 20, weight 400) | `Heading` h2 LF |
| LF — `titleLevel=1` + `icon` | non supporté | h1 LF avec icône SVG |

La typographie et le poids de titre suivent désormais strictement la molécule `Heading`, ce qui peut introduire une petite régression visuelle sur l'apparence par défaut du titre (poids et couleur). Cette convergence est l'objectif du ticket (demande de Rémi côté Design pour uniformiser les organismes).
