### PR TITLE
feat(client): converge Link text to Body 2 SB typography (#1753)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
@@ -4,7 +4,7 @@
   height: fit-content;
   align-items: center;
   gap: var(--rem-4);
-  font-size: var(--link-font-size, var(--rem-16));
+  font-size: var(--rem-16);
   font-weight: var(--link-font-weight, 600);
   line-height: var(--rem-20);
   text-decoration: underline;
@@ -13,7 +13,7 @@
   fill: var(--link-text-color, var(--blue-1000));
 
   @media (--desktop-small) {
-    --link-font-size: var(--rem-18);
+    font-size: var(--rem-18);
   }
 
   svg {
@@ -37,7 +37,6 @@
   &.af-btn-client {
     --link-text-color: var(--white-1000);
     --link-line-height: var(--rem-24);
-    --link-font-size: var(--rem-16);
     --link-background-color: var(--blue-1000);
 
     width: inherit;
@@ -47,7 +46,6 @@
 
     @media (--desktop-small) {
       --link-line-height: var(--rem-32);
-      --link-font-size: var(--rem-18);
     }
 
     :is(&:hover, &:active, &:focus) {

--- a/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
@@ -4,7 +4,7 @@
   height: fit-content;
   align-items: center;
   gap: var(--rem-4);
-  font-size: var(--link-font-size, var(--rem-14));
+  font-size: var(--link-font-size, var(--rem-16));
   font-weight: var(--link-font-weight, 600);
   line-height: var(--rem-20);
   text-decoration: underline;
@@ -13,7 +13,7 @@
   fill: var(--link-text-color, var(--blue-1000));
 
   @media (--desktop-small) {
-    --link-font-size: var(--rem-16);
+    --link-font-size: var(--rem-18);
   }
 
   svg {

--- a/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
@@ -5,7 +5,7 @@
     height: fit-content;
     align-items: center;
     gap: var(--rem-4);
-    font-size: var(--link-font-size, var(--rem-14));
+    font-size: var(--link-font-size, var(--rem-16));
     font-weight: var(--link-font-weight, 600);
     line-height: var(--rem-20);
     text-decoration: underline;
@@ -14,7 +14,7 @@
     fill: var(--link-text-color, var(--blue-1000));
 
     @media (--desktop-small) {
-      --link-font-size: var(--rem-16);
+      --link-font-size: var(--rem-18);
     }
 
     svg {

--- a/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkCommon.css
@@ -5,7 +5,7 @@
     height: fit-content;
     align-items: center;
     gap: var(--rem-4);
-    font-size: var(--link-font-size, var(--rem-16));
+    font-size: var(--rem-16);
     font-weight: var(--link-font-weight, 600);
     line-height: var(--rem-20);
     text-decoration: underline;
@@ -14,7 +14,7 @@
     fill: var(--link-text-color, var(--blue-1000));
 
     @media (--desktop-small) {
-      --link-font-size: var(--rem-18);
+      font-size: var(--rem-18);
     }
 
     svg {
@@ -38,7 +38,6 @@
     &.af-btn-client {
       --link-text-color: var(--white-1000);
       --link-line-height: var(--rem-24);
-      --link-font-size: var(--rem-16);
       --link-background-color: var(--blue-1000);
 
       width: inherit;
@@ -48,7 +47,6 @@
 
       @media (--desktop-small) {
         --link-line-height: var(--rem-32);
-        --link-font-size: var(--rem-18);
       }
 
       :is(&:hover, &:active, &:focus) {

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -2,11 +2,6 @@
 
 .af-link {
   --link-font-weight: 400;
-  --link-font-size: var(--rem-16);
-
-  @media (--desktop-small) {
-    --link-font-size: var(--rem-18);
-  }
 
   &.af-btn-client {
     @media (--desktop-small) {

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -1,6 +1,7 @@
 @import "./LinkCommon.css";
 
 .af-link {
+  --link-font-weight: 400;
   --link-font-size: var(--rem-16);
 
   @media (--desktop-small) {
@@ -12,4 +13,8 @@
       --link-line-height: var(--rem-24);
     }
   }
+}
+
+.af-link--openInNewTab {
+  --link-font-weight: 600;
 }

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -1,20 +1,9 @@
 @import "./LinkCommon.css";
 
 .af-link {
-  --link-font-weight: 400;
-  --link-font-size: var(--rem-16);
-
-  @media (--desktop-small) {
-    --link-font-size: var(--rem-18);
-  }
-
   &.af-btn-client {
     @media (--desktop-small) {
       --link-line-height: var(--rem-24);
     }
   }
-}
-
-.af-link--openInNewTab {
-  --link-font-weight: 600;
 }

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -1,6 +1,12 @@
 @import "./LinkCommon.css";
 
 .af-link {
+  --link-font-size: var(--rem-16);
+
+  @media (--desktop-small) {
+    --link-font-size: var(--rem-18);
+  }
+
   &.af-btn-client {
     @media (--desktop-small) {
       --link-line-height: var(--rem-24);

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -2,6 +2,12 @@
 
 @layer canopee {
   .af-link {
+    --link-font-size: var(--rem-16);
+
+    @media (--desktop-small) {
+      --link-font-size: var(--rem-18);
+    }
+
     &.af-btn-client {
       @media (--desktop-small) {
         --link-line-height: var(--rem-24);

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -3,11 +3,6 @@
 @layer canopee {
   .af-link {
     --link-font-weight: 400;
-    --link-font-size: var(--rem-16);
-
-    @media (--desktop-small) {
-      --link-font-size: var(--rem-18);
-    }
 
     &.af-btn-client {
       @media (--desktop-small) {

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -2,6 +2,7 @@
 
 @layer canopee {
   .af-link {
+    --link-font-weight: 400;
     --link-font-size: var(--rem-16);
 
     @media (--desktop-small) {
@@ -13,5 +14,9 @@
         --link-line-height: var(--rem-24);
       }
     }
+  }
+
+  .af-link--openInNewTab {
+    --link-font-weight: 600;
   }
 }

--- a/packages/canopee-css/src/prospect-client/Link/LinkLF.css
+++ b/packages/canopee-css/src/prospect-client/Link/LinkLF.css
@@ -2,21 +2,10 @@
 
 @layer canopee {
   .af-link {
-    --link-font-weight: 400;
-    --link-font-size: var(--rem-16);
-
-    @media (--desktop-small) {
-      --link-font-size: var(--rem-18);
-    }
-
     &.af-btn-client {
       @media (--desktop-small) {
         --link-line-height: var(--rem-24);
       }
     }
-  }
-
-  .af-link--openInNewTab {
-    --link-font-weight: 600;
   }
 }


### PR DESCRIPTION
Aligne la typographie du Link (Client) sur Body 2 SB (16px / 18px desktop, weight 600) en retirant la surcharge `--link-font-weight: 400` et la règle `.af-link--openInNewTab { --link-font-weight: 600 }` qui devient redondante avec la nouvelle valeur par défaut héritée de `LinkCommon`.

Mise à jour suite à l'évolution du ticket — la spec cible est Body 2 SB, pas Body 3 SB.

Closes #1753
