### PR TITLE
fix(client,prospect): suppress ItemTabBar focus ring on selected tab (#1601)

### DIFF
--- a/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
+++ b/packages/canopee-css/src/prospect-client/ItemTabBar/ItemTabBarCommon.css
@@ -16,7 +16,11 @@
     --item-tab-bar-box-shadow-width: -4px;
   }
 
-  &:focus-visible {
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible:not([aria-selected="true"]) {
     outline: 2px solid var(--item-tab-bar-outline-color);
     outline-offset: 2px;
   }


### PR DESCRIPTION
When a tab is activated (aria-selected=true), the browser keyboard focus ring was still visible alongside the active-tab underline, creating a cluttered look on click. The underline already indicates the active/focused state.

Fix: skip `:focus-visible` outline when `[aria-selected="true"]`. Unselected tabs keep their focus ring for keyboard a11y. Also adds an explicit `&:focus { outline: none; }` reset per the DS focus convention.

Closes #1601

## Visuel
| Avant | Après |
|-------|-------|
| ![ds-before](https://github.com/Debaerdm/gitshot-images/releases/download/_gitshot/ds-before-114517d8.png) | ![ds-after](https://github.com/Debaerdm/gitshot-images/releases/download/_gitshot/ds-after-1ea855ec.png) |

---
*Made with [Claude](https://claude.ai)*
