### PR TITLE
feat(client,prospect): unify Message for both Client and Prospect (#1773)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Message/MessageApollo.css
+++ b/packages/canopee-css/src/prospect-client/Message/MessageApollo.css
@@ -6,9 +6,9 @@
   --message-icon-color: var(--message-theme-color);
   --message-title-color: var(--message-theme-color);
   --message-content-color: var(--message-theme-color);
-  --message-content-font-size: 14;
+  --message-content-font-size: 16;
   --message-title-font-size: 16;
-  --message-content-line-height: var(--rem-18);
+  --message-content-line-height: var(--rem-20);
   --message-border-radius: var(--radius-8);
   --message-action-padding-top: 4;
 

--- a/packages/canopee-css/src/prospect-client/Message/MessageLF.css
+++ b/packages/canopee-css/src/prospect-client/Message/MessageLF.css
@@ -11,12 +11,12 @@
   --message-content-color: var(--gray-1000);
   --message-content-font-size: 16;
   --message-content-line-height: var(--rem-20);
-  --message-action-padding-top: 12;
+  --message-action-padding-top: 4;
 
   @media (--desktop-small) {
-    --message-content-font-size: 18;
+    --message-content-font-size: 16;
     --message-title-font-size: 18;
-    --message-content-line-height: var(--rem-23);
+    --message-content-line-height: var(--rem-20);
   }
 }
 


### PR DESCRIPTION
Cette PR concerne l'harmonisation de la structure du composant Message pour les thèmes Prospect et Client, comme mentionné dans l'issue #1773 

### Fichiers concernés par cet ajustement : 

**MessageApollo.css (Prospect / Mobile)**

- Body 2 (16px / line-height rem-20)

```
--message-content-font-size: 16;
--message-content-line-height: var(--rem-20);
```

- Spacing texte/icon déjà en place avec un gap à 8px


**MessageLF.css (Client / Desktop)**

- Body 3 (16px / line-height rem-20)

```
--message-content-font-size: 16;
--message-content-line-height: var(--rem-20);
```

- Un ajustement a été fait au niveau du padding-top de l'input action afin de pouvoir remplir les conditions d'un spacing à 8px (gap à 4px + padding-top à 4px) :

`--message-action-padding-top: 4;`


