### PR TITLE
feat(client, prospect): add warning variant to Dropdown (#1723)

### DIFF
--- a/apps/apollo-stories/src/components/Dropdown/Dropdown.mdx
+++ b/apps/apollo-stories/src/components/Dropdown/Dropdown.mdx
@@ -22,3 +22,11 @@ Use the `type` prop to change the type of the select. The available variants are
 <Canvas of={DropdownStories.DropdownStory} />
 
 <Controls of={DropdownStories.DropdownStory} />
+
+## Warning
+
+Use `message` with `messageType="warning"` to display a warning state with orange border and warning icon.
+
+```tsx
+<Dropdown label="Label" message="Warning Message" messageType="warning" />
+```

--- a/apps/look-and-feel-stories/src/components/Dropdown/Dropdown.mdx
+++ b/apps/look-and-feel-stories/src/components/Dropdown/Dropdown.mdx
@@ -22,3 +22,11 @@ Use the `type` prop to change the type of the select. The available variants are
 <Canvas of={DropdownStories.DropdownStory} />
 
 <Controls of={DropdownStories.DropdownStory} />
+
+## Warning
+
+Use `message` with `messageType="warning"` to display a warning state with orange border and warning icon.
+
+```tsx
+<Dropdown label="Label" message="Warning Message" messageType="warning" />
+```

--- a/packages/canopee-css/src/prospect-client/Form/Dropdown/DropdownCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Dropdown/DropdownCommon.css
@@ -48,11 +48,20 @@
   }
 }
 
-.af-form__dropdown-input--error {
+.af-form__dropdown-input--error,
+.af-form__dropdown-input--warning {
   --dropdown-box-shadow-width: 2px;
 
   &:is(:focus-visible, :hover, :active) {
     --dropdown-box-shadow-width: 3px;
+  }
+}
+
+.af-form__dropdown-input.af-form__dropdown-input--warning {
+  --dropdown-box-shadow-color: var(--orange-1050);
+
+  &:is(:focus-visible, :hover, :active) {
+    --dropdown-box-shadow-color: var(--orange-1050);
   }
 }
 

--- a/packages/canopee-react/src/prospect-client/Form/Dropdown/DropdownCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Dropdown/DropdownCommon.tsx
@@ -83,10 +83,13 @@ const DropdownCommon = forwardRef<HTMLSelectElement, DropdownCommonProps>(
 
     const hasError =
       (Boolean(message) && messageType === "error") || Boolean(error);
+    const hasWarning =
+      !hasError && Boolean(message) && messageType === "warning";
 
     const classname = classNames(
       "af-form__dropdown-input",
       hasError && "af-form__dropdown-input--error",
+      hasWarning && "af-form__dropdown-input--warning",
     );
 
     return (
@@ -114,7 +117,6 @@ const DropdownCommon = forwardRef<HTMLSelectElement, DropdownCommonProps>(
         {helper ? (
           <span className="af-form__input-helper">{helper}</span>
         ) : null}
-
         <ItemMessageComponent
           id={idMessage}
           message={message || error || success}


### PR DESCRIPTION
Add Warning and Hover_Warning variants to Dropdown for Prospect (Apollo) and Client (LF) themes, mirroring the Input Text warning pattern (#1693 / #1774).

Impl: new `.af-form__dropdown-input--warning` modifier, applied when `message` is set with `messageType="warning"` and no `error` is present. Border color uses `--orange-1050`; error takes precedence over warning.

Closes #1723

Figma: https://www.figma.com/design/o8i4TfIg4aj3T8Q2kFpOTE/%F0%9F%9A%A7-Dropdown-%E2%80%A2-%7BEn-Design%7D---Ajout-du-variant-Warning?node-id=17278-55373

---
*Made with [Claude](https://claude.ai)*
