### PR TITLE
feat(client): add handleSelectTab functionality to TabBar component

### DIFF
--- a/apps/apollo-stories/src/components/TabBar/TabBar.mdx
+++ b/apps/apollo-stories/src/components/TabBar/TabBar.mdx
@@ -57,6 +57,34 @@ const MyComponent = () => (
 );
 ```
 
+You can also handle the tab selection with the `handleSelectTab` function in each item.
+
+```tsx
+import { TabBar } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      {
+        title: "Tab 1",
+        content: "Content 1",
+        handleSelectTab: () => console.log("Tab 1 selected"),
+      },
+      {
+        title: "Tab 2",
+        content: "Content 2",
+        handleSelectTab: () => console.log("Tab 2 selected"),
+      },
+      {
+        title: "Tab 3",
+        content: "Content 3",
+        handleSelectTab: () => console.log("Tab 3 selected"),
+      },
+    ]}
+  />
+);
+```
+
 ## With text content
 
 <Canvas of={TabBarStories.TabBarStory} />

--- a/apps/apollo-stories/src/components/TabBar/TabBar.stories.tsx
+++ b/apps/apollo-stories/src/components/TabBar/TabBar.stories.tsx
@@ -1,5 +1,6 @@
 import { TabBar, tabBarDirection } from "@axa-fr/canopee-react/prospect";
 import { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { ComponentProps } from "react";
 
 const meta: Meta<typeof TabBar> = {
@@ -46,6 +47,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
     items: [
       {
         title: "ReactNode tab 1",
+        handleSelectTab: fn(() => console.log("ReactNode tab 1")),
         content: (
           <>
             <h2>Titre 1</h2>
@@ -55,6 +57,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
       },
       {
         title: "ReactNode tab 2",
+        handleSelectTab: fn(() => console.log("ReactNode tab 2")),
         content: (
           <>
             <h2>Titre 2</h2>
@@ -64,6 +67,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
       },
       {
         title: "ReactNode tab 3",
+        handleSelectTab: fn(() => console.log("ReactNode tab 3")),
         content: (
           <>
             <h2>Titre 3</h2>

--- a/apps/look-and-feel-stories/src/components/TabBar/TabBar.mdx
+++ b/apps/look-and-feel-stories/src/components/TabBar/TabBar.mdx
@@ -57,6 +57,34 @@ const MyComponent = () => (
 );
 ```
 
+You can also handle the tab selection with the `handleSelectTab` function in each item.
+
+```tsx
+import { TabBar } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <TabBar
+    items={[
+      {
+        title: "Tab 1",
+        content: "Content 1",
+        handleSelectTab: () => console.log("Tab 1 selected"),
+      },
+      {
+        title: "Tab 2",
+        content: "Content 2",
+        handleSelectTab: () => console.log("Tab 2 selected"),
+      },
+      {
+        title: "Tab 3",
+        content: "Content 3",
+        handleSelectTab: () => console.log("Tab 3 selected"),
+      },
+    ]}
+  />
+);
+```
+
 ## With text content
 
 <Canvas of={TabBarStories.TabBarStory} />

--- a/apps/look-and-feel-stories/src/components/TabBar/TabBar.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/TabBar/TabBar.stories.tsx
@@ -4,6 +4,7 @@ import {
   type TabBarProps,
 } from "@axa-fr/canopee-react/client";
 import { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { ComponentProps } from "react";
 
 const meta: Meta<typeof TabBar> = {
@@ -50,6 +51,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
     items: [
       {
         title: "ReactNode tab 1",
+        handleSelectTab: fn(() => console.log("ReactNode tab 1")),
         content: (
           <>
             <h2>Titre 1</h2>
@@ -59,6 +61,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
       },
       {
         title: "ReactNode tab 2",
+        handleSelectTab: fn(() => console.log("ReactNode tab 2")),
         content: (
           <>
             <h2>Titre 2</h2>
@@ -68,6 +71,7 @@ export const TabBarWithReactNodeStory: StoryObj<typeof TabBar> = {
       },
       {
         title: "ReactNode tab 3",
+        handleSelectTab: fn(() => console.log("ReactNode tab 3")),
         content: (
           <>
             <h2>Titre 3</h2>

--- a/packages/canopee-react/src/prospect-client/TabBar/TabBarCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/TabBar/TabBarCommon.tsx
@@ -22,6 +22,7 @@ export type TabBarDirection = keyof typeof tabBarDirection;
 export type TabBarProps = {
   items: ({
     content: ReactNode;
+    handleSelectTab?: () => void;
   } & Omit<ItemTabBarProps, "content">)[];
   preSelectedTabIndex?: number;
   direction?: TabBarDirection;
@@ -48,6 +49,11 @@ export const TabBarCommon = ({
 
   const isActive = (index: number) => index === selectedTabIndex;
 
+  const handleClickFn = (index: number) => {
+    setSelectedTabIndex(index);
+    items[index]?.handleSelectTab?.();
+  };
+
   const onChangeTab = useCallback(
     (e: React.KeyboardEvent<HTMLButtonElement>) => {
       const firstTabIndex = 0;
@@ -55,6 +61,7 @@ export const TabBarCommon = ({
 
       const goToNextTab = (nextTabIndex: number) => {
         setSelectedTabIndex(nextTabIndex);
+        items[nextTabIndex]?.handleSelectTab?.();
         buttonRefs.current[nextTabIndex].focus();
         e.stopPropagation();
         e.preventDefault();
@@ -103,7 +110,7 @@ export const TabBarCommon = ({
             aria-selected={isActive(index)}
             aria-controls={`tabpanel-${index}`}
             onKeyDown={onChangeTab}
-            onClick={() => setSelectedTabIndex(index)}
+            onClick={() => handleClickFn(index)}
             ref={(element: HTMLButtonElement) => {
               buttonRefs.current[index] = element;
             }}

--- a/packages/canopee-react/src/prospect-client/TabBar/__test__/TabBar.test.tsx
+++ b/packages/canopee-react/src/prospect-client/TabBar/__test__/TabBar.test.tsx
@@ -87,7 +87,7 @@ describe("TabBar", () => {
     );
   });
 
-  it("should change tab on click", async () => {
+  it("should change tab and call handleClick on click", async () => {
     const user = userEvent.setup();
     render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
     expect(screen.getByRole("tablist")).toBeInTheDocument();
@@ -99,9 +99,10 @@ describe("TabBar", () => {
       "aria-selected",
       "true",
     );
+    expect(handleSelectTabMock).toHaveBeenCalledOnce();
   });
 
-  it("should change tab on arrow right key press", async () => {
+  it("should change tab and call handleClick on arrow right key press", async () => {
     const user = userEvent.setup();
     render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
     expect(screen.getByRole("tablist")).toBeInTheDocument();
@@ -114,45 +115,10 @@ describe("TabBar", () => {
       "aria-selected",
       "true",
     );
-  });
-
-  it("should change tab on arrow left key press", async () => {
-    const user = userEvent.setup();
-    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
-    expect(screen.getByRole("tablist")).toBeInTheDocument();
-    expect(screen.getAllByRole("tab")).toHaveLength(3);
-    expect(screen.getByText("Content 1")).toBeInTheDocument();
-    screen.getAllByRole("tab")[0].focus();
-    await user.keyboard("{ArrowLeft}");
-    expect(screen.getByText("Content 3")).toBeInTheDocument();
-    expect(screen.getAllByRole("tab")[2]).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-  });
-
-  it("should call handleClick tab on click", async () => {
-    const user = userEvent.setup();
-    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
-    expect(screen.getByRole("tablist")).toBeInTheDocument();
-    expect(screen.getAllByRole("tab")).toHaveLength(3);
-    expect(screen.getByText("Content 1")).toBeInTheDocument();
-    await user.click(screen.getAllByRole("tab")[1]);
     expect(handleSelectTabMock).toHaveBeenCalledOnce();
   });
 
-  it("should call handleClick tab on arrow right key press", async () => {
-    const user = userEvent.setup();
-    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
-    expect(screen.getByRole("tablist")).toBeInTheDocument();
-    expect(screen.getAllByRole("tab")).toHaveLength(3);
-    expect(screen.getByText("Content 1")).toBeInTheDocument();
-    screen.getAllByRole("tab")[0].focus();
-    await user.keyboard("{ArrowRight}");
-    expect(handleSelectTabMock).toHaveBeenCalledOnce();
-  });
-
-  it("should call handleClick tab on arrow left key press", async () => {
+  it("should change tab and call handleClick on arrow left key press", async () => {
     const user = userEvent.setup();
     render(
       <TabBar
@@ -166,6 +132,11 @@ describe("TabBar", () => {
     expect(screen.getByText("Content 3")).toBeInTheDocument();
     screen.getAllByRole("tab")[2].focus();
     await user.keyboard("{ArrowLeft}");
+    expect(screen.getByText("Content 2")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")[1]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
     expect(handleSelectTabMock).toHaveBeenCalledOnce();
   });
 

--- a/packages/canopee-react/src/prospect-client/TabBar/__test__/TabBar.test.tsx
+++ b/packages/canopee-react/src/prospect-client/TabBar/__test__/TabBar.test.tsx
@@ -9,9 +9,15 @@ import {
   type TabBarDirection,
 } from "../TabBarCommon";
 
+const handleSelectTabMock = vi.fn();
+
 const tabs = [
   { title: "Tab 1", content: "Content 1" },
-  { title: "Tab 2", content: "Content 2" },
+  {
+    title: "Tab 2",
+    content: "Content 2",
+    handleSelectTab: handleSelectTabMock,
+  },
   { title: "Tab 3", content: "Content 3" },
 ];
 
@@ -22,6 +28,10 @@ const tabs2 = [
 ];
 
 describe("TabBar", () => {
+  afterEach(() => {
+    handleSelectTabMock.mockReset();
+  });
+
   it("should render the component", () => {
     render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
     expect(screen.getByRole("tablist")).toBeInTheDocument();
@@ -119,6 +129,44 @@ describe("TabBar", () => {
       "aria-selected",
       "true",
     );
+  });
+
+  it("should call handleClick tab on click", async () => {
+    const user = userEvent.setup();
+    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    await user.click(screen.getAllByRole("tab")[1]);
+    expect(handleSelectTabMock).toHaveBeenCalledOnce();
+  });
+
+  it("should call handleClick tab on arrow right key press", async () => {
+    const user = userEvent.setup();
+    render(<TabBar items={tabs} ItemTabBarComponent={ItemTabBar} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+    screen.getAllByRole("tab")[0].focus();
+    await user.keyboard("{ArrowRight}");
+    expect(handleSelectTabMock).toHaveBeenCalledOnce();
+  });
+
+  it("should call handleClick tab on arrow left key press", async () => {
+    const user = userEvent.setup();
+    render(
+      <TabBar
+        items={tabs}
+        preSelectedTabIndex={2}
+        ItemTabBarComponent={ItemTabBar}
+      />,
+    );
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByText("Content 3")).toBeInTheDocument();
+    screen.getAllByRole("tab")[2].focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(handleSelectTabMock).toHaveBeenCalledOnce();
   });
 
   it("should have no accessibility violations", async () => {


### PR DESCRIPTION
## ✨ feat(canopee): ajout d'un callback `handleSelectTab` sur les items du `TabBar`

### 📋 Résumé

Ajout d'une prop optionnelle `handleSelectTab` sur chaque item du composant `TabBar`, permettant d'exécuter une fonction de rappel lors de la sélection d'un onglet (via clic ou navigation clavier).

---

### 🔧 Changements

**`TabBarCommon.tsx`**
- Ajout de `handleSelectTab?: () => void` dans le type `TabBarProps` pour chaque item
- Création d'une fonction interne `handleClickFn` qui appelle à la fois `setSelectedTabIndex` et `handleSelectTab` de l'item concerné
- Le callback est également déclenché lors de la navigation au clavier (flèches gauche/droite) via `goToNextTab`

**`TabBar.stories.tsx` (look-and-feel)**
- Ajout du callback `handleSelectTab` sur chaque item de la story `TabBarWithReactNodeStory`, utilisant `fn()` de Storybook pour le tracking des actions

**`TabBar.test.tsx`**
- Ajout de 3 nouveaux cas de test :
  - Vérification du callback au **clic** sur un onglet
  - Vérification du callback à la **touche flèche droite**
  - Vérification du callback à la **touche flèche gauche**
- Ajout d'un mock `handleSelectTabMock` avec reset après chaque test (`afterEach`)

---

### ✅ Tests

Tous les nouveaux cas de test couvrent les interactions utilisateur (clic et clavier) et vérifient que le callback est bien appelé exactement une fois.