### PR TITLE
fix(client): ghost button desktop font size uses Body 2 (#1794)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Button/ButtonLF.css
+++ b/packages/canopee-css/src/prospect-client/Button/ButtonLF.css
@@ -68,7 +68,6 @@
   --button-text-color: var(--blue-1000);
   --button-bg-color: transparent;
   --button-padding: 0;
-  --button-font-size: var(--rem-16);
 
   &:hover,
   &:focus,


### PR DESCRIPTION
Converge the ghost button desktop font size with the other variants: Body 3 (16px) -> Body 2 (18px). Mobile is already Body 2 and stays unchanged.

Implementation: removed the `--button-font-size: var(--rem-16)` override on `.af-btn-client--ghost` so it inherits the parent `.af-btn-client` tokens (16px mobile, 18px desktop).

Closes #1794

Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/VF3Qs8fhpYSL12hXxO3bpX

---
*Made with [Claude](https://claude.ai)*