### PR TITLE
feat(client,prospect): set TextArea min-height to 40/48px (#1599)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/TextArea/TextAreaCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/TextArea/TextAreaCommon.css
@@ -2,7 +2,7 @@
   --textarea-box-shadow-width: 1px;
 
   width: 100%;
-  min-height: var(--rem-40);
+  min-height: var(--rem-72);
   padding: var(--rem-16);
   border: none;
   border-radius: var(--textarea-border-radius);
@@ -22,7 +22,7 @@
   }
 
   @media (--desktop-small) {
-    min-height: var(--rem-48);
+    min-height: var(--rem-80);
     font-size: var(--rem-18);
   }
 

--- a/packages/canopee-css/src/prospect-client/Form/TextArea/TextAreaCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/TextArea/TextAreaCommon.css
@@ -2,6 +2,7 @@
   --textarea-box-shadow-width: 1px;
 
   width: 100%;
+  min-height: var(--rem-40);
   padding: var(--rem-16);
   border: none;
   border-radius: var(--textarea-border-radius);
@@ -21,6 +22,7 @@
   }
 
   @media (--desktop-small) {
+    min-height: var(--rem-48);
     font-size: var(--rem-18);
   }
 

--- a/packages/canopee-css/src/prospect-client/common/tokens.css
+++ b/packages/canopee-css/src/prospect-client/common/tokens.css
@@ -242,6 +242,7 @@
   --rem-52: calc(52 / var(--font-size-base) * 1rem);
   --rem-60: calc(60 / var(--font-size-base) * 1rem);
   --rem-64: calc(64 / var(--font-size-base) * 1rem);
+  --rem-72: calc(72 / var(--font-size-base) * 1rem);
   --rem-80: calc(80 / var(--font-size-base) * 1rem);
   --rem-120: calc(120 / var(--font-size-base) * 1rem);
 


### PR DESCRIPTION
Applique le min-height spécifié pour TextArea : 40px mobile, 48px desktop (valeurs suivant la règle de 8 qui correspondent à 2 lignes de contenu en Body-2).

Appliqué sur `.af-form__textarea` dans `TextAreaCommon.css` (couvre les thèmes Client/LF et Prospect/Apollo).

Closes #1599

Figma : https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/LLsnJvAf0brZi6QXD0f7y8/B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17278-55815

---
*Made with [Claude](https://claude.ai)*
