### PR TITLE
fix(distributeur): corrections du gras des titres et couleurs des values dans restit

### DIFF
--- a/packages/canopee-css/src/distributeur/Restitution/Restitution.css
+++ b/packages/canopee-css/src/distributeur/Restitution/Restitution.css
@@ -35,7 +35,7 @@
 .af-restitution__content-title {
   margin-bottom: 1.25rem;
   font-size: 1.25rem;
-  font-weight: 600;
+  font-weight: normal;
   color: var(--brand-primary);
 }
 
@@ -114,7 +114,6 @@
   padding-left: 0.5rem;
   flex-basis: 50%;
   font-weight: 600;
-  color: var(--azur);
 }
 
 .af-restitution__listdef--marge {


### PR DESCRIPTION
NOW: 
<img width="2228" height="728" alt="image" src="https://github.com/user-attachments/assets/63091963-90ef-47b0-967d-48b7f736eee0" />

Before :
<img width="2228" height="728" alt="image" src="https://github.com/user-attachments/assets/becf4442-3e8f-4ef4-bcde-a37d49d7a3e8" />
