### PR TITLE
feat(client): checkbox icon 16px with 4px padding (#1749)

### DIFF
--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -6,6 +6,10 @@
   --checkbox-background-color: var(--white-1000);
   --checkbox-border-color: var(--gray-500);
 
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: var(--rem-16) var(--rem-16);
+
   &:hover,
   &:focus-within,
   &:checked {


### PR DESCRIPTION
Checkbox icon now renders at 16x16 with 4px padding around it (24x24 container unchanged). Client theme only per issue scope.

- Added `background-size: var(--rem-16)` to constrain the check glyph to 16px
- Added `background-position: center` + `background-repeat: no-repeat` for clean centering

Closes #1749

Figma: https://www.figma.com/design/vwprvN2ELfI50pjU6MK1Ea/branch/maF2jngJCOmul4sXV06eVc/%E2%9C%A8-B2C-%E2%80%A2-Design-System-Canop%C3%A9e?node-id=141-18706

## Visuel
| Avant | Après |
|-------|-------|
| ![ds-before](https://github.com/Debaerdm/gitshot-images/releases/download/_gitshot/ds-before-46ce3cd2.png) | ![ds-after](https://github.com/Debaerdm/gitshot-images/releases/download/_gitshot/ds-after-11d96e0f.png) |

---
*Made with [Claude](https://claude.ai)*
