### PR TITLE
feat(client,prospect): add warning variant to InputDate (#1804)

### DIFF
--- a/apps/apollo-stories/src/components/InputDate/InputDate.mdx
+++ b/apps/apollo-stories/src/components/InputDate/InputDate.mdx
@@ -36,3 +36,18 @@ For browsers _**not supporting WebKit**_ (such as Firefox), the date picker _**i
 <Canvas of={InputDateStories.InputDateDefaultStory} />
 
 <Controls of={InputDateStories.InputDateDefaultStory} />
+
+## Warning
+
+Use `message` with `messageType="warning"` to display a warning state with an orange border.
+
+```tsx
+<InputDate
+  label="Date de naissance"
+  message="Titre du message"
+  messageType="warning"
+  value={new Date("2000-09-12")}
+/>
+```
+
+<Canvas of={InputDateStories.InputDateWarningStory} />

--- a/apps/apollo-stories/src/components/InputDate/InputDate.stories.tsx
+++ b/apps/apollo-stories/src/components/InputDate/InputDate.stories.tsx
@@ -135,13 +135,3 @@ export const InputDateWarningStory: Story = {
     value: new Date("2000-09-12"),
   },
 };
-
-export const InputDateWarningEmptyStory: Story = {
-  name: "Date on warning empty",
-  render,
-  args: {
-    message: "Titre du message",
-    messageType: "warning",
-    value: undefined,
-  },
-};

--- a/apps/apollo-stories/src/components/InputDate/InputDate.stories.tsx
+++ b/apps/apollo-stories/src/components/InputDate/InputDate.stories.tsx
@@ -125,3 +125,23 @@ export const InputDateTextStory: Story = {
     hidePicker: true,
   },
 };
+
+export const InputDateWarningStory: Story = {
+  name: "Date on warning",
+  render,
+  args: {
+    message: "Titre du message",
+    messageType: "warning",
+    value: new Date("2000-09-12"),
+  },
+};
+
+export const InputDateWarningEmptyStory: Story = {
+  name: "Date on warning empty",
+  render,
+  args: {
+    message: "Titre du message",
+    messageType: "warning",
+    value: undefined,
+  },
+};

--- a/apps/look-and-feel-stories/src/components/InputDate/InputDate.mdx
+++ b/apps/look-and-feel-stories/src/components/InputDate/InputDate.mdx
@@ -36,3 +36,18 @@ For browsers _**not supporting WebKit**_ (such as Firefox), the date picker _**i
 <Canvas of={InputDateStories.InputDateDefaultStory} />
 
 <Controls of={InputDateStories.InputDateDefaultStory} />
+
+## Warning
+
+Use `message` with `messageType="warning"` to display a warning state with an orange border.
+
+```tsx
+<InputDate
+  label="Date de naissance"
+  message="Titre du message"
+  messageType="warning"
+  value={new Date("2025-01-01")}
+/>
+```
+
+<Canvas of={InputDateStories.InputDateWarningStory} />

--- a/apps/look-and-feel-stories/src/components/InputDate/InputDate.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/InputDate/InputDate.stories.tsx
@@ -131,13 +131,3 @@ export const InputDateWarningStory: Story = {
     value: new Date("2025-01-01"),
   },
 };
-
-export const InputDateWarningEmptyStory: Story = {
-  name: "Date on warning empty",
-  render,
-  args: {
-    message: "Titre du message",
-    messageType: "warning",
-    value: undefined,
-  },
-};

--- a/apps/look-and-feel-stories/src/components/InputDate/InputDate.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/InputDate/InputDate.stories.tsx
@@ -121,3 +121,23 @@ export const InputDateTextStory: Story = {
     hidePicker: true,
   },
 };
+
+export const InputDateWarningStory: Story = {
+  name: "Date on warning",
+  render,
+  args: {
+    message: "Titre du message",
+    messageType: "warning",
+    value: new Date("2025-01-01"),
+  },
+};
+
+export const InputDateWarningEmptyStory: Story = {
+  name: "Date on warning empty",
+  render,
+  args: {
+    message: "Titre du message",
+    messageType: "warning",
+    value: undefined,
+  },
+};

--- a/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateApollo.css
@@ -30,14 +30,6 @@
     }
   }
 
-  &[class*="--warning"] {
-    --input-date-box-shadow-color: var(--orange-1050);
-
-    &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
-      --input-date-box-shadow-width: 3px;
-    }
-  }
-
   &:disabled {
     --input-date-box-shadow-color: var(--gray-500);
     --input-date-color: var(--gray-500);

--- a/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateApollo.css
@@ -11,12 +11,12 @@
   --input-date-bg-color: var(--white-1000);
   --input-date-indicator-bg-color: var(--white-1000);
 
-  &[value]:not([value=""], [aria-invalid="true"]),
+  &[value]:not([value=""], [aria-invalid="true"], [class*="--warning"]),
   &:is(:focus-visible, :hover, :active, :focus-within) {
     --input-date-box-shadow-color: var(--blue-1000);
   }
 
-  &[value]:not([aria-invalid="true"], [value=""]) {
+  &[value]:not([aria-invalid="true"], [value=""], [class*="--warning"]) {
     --input-date-color: var(--blue-1000);
     --input-date-box-shadow-color: var(--blue-1000);
   }
@@ -24,6 +24,14 @@
   &[aria-invalid="true"] {
     --input-date-box-shadow-color: var(--red-alert-1000);
     --input-date-color: var(--gray-800);
+
+    &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
+      --input-date-box-shadow-width: 3px;
+    }
+  }
+
+  &[class*="--warning"] {
+    --input-date-box-shadow-color: var(--orange-1050);
 
     &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
       --input-date-box-shadow-width: 3px;

--- a/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateCommon.css
@@ -59,6 +59,14 @@
     outline-width: var(--input-date-box-shadow-width);
   }
 
+  &[class*="--warning"] {
+    --input-date-box-shadow-color: var(--orange-1050);
+
+    &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
+      --input-date-box-shadow-width: 3px;
+    }
+  }
+
   @media (--desktop-small) {
     font-size: var(--rem-18);
     line-height: 1.25;

--- a/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateCommon.css
@@ -44,7 +44,8 @@
       :hover,
       :active,
       :focus-within,
-      &[aria-invalid="true"]
+      &[aria-invalid="true"],
+      &[class*="--warning"]
     ):not(:disabled) {
     --input-date-box-shadow-width: 2px;
   }

--- a/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateLF.css
@@ -29,14 +29,6 @@
     }
   }
 
-  &[class*="--warning"] {
-    --input-date-box-shadow-color: var(--orange-1050);
-
-    &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
-      --input-date-box-shadow-width: 3px;
-    }
-  }
-
   &:disabled {
     --input-date-box-shadow-color: var(--gray-140);
     --input-date-color: var(--gray-500);

--- a/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/InputDate/InputDateLF.css
@@ -11,18 +11,26 @@
   --input-date-bg-color: var(--white-1000);
   --input-date-indicator-bg-color: var(--white-1000);
 
-  &[value]:not([value=""], [aria-invalid="true"]),
+  &[value]:not([value=""], [aria-invalid="true"], [class*="--warning"]),
   &:is(:focus-visible, :hover, :active, :focus-within) {
     --input-date-box-shadow-color: var(--blue-1000);
   }
 
-  &[value]:not([aria-invalid="true"], [value=""]) {
+  &[value]:not([aria-invalid="true"], [value=""], [class*="--warning"]) {
     --input-date-color: var(--blue-1000);
   }
 
   &[aria-invalid="true"] {
     --input-date-box-shadow-color: var(--red-alert-1200);
     --input-date-color: var(--gray-1000);
+
+    &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
+      --input-date-box-shadow-width: 3px;
+    }
+  }
+
+  &[class*="--warning"] {
+    --input-date-box-shadow-color: var(--orange-1050);
 
     &:is(:focus-visible, :hover, :active, :focus-within):not(:disabled) {
       --input-date-box-shadow-width: 3px;

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
@@ -112,7 +112,7 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
 
     const componentClassName = getClassName({
       baseClassName: "af-form__input-date",
-      modifiers: [...classModifier.split(" "), hasWarning ? "warning" : ""],
+      modifiers: [...classModifier.split(" "), hasWarning && "warning"],
       className,
     });
 

--- a/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/InputDate/InputDateCommon.tsx
@@ -85,12 +85,6 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
     },
     inputRef,
   ) => {
-    const componentClassName = getClassName({
-      baseClassName: "af-form__input-date",
-      modifiers: classModifier.split(" "),
-      className,
-    });
-
     let inputId = useId();
     inputId = otherProps.id ?? inputId;
     const idMessage = useId();
@@ -112,6 +106,15 @@ const InputDateCommon = forwardRef<HTMLInputElement, InputDateCommonProps>(
     const ariaErrormessage = hasError ? idMessage : undefined;
 
     const ariaInvalid = hasError || undefined;
+
+    const hasWarning =
+      Boolean(message) && messageType === "warning" && !hasError;
+
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-date",
+      modifiers: [...classModifier.split(" "), hasWarning ? "warning" : ""],
+      className,
+    });
 
     return (
       <div className="af-form__input-container" {...containerProps}>


### PR DESCRIPTION
Adds the `warning` and hover-warning state to the InputDate component (Apollo + LF), aligned with the InputText warning pattern (#1693).

Behavior: when `messageType="warning"` is set with a non-empty `message` and no error, the input now renders an orange (Orange-1050 / #BF4A13) border — 2px at rest, 3px on hover/focus/active.

Closes #1804
Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/b1G0wMGz53MvQCqkAQCU1X/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17278-55799

---
*Made with [Claude](https://claude.ai)*