### PR TITLE
feat(prospect): apply 4px gap to CardCheckboxOption content in all variants (#1782)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css
@@ -25,13 +25,11 @@
   }
 }
 
+.af-card-checkbox-option .af-card-checkbox-option__content {
+  --checkbox-option-gap: var(--rem-4);
+}
+
 .af-card-checkbox-option--horizontal {
-  --checkbox-option-gap: var(--rem-8);
-
-  & .af-card-checkbox-option__content {
-    --checkbox-option-gap: var(--rem-4);
-  }
-
   & .af-checkbox {
     margin-right: var(--rem-8);
   }


### PR DESCRIPTION
Prospect: CardCheckboxOption content gap reduit de 8px a 4px dans toutes les variantes (spec issue, bullet 1 cote Prospect).

Deplacement de l override `--checkbox-option-gap: var(--rem-4)` sur `__content` du bloc `.af-card-checkbox-option--horizontal` vers une regle dediee au niveau root, et suppression du `--checkbox-option-gap: var(--rem-8)` redondant sur la variante horizontale (identique au defaut). Meme pattern que #1785 pour CardRadioOption.

Refs #1782 (partie Prospect uniquement - Client necessite restructuration: passage checkbox en dessous + gaps horizontale, clarifie mais impact structurel plus large, prevu dans une PR distincte).

Lien Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/0WnBNpmJSxomOcjRWNvFVi/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=17278-55403

## Note visuelle

![screenshot-cardcheckbox-1818](https://github.com/Debaerdm/gitshot-images/releases/download/_gitshot/screenshot-cardcheckbox-1818-39ae78ed.png)

---
*Made with [Claude](https://claude.ai)*