### PR TITLE
feat(client, prospect): converge ItemTabBar typography and padding to Body 3 (#1750)

### DIFF
--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarApollo.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarApollo.css
@@ -2,17 +2,4 @@
 
 .af-item-tab-bar {
   --item-tab-bar-font-color: var(--blue-1000);
-  --item-tab-bar-font-size: var(--rem-14);
-  --item-tab-bar-padding: var(--rem-12) var(--rem-8);
-  --item-tab-bar-box-shadow-color: var(--blue-200);
-  --item-tab-bar-outline-color: var(--blue-1000);
-
-  &[aria-selected="true"] {
-    --item-tab-bar-box-shadow-color: var(--blue-1000);
-  }
-
-  @media (--desktop-small) {
-    --item-tab-bar-font-size: var(--rem-16);
-    --item-tab-bar-padding: var(--rem-16);
-  }
 }

--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarApollo.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarApollo.css
@@ -2,7 +2,8 @@
 
 .af-item-tab-bar {
   --item-tab-bar-font-color: var(--blue-1000);
-  --item-tab-bar-padding: var(--rem-10) var(--rem-8);
+  --item-tab-bar-font-size: var(--rem-14);
+  --item-tab-bar-padding: var(--rem-12) var(--rem-8);
   --item-tab-bar-box-shadow-color: var(--blue-200);
   --item-tab-bar-outline-color: var(--blue-1000);
 
@@ -11,6 +12,7 @@
   }
 
   @media (--desktop-small) {
+    --item-tab-bar-font-size: var(--rem-16);
     --item-tab-bar-padding: var(--rem-16);
   }
 }

--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
@@ -1,9 +1,11 @@
 .af-item-tab-bar {
   --item-tab-bar-font-size: var(--rem-14);
   --item-tab-bar-padding: var(--rem-12) var(--rem-8);
+  --item-tab-bar-min-height: var(--rem-48);
   --item-tab-bar-box-shadow-color: var(--blue-200);
   --item-tab-bar-outline-color: var(--blue-1000);
 
+  min-height: var(--item-tab-bar-min-height);
   padding: var(--item-tab-bar-padding, var(--rem-16));
   border: none;
   font-size: var(--item-tab-bar-font-size, var(--rem-16));
@@ -11,7 +13,7 @@
   line-height: 125%;
   color: var(--item-tab-bar-font-color);
   background-color: transparent;
-  box-shadow: inset 0 var(--item-tab-bar-box-shadow-width, 0) 0 0
+  box-shadow: inset 0 var(--item-tab-bar-box-shadow-width, -1px) 0 0
     var(--item-tab-bar-box-shadow-color);
   outline: none;
   cursor: pointer;
@@ -34,5 +36,6 @@
   @media (--desktop-small) {
     --item-tab-bar-font-size: var(--rem-16);
     --item-tab-bar-padding: var(--rem-16);
+    --item-tab-bar-min-height: var(--rem-52);
   }
 }

--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
@@ -1,4 +1,9 @@
 .af-item-tab-bar {
+  --item-tab-bar-font-size: var(--rem-14);
+  --item-tab-bar-padding: var(--rem-12) var(--rem-8);
+  --item-tab-bar-box-shadow-color: var(--blue-200);
+  --item-tab-bar-outline-color: var(--blue-1000);
+
   padding: var(--item-tab-bar-padding, var(--rem-16));
   border: none;
   font-size: var(--item-tab-bar-font-size, var(--rem-16));
@@ -23,5 +28,11 @@
 
   &[aria-selected="true"] {
     --item-tab-bar-font-weight: 600;
+    --item-tab-bar-box-shadow-color: var(--blue-1000);
+  }
+
+  @media (--desktop-small) {
+    --item-tab-bar-font-size: var(--rem-16);
+    --item-tab-bar-padding: var(--rem-16);
   }
 }

--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarLF.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarLF.css
@@ -2,18 +2,8 @@
 
 .af-item-tab-bar {
   --item-tab-bar-font-color: var(--gray-1000);
-  --item-tab-bar-font-size: var(--rem-14);
-  --item-tab-bar-padding: var(--rem-12) var(--rem-8);
-  --item-tab-bar-box-shadow-color: var(--blue-200);
-  --item-tab-bar-outline-color: var(--blue-1000);
 
   &[aria-selected="true"] {
     --item-tab-bar-font-color: var(--blue-1000);
-    --item-tab-bar-box-shadow-color: var(--blue-1000);
-  }
-
-  @media (--desktop-small) {
-    --item-tab-bar-font-size: var(--rem-16);
-    --item-tab-bar-padding: var(--rem-16);
   }
 }

--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarLF.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarLF.css
@@ -2,9 +2,10 @@
 
 .af-item-tab-bar {
   --item-tab-bar-font-color: var(--gray-1000);
+  --item-tab-bar-font-size: var(--rem-14);
+  --item-tab-bar-padding: var(--rem-12) var(--rem-8);
   --item-tab-bar-box-shadow-color: var(--blue-200);
   --item-tab-bar-outline-color: var(--blue-1000);
-  --item-tab-bar-font-size: var(--rem-18);
 
   &[aria-selected="true"] {
     --item-tab-bar-font-color: var(--blue-1000);
@@ -12,6 +13,7 @@
   }
 
   @media (--desktop-small) {
-    --item-tab-bar-font-size: var(--rem-20);
+    --item-tab-bar-font-size: var(--rem-16);
+    --item-tab-bar-padding: var(--rem-16);
   }
 }


### PR DESCRIPTION
Converge ItemTabBar typography and padding to Body 3 (14/18 mobile, 16/20 desktop) for both Client (LF) and Prospect (Apollo).

Changes:
- **Apollo (Prospect)**: mobile font-size 16→14, mobile padding 10→12 top/bottom (horizontal stays 8px); desktop unchanged (16/16).
- **LF (Client)**: mobile font-size 18→14, desktop font-size 20→16, mobile padding 16→12 top/bottom and 16→8 left/right; desktop padding unchanged (16 all around).

Closes #1750

Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/fry1pzPqMLeObycy9IRUrj

---
*Made with [Claude](https://claude.ai)*
