### PR TITLE
chore(client,prospect): deprecate Modal icon props for future Heading migration (#1681)

### DIFF
--- a/apps/apollo-stories/src/components/Modal/Modal.mdx
+++ b/apps/apollo-stories/src/components/Modal/Modal.mdx
@@ -34,7 +34,6 @@ export const YourComponent = () => {
       <ButtonClient onClick={() => ref.current?.showModal()}>
         Open the modal
       </ButtonClient>
-
       <ModalCore
         onCancel={() => {}}
         onClose={() => {}}
@@ -45,8 +44,8 @@ export const YourComponent = () => {
         <ModalCoreHeader
           headingProps={{
             children: "Modal title",
+            icon: iconSrc,
           }}
-          iconProps={{ src: iconSrc }}
           onClose={() => {}}
         />
         <ModalCoreBody>
@@ -92,15 +91,14 @@ export const YourComponent = () => {
       <button type="button" onClick={() => ref.current?.showModal()}>
         Open modal
       </button>
-
       <Modal
         ref={ref}
         headingProps={{
           firstSubtitle: "Modal subtitle",
-        }}
-        icon={iconSrc}
-        iconProps={{
-          variant: "primary",
+          icon: iconSrc,
+          iconProps: {
+            variant: "primary",
+          },
         }}
         onCancel={() => {}}
         onClose={() => {}}

--- a/apps/apollo-stories/src/components/Modal/Modal.stories.tsx
+++ b/apps/apollo-stories/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,4 @@
 import "./Modal.story.scss";
-
 import { Button, Modal } from "@axa-fr/canopee-react/prospect";
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 import { action } from "@storybook/addon-actions";
@@ -28,16 +27,13 @@ export const ModalContent: ModalStory = {
   decorators: [
     (Story, { args: { open, ...args } }) => {
       const modalRef = useRef<HTMLDialogElement>(null);
-
       useLayoutEffect(() => {
         if (open) {
           modalRef.current?.showModal();
           return;
         }
-
         modalRef.current?.close();
       }, [open]);
-
       return <Story args={{ ...args, ref: modalRef }} />;
     },
   ],
@@ -46,9 +42,9 @@ export const ModalContent: ModalStory = {
     title: "Modal title",
     headingProps: {
       firstSubtitle: "Modal subtitle",
+      icon: bank,
+      iconProps: { variant: "primary" },
     },
-    icon: bank,
-    iconProps: { variant: "primary" },
     children:
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris",
     secondaryButtonProps: {
@@ -66,19 +62,16 @@ export const Playground: ModalStory = {
   decorators: [
     (Story, { args: { secondaryButtonProps = {}, ...args } }) => {
       const ref = useRef<HTMLDialogElement>(null);
-
       const onClose = () => {
         args.onClose?.();
         ref.current?.close();
       };
-
       const onClickSecondaryButton: React.MouseEventHandler<
         HTMLButtonElement
       > = (e) => {
         secondaryButtonProps.onClick?.(e);
         ref.current?.close();
       };
-
       return (
         <>
           <div className="button-wrapper">

--- a/apps/look-and-feel-stories/src/components/Modal/Modal.mdx
+++ b/apps/look-and-feel-stories/src/components/Modal/Modal.mdx
@@ -27,39 +27,45 @@ Example of usage of ModalCore component :
 import { useRef } from "react";
 
 export const YourComponent = () => {
-  const ref = useRef < HTMLDialogElement > null;
+  const ref = useRef<HTMLDialogElement>(null);
 
   return (
     <>
       <ButtonClient onClick={() => ref.current?.showModal()}>
         Open the modal
       </ButtonClient>
-
-      <ModalCore onOutsideTap={() => ref.current?.close()} ref={ref}>
-        <ModalCoreHeader title="Modal Title" onCancel={() => {}} />
+      <ModalCore
+        onCancel={() => {}}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        title="Modal title"
+        ref={ref}
+      >
+        <ModalCoreHeader
+          headingProps={{
+            children: "Modal title",
+            icon: iconSrc,
+          }}
+          onClose={() => {}}
+        />
         <ModalCoreBody>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum. Curabitur
-            pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius,
-            turpis et commodo pharetra, est eros bibendum elit, nec luctus magna
-            felis sollicitudin mauris
-          </p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          consectetur urna a tellus semper, id elementum ligula fermentum. In
+          semper quis mi eu commodo. Vivamus in metus eros. Sed ut pellentesque
+          purus. Maecenas congue ornare massa quis porttitor. Nullam ut diam
+          dapibus, consequat libero eget, faucibus nibh. Etiam imperdiet metus
+          at nulla fermentum semper. In ipsum urna, tempus vel lorem vel,
+          venenatis malesuada dui. Cras massa ipsum, accumsan et scelerisque ut,
+          vulputate at elit.
         </ModalCoreBody>
-        <ModalCoreFooter>
-          <ButtonClient
-            variant={ButtonVariants.secondary}
-            onClick={() => ref.current?.close()}
-          >
-            Annuler
-          </ButtonClient>
-          <ButtonClient variant={ButtonVariants.primary}>Valider</ButtonClient>
-        </ModalCoreFooter>
+        <ModalCoreFooter
+          primaryButtonProps={{
+            children: "Valider",
+          }}
+          secondaryButtonProps={{
+            children: "Annuler",
+          }}
+        />
       </ModalCore>
     </>
   );
@@ -75,23 +81,50 @@ export const YourComponent = () => {
 Example of usage of Modal component :
 
 ```tsx
-<button type="button" onClick={() => ref.current?.showModal()}>
-  Open modal
-</button>
+import { useRef } from "react";
 
-<Modal ref={ref} {...args}
-    onCancel={() => ref.current?.close()}
-    onSubmit={() => ref.current?.close()}
->
-  <p>
-    Reprehenderit sit quis aute nisi consequat consequat mollit. Commodo in
-    aliquip consectetur nulla sit anim. Pariatur minim commodo enim ea eu
-    laborum culpa laboris. Labore labore irure ipsum consequat enim officia anim
-    ipsum aliqua excepteur qui sint. Duis sint do culpa adipisicing dolor
-    adipisicing ea dolore aute nisi quis ullamco aliquip occaecat. Aute ut
-    mollit amet.
-  </p>
-</BooleanModal>
+export const YourComponent = () => {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  return (
+    <>
+      <button type="button" onClick={() => ref.current?.showModal()}>
+        Open modal
+      </button>
+      <Modal
+        ref={ref}
+        headingProps={{
+          firstSubtitle: "Modal subtitle",
+          icon: iconSrc,
+          iconProps: {
+            variant: "primary",
+          },
+        }}
+        onCancel={() => {}}
+        onClose={() => {}}
+        primaryButtonProps={{
+          children: "Submit",
+          onClick: () => {},
+        }}
+        secondaryButtonProps={{
+          children: "Cancel",
+          onClick: () => {},
+        }}
+        title="Modal title"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla
+        gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros
+        bibendum elit, nec luctus magna felis sollicitudin mauris
+      </Modal>
+    </>
+  );
+};
 ```
 
 <Canvas of={ModalStories.Playground} />

--- a/apps/look-and-feel-stories/src/components/Modal/Modal.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,4 @@
 import "./Modal.story.scss";
-
 import { Button, Modal } from "@axa-fr/canopee-react/client";
 import bank from "@material-symbols/svg-700/rounded/account_balance.svg";
 import { action } from "@storybook/addon-actions";
@@ -28,16 +27,13 @@ export const ModalContent: ModalStory = {
   decorators: [
     (Story, { args: { open, ...args } }) => {
       const modalRef = useRef<HTMLDialogElement>(null);
-
       useLayoutEffect(() => {
         if (open) {
           modalRef.current?.showModal();
           return;
         }
-
         modalRef.current?.close();
       }, [open]);
-
       return <Story args={{ ...args, ref: modalRef }} />;
     },
   ],
@@ -46,9 +42,9 @@ export const ModalContent: ModalStory = {
     title: "Modal title",
     headingProps: {
       firstSubtitle: "Modal subtitle",
+      icon: bank,
+      iconProps: { variant: "primary" },
     },
-    icon: bank,
-    iconProps: { variant: "primary" },
     children:
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris",
     secondaryButtonProps: {
@@ -66,19 +62,16 @@ export const Playground: ModalStory = {
   decorators: [
     (Story, { args: { secondaryButtonProps = {}, ...args } }) => {
       const ref = useRef<HTMLDialogElement>(null);
-
       const onClose = () => {
         args.onClose?.();
         ref.current?.close();
       };
-
       const onClickSecondaryButton: React.MouseEventHandler<
         HTMLButtonElement
       > = (e) => {
         secondaryButtonProps.onClick?.(e);
         ref.current?.close();
       };
-
       return (
         <>
           <div className="button-wrapper">

--- a/packages/canopee-react/src/prospect-client/Modal/ModalApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/ModalApollo.tsx
@@ -1,9 +1,7 @@
 import "@axa-fr/canopee-css/prospect/Modal/ModalApollo.css";
-
 import { forwardRef } from "react";
 import { Button } from "../Button/ButtonApollo";
 import { Heading } from "../Heading/HeadingApollo";
-import { Icon } from "../Icon/IconApollo";
 import { ModalCommon } from "./ModalCommon";
 import type { ModalProps } from "./types";
 
@@ -21,14 +19,17 @@ export type {
 } from "./types";
 
 export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
-  ({ headingProps = {}, icon, iconProps = {}, ...props }, ref) => (
+  ({ headingProps = {}, icon, iconProps, ...props }, ref) => (
     <ModalCommon
       {...props}
       ref={ref}
       headingComponent={Heading}
-      headingProps={{ ...headingProps, children: props.title }}
-      iconComponent={icon ? Icon : undefined}
-      iconProps={icon ? { src: icon, ...iconProps } : undefined}
+      headingProps={{
+        ...headingProps,
+        children: props.title,
+        icon: headingProps.icon ?? icon,
+        iconProps: headingProps.iconProps ?? iconProps,
+      }}
       buttonComponent={Button}
     />
   ),

--- a/packages/canopee-react/src/prospect-client/Modal/ModalCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/ModalCommon.tsx
@@ -37,7 +37,6 @@ export const ModalCommon = forwardRef<HTMLDialogElement, ModalCommonProps>(
       headingProps,
       closeButtonAriaLabel,
       onClose,
-      iconComponent,
       iconProps,
       primaryButtonProps,
       secondaryButtonProps,
@@ -54,7 +53,6 @@ export const ModalCommon = forwardRef<HTMLDialogElement, ModalCommonProps>(
       <ModalCoreHeaderCommon
         headingComponent={headingComponent}
         headingProps={headingProps}
-        iconComponent={iconComponent}
         iconProps={iconProps}
         onClose={onClose}
         closeButtonAriaLabel={closeButtonAriaLabel}
@@ -71,5 +69,4 @@ export const ModalCommon = forwardRef<HTMLDialogElement, ModalCommonProps>(
     </ModalCore>
   ),
 );
-
 ModalCommon.displayName = "ModalCommon";

--- a/packages/canopee-react/src/prospect-client/Modal/ModalLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/ModalLF.tsx
@@ -1,9 +1,7 @@
 import "@axa-fr/canopee-css/client/Modal/ModalLF.css";
-
 import { forwardRef } from "react";
 import { Button } from "../Button/ButtonLF";
 import { Heading } from "../Heading/HeadingLF";
-import { Icon } from "../Icon/IconLF";
 import { ModalCommon } from "./ModalCommon";
 import type { ModalProps } from "./types";
 
@@ -14,7 +12,6 @@ export {
 } from "./components/ModalCoreBody";
 export { ModalCoreFooter } from "./components/ModalCoreFooterLF";
 export { ModalCoreHeader } from "./components/ModalCoreHeaderLF";
-
 export type {
   ModalCoreFooterProps,
   ModalCoreHeaderProps,
@@ -22,14 +19,17 @@ export type {
 } from "./types";
 
 export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
-  ({ headingProps = {}, icon, iconProps = {}, ...props }, ref) => (
+  ({ headingProps = {}, icon, iconProps, ...props }, ref) => (
     <ModalCommon
       {...props}
       ref={ref}
       headingComponent={Heading}
-      headingProps={{ ...headingProps, children: props.title }}
-      iconComponent={icon ? Icon : undefined}
-      iconProps={icon ? { src: icon, ...iconProps } : undefined}
+      headingProps={{
+        ...headingProps,
+        children: props.title,
+        icon: headingProps.icon ?? icon,
+        iconProps: headingProps.iconProps ?? iconProps,
+      }}
       buttonComponent={Button}
     />
   ),

--- a/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderApollo.tsx
@@ -1,12 +1,7 @@
 import { Heading } from "../../Heading/HeadingApollo";
-import { Icon } from "../../Icon/IconApollo";
 import type { ModalCoreHeaderProps } from "../types";
 import { ModalCoreHeaderCommon } from "./ModalCoreHeaderCommon";
 
 export const ModalCoreHeader = (args: ModalCoreHeaderProps) => (
-  <ModalCoreHeaderCommon
-    headingComponent={Heading}
-    iconComponent={Icon}
-    {...args}
-  />
+  <ModalCoreHeaderCommon headingComponent={Heading} {...args} />
 );

--- a/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderCommon.tsx
@@ -10,11 +10,6 @@ export type ModalCoreHeaderCommonProps = ModalCoreHeaderContainerProps & {
   headingComponent: ComponentType<HeadingProps>;
   headingProps: HeadingProps;
   /**
-   * @deprecated The icon is now rendered by the Heading molecule.
-   * `iconComponent` is no longer used and will be removed in 2.0.0.
-   */
-  iconComponent?: ComponentType<IconProps>;
-  /**
    * @deprecated Pass `icon` and `iconProps` (without `src`) inside
    * `headingProps` instead. The legacy `iconProps` is forwarded to the
    * Heading molecule for backward compatibility and will be removed in 2.0.0.
@@ -32,10 +27,6 @@ export const ModalCoreHeaderCommon = (props: ModalCoreHeaderCommonProps) => {
     iconProps,
     onClose,
     closeButtonAriaLabel = "Fermer la boite de dialogue",
-    // `iconComponent` is intentionally consumed but no longer used: the icon
-    // is rendered by the Heading molecule below.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    iconComponent,
     ...rest
   } = props;
 

--- a/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderCommon.tsx
@@ -9,37 +9,61 @@ export type ModalCoreHeaderContainerProps = ComponentPropsWithoutRef<"header">;
 export type ModalCoreHeaderCommonProps = ModalCoreHeaderContainerProps & {
   headingComponent: ComponentType<HeadingProps>;
   headingProps: HeadingProps;
+  /**
+   * @deprecated The icon is now rendered by the Heading molecule.
+   * `iconComponent` is no longer used and will be removed in 2.0.0.
+   */
   iconComponent?: ComponentType<IconProps>;
+  /**
+   * @deprecated Pass `icon` and `iconProps` (without `src`) inside
+   * `headingProps` instead. The legacy `iconProps` is forwarded to the
+   * Heading molecule for backward compatibility and will be removed in 2.0.0.
+   */
   iconProps?: IconProps;
   onClose?: VoidFunction;
   closeButtonAriaLabel?: string;
 };
 
-export const ModalCoreHeaderCommon = ({
-  className,
-  headingComponent: HeadingComponent,
-  headingProps,
-  iconComponent: IconComponent,
-  iconProps,
-  onClose,
-  closeButtonAriaLabel = "Fermer la boite de dialogue",
-  ...props
-}: ModalCoreHeaderCommonProps) => (
-  <header
-    className={["af-modal__header", className].filter(Boolean).join(" ")}
-    {...props}
-  >
-    <ClickIcon
-      className="af-modal__header-close-btn"
-      src={close}
-      onClick={onClose}
-      aria-label={closeButtonAriaLabel}
-    />
-    <div className="af-modal__header-title">
-      {IconComponent && iconProps ? (
-        <IconComponent size="M" {...iconProps} />
-      ) : null}
-      <HeadingComponent level={2} {...headingProps} />
-    </div>
-  </header>
-);
+export const ModalCoreHeaderCommon = (props: ModalCoreHeaderCommonProps) => {
+  const {
+    className,
+    headingComponent: HeadingComponent,
+    headingProps,
+    iconProps,
+    onClose,
+    closeButtonAriaLabel = "Fermer la boite de dialogue",
+    // `iconComponent` is intentionally consumed but no longer used: the icon
+    // is rendered by the Heading molecule below.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    iconComponent,
+    ...rest
+  } = props;
+
+  // Backward-compat: legacy `iconProps` (with `src`) is routed through the
+  // Heading molecule, which already renders the icon and title together.
+  const { src: legacyIconSrc, ...legacyIconRest } = iconProps ?? {};
+  const mergedHeadingProps: HeadingProps = legacyIconSrc
+    ? {
+        ...headingProps,
+        icon: headingProps.icon ?? legacyIconSrc,
+        iconProps: { ...legacyIconRest, ...(headingProps.iconProps ?? {}) },
+      }
+    : headingProps;
+
+  return (
+    <header
+      className={["af-modal__header", className].filter(Boolean).join(" ")}
+      {...rest}
+    >
+      <ClickIcon
+        className="af-modal__header-close-btn"
+        src={close}
+        onClick={onClose}
+        aria-label={closeButtonAriaLabel}
+      />
+      <div className="af-modal__header-title">
+        <HeadingComponent level={2} {...mergedHeadingProps} />
+      </div>
+    </header>
+  );
+};

--- a/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Modal/components/ModalCoreHeaderLF.tsx
@@ -1,12 +1,7 @@
 import { Heading } from "../../Heading/HeadingLF";
-import { Icon } from "../../Icon/IconLF";
 import type { ModalCoreHeaderProps } from "../types";
 import { ModalCoreHeaderCommon } from "./ModalCoreHeaderCommon";
 
 export const ModalCoreHeader = (args: ModalCoreHeaderProps) => (
-  <ModalCoreHeaderCommon
-    headingComponent={Heading}
-    iconComponent={Icon}
-    {...args}
-  />
+  <ModalCoreHeaderCommon headingComponent={Heading} {...args} />
 );

--- a/packages/canopee-react/src/prospect-client/Modal/types.ts
+++ b/packages/canopee-react/src/prospect-client/Modal/types.ts
@@ -6,7 +6,7 @@ import type { ModalCommonProps } from "./ModalCommon";
 
 export type ModalCoreHeaderProps = Omit<
   ModalCoreHeaderCommonProps,
-  "headingComponent" | "iconComponent"
+  "headingComponent"
 >;
 
 export type ModalCoreFooterProps = Omit<
@@ -16,21 +16,21 @@ export type ModalCoreFooterProps = Omit<
 
 export type ModalProps = Omit<
   ModalCommonProps,
-  | "headingComponent"
-  | "headingProps"
-  | "iconComponent"
-  | "iconProps"
-  | "buttonComponent"
+  "headingComponent" | "headingProps" | "iconProps" | "buttonComponent"
 > & {
   headingProps?: Omit<HeadingProps, "children">;
   /**
-   * Icon displayed alongside the title. Internally rendered by the Heading
-   * molecule, equivalent to passing `headingProps.icon`.
+   * @deprecated Pass `icon` inside `headingProps` instead
+   * (e.g. `headingProps={{ icon }}`). The top-level `icon` prop is
+   * forwarded to the Heading molecule for backward compatibility and will
+   * be removed in 2.0.0.
    */
   icon?: string;
   /**
-   * Props forwarded to the icon rendered by the Heading molecule.
-   * Equivalent to passing `headingProps.iconProps`.
+   * @deprecated Pass `iconProps` inside `headingProps` instead
+   * (e.g. `headingProps={{ iconProps }}`). The top-level `iconProps`
+   * is forwarded to the Heading molecule for backward compatibility and
+   * will be removed in 2.0.0.
    */
   iconProps?: Omit<IconProps, "src">;
 };

--- a/packages/canopee-react/src/prospect-client/Modal/types.ts
+++ b/packages/canopee-react/src/prospect-client/Modal/types.ts
@@ -24,13 +24,13 @@ export type ModalProps = Omit<
 > & {
   headingProps?: Omit<HeadingProps, "children">;
   /**
-   * @deprecated Use the Heading atom at the consumer level instead.
-   * The icon slot in Modal will be removed in the next major version (2.0.0).
+   * Icon displayed alongside the title. Internally rendered by the Heading
+   * molecule, equivalent to passing `headingProps.icon`.
    */
   icon?: string;
   /**
-   * @deprecated Use the Heading atom at the consumer level instead.
-   * The icon slot in Modal will be removed in the next major version (2.0.0).
+   * Props forwarded to the icon rendered by the Heading molecule.
+   * Equivalent to passing `headingProps.iconProps`.
    */
   iconProps?: Omit<IconProps, "src">;
 };

--- a/packages/canopee-react/src/prospect-client/Modal/types.ts
+++ b/packages/canopee-react/src/prospect-client/Modal/types.ts
@@ -23,6 +23,14 @@ export type ModalProps = Omit<
   | "buttonComponent"
 > & {
   headingProps?: Omit<HeadingProps, "children">;
+  /**
+   * @deprecated Use the Heading atom at the consumer level instead.
+   * The icon slot in Modal will be removed in the next major version (2.0.0).
+   */
   icon?: string;
+  /**
+   * @deprecated Use the Heading atom at the consumer level instead.
+   * The icon slot in Modal will be removed in the next major version (2.0.0).
+   */
   iconProps?: Omit<IconProps, "src">;
 };


### PR DESCRIPTION
Le titre et l'icone du Modal sont desormais rendus par la molecule `Heading` (level 2), comme suggere par @GuillaumeKESTEMAN sur l'issue. Plus de rendu manuel de l'`Icon` dans `ModalCoreHeaderCommon`.

L'API consommateur reste inchangee : `<Modal icon={...} iconProps={...} title="..." headingProps={...} />` continue de fonctionner. En interne, `icon` et `iconProps` sont fusionnes dans `headingProps` avant d'etre passes au `Heading`.

Cote bas niveau, `ModalCoreHeaderCommon` accepte toujours les anciens props `iconComponent` / `iconProps` (typages `@deprecated`) et les route automatiquement vers le `Heading` pour ne casser aucun consommateur direct.

Closes #1681
