### PR TITLE
fix(slash): rework Title so contentLeft sits next to the heading

### DIFF
--- a/packages/canopee-css/src/distributeur/Title/Title.css
+++ b/packages/canopee-css/src/distributeur/Title/Title.css
@@ -12,52 +12,48 @@ h4.af-title {
 
 .af-title {
   position: relative;
-  flex: 1;
   overflow: hidden;
   font-weight: 600;
   color: var(--gray80);
 }
 
-.af-title--container {
+.af-title--content {
   display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
-.af-title--container > * {
+.af-title--content > .af-title {
+  flex: 0 0 auto;
+}
+
+.af-title--content .content-left,
+.af-title--content .content-right {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
 }
 
-.af-title--container .content-right {
-  margin-bottom: 0.5em;
+.af-title--content .content-left > .af-btn,
+.af-title--content .content-right > .af-btn {
+  width: auto;
 }
 
-.af-title::after {
-  z-index: 1;
-  width: 100%;
-  height: 1px;
-  margin: 0.5rem 1rem;
-  flex: 1;
-  background-color: var(--gray40);
-  content: " ";
+.af-title--container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.af-title--container > .af-title {
+  flex: 0 0 auto;
+}
+
+.af-title--container > .af-title--content {
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .af-title + .af-title {
   margin-top: 0;
-}
-
-.af-title--content {
-  margin: 2rem 0 3rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--gray40);
-  font-size: 1.75em;
-  font-weight: 600;
-  color: var(--gray80);
-}
-
-.af-title--content:nth-child(1) {
-  margin-top: 0;
-}
-
-.af-title > :first-child {
-  margin-left: 1.5rem;
 }

--- a/packages/canopee-react/src/distributeur/Title/Title.tsx
+++ b/packages/canopee-react/src/distributeur/Title/Title.tsx
@@ -7,6 +7,7 @@ import {
   forwardRef,
 } from "react";
 
+import { Divider } from "../Divider/Divider";
 import { getComponentClassName } from "../utilities";
 
 type Headings = "h2" | "h3" | "h4";
@@ -42,14 +43,23 @@ export const Title = forwardRef<
       baseClass,
     );
 
+    const hasContent = Boolean(contentLeft || contentRight);
+
     return (
       <div className={`${baseClass}--container`}>
         <Heading ref={ref} className={componentClassName} {...otherProps}>
           {children}
-          {contentLeft}
         </Heading>
-        {contentRight ? (
-          <div className="content-right">{contentRight}</div>
+        {hasContent ? (
+          <div className={`${baseClass}--content`}>
+            {contentLeft ? (
+              <div className="content-left">{contentLeft}</div>
+            ) : null}
+            <Divider mode="horizontal" />
+            {contentRight ? (
+              <div className="content-right">{contentRight}</div>
+            ) : null}
+          </div>
         ) : null}
       </div>
     );

--- a/packages/canopee-react/src/distributeur/Title/Title.tsx
+++ b/packages/canopee-react/src/distributeur/Title/Title.tsx
@@ -7,6 +7,7 @@ import {
   forwardRef,
 } from "react";
 
+import { Divider } from "../Divider/Divider";
 import { getClassName } from "../utilities/helpers/getClassName";
 
 type Headings = "h2" | "h3" | "h4";
@@ -43,14 +44,23 @@ export const Title = forwardRef<
       className,
     });
 
+    const hasContent = Boolean(contentLeft || contentRight);
+
     return (
       <div className={`${baseClass}--container`}>
         <Heading ref={ref} className={componentClassName} {...otherProps}>
           {children}
-          {contentLeft}
         </Heading>
-        {contentRight ? (
-          <div className="content-right">{contentRight}</div>
+        {hasContent ? (
+          <div className={`${baseClass}--content`}>
+            {contentLeft ? (
+              <div className="content-left">{contentLeft}</div>
+            ) : null}
+            <Divider mode="horizontal" />
+            {contentRight ? (
+              <div className="content-right">{contentRight}</div>
+            ) : null}
+          </div>
         ) : null}
       </div>
     );

--- a/packages/canopee-react/src/distributeur/Title/__tests__/Title.test.tsx
+++ b/packages/canopee-react/src/distributeur/Title/__tests__/Title.test.tsx
@@ -1,133 +1,118 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { Title } from "../Title";
 
 describe("Title", () => {
   it("should render children", () => {
-    // Act
     render(<Title>A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).toBeInTheDocument();
   });
 
   it("should have default class", () => {
-    // Act
     render(<Title>A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("af-title", {
-      exact: true,
-    });
+    ).toHaveClass("af-title", { exact: true });
   });
 
   it("should have custom class", () => {
-    // Act
     render(<Title className="custom-class">A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("custom-class", {
-      exact: true,
-    });
+    ).toHaveClass("custom-class", { exact: true });
   });
 
   it("should have custom class with modifier", () => {
-    // Act
     render(
       <Title className="custom-class" classModifier="modifier">
         A title
       </Title>,
     );
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("custom-class custom-class--modifier", {
-      exact: true,
-    });
+    ).toHaveClass("custom-class custom-class--modifier", { exact: true });
   });
 
   it("should not have classModifier attribute", () => {
-    // Act
     render(
       <Title className="custom-class" classModifier="modifier">
         A title
       </Title>,
     );
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).not.toHaveAttribute("classModifier");
   });
 
   it("should have correct heading level", () => {
-    // Act
     render(<Title heading="h3">A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 3 }),
     ).toBeInTheDocument();
   });
 
   it("shouldn't have an accessibility violation <Title/>", async () => {
-    // Act
     const { container } = render(<Title heading="h3">A title</Title>);
 
-    // Assert
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("should be wrapped in a container", async () => {
-    // Act
+  it("should be wrapped in a container", () => {
     render(<Title heading="h3">A title</Title>);
 
-    // Assert
     const container = screen.getByRole("heading", {
       name: /A title/,
       level: 3,
-    }).parentElement as HTMLElement;
-    expect(container.getAttribute("class")).toEqual("af-title--container");
-  });
-
-  it("content left should be child of heading", () => {
-    // Act
-    render(
-      <Title heading="h3" contentLeft={<p>Some content</p>}>
-        A title
-      </Title>,
-    );
-
-    // Assert
-    const heading = screen.getByRole("heading", {
-      level: 3,
-    });
-
-    expect(within(heading).getByText("Some content")).toBeInTheDocument();
-  });
-
-  it("content right should be child of content-right div", () => {
-    // Act
-    render(
-      <Title heading="h3" contentRight={<p>Some content</p>}>
-        A title
-      </Title>,
-    );
-
-    // Assert
-    const container = screen.getByRole("heading", {
-      level: 3,
     }).parentElement!;
+    expect(container).toHaveClass("af-title--container");
+  });
 
-    expect(
-      within(container.childNodes[1] as HTMLElement).getByText("Some content"),
-    ).toBeInTheDocument();
+  it("renders contentLeft inside .content-left wrapper outside the heading", () => {
+    render(
+      <Title heading="h3" contentLeft={<p>Left content</p>}>
+        A title
+      </Title>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading.textContent).not.toContain("Left content");
+
+    const wrapper = screen.getByText("Left content").closest(".content-left");
+    expect(wrapper).not.toBeNull();
+  });
+
+  it("renders contentRight inside .content-right wrapper", () => {
+    render(
+      <Title heading="h3" contentRight={<p>Right content</p>}>
+        A title
+      </Title>,
+    );
+
+    const wrapper = screen.getByText("Right content").closest(".content-right");
+    expect(wrapper).not.toBeNull();
+  });
+
+  it("renders a horizontal divider between left and right contents", () => {
+    render(
+      <Title
+        heading="h3"
+        contentLeft={<span>L</span>}
+        contentRight={<span>R</span>}
+      >
+        A title
+      </Title>,
+    );
+
+    const container = screen.getByRole("heading", { level: 3 }).parentElement!;
+    const content = container.querySelector(".af-title--content")!;
+    expect(content.querySelector("hr.af-divider")).not.toBeNull();
   });
 });

--- a/packages/canopee-react/src/distributeur/Title/__tests__/Title.test.tsx
+++ b/packages/canopee-react/src/distributeur/Title/__tests__/Title.test.tsx
@@ -1,35 +1,27 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { Title } from "../Title";
 
 describe("Title", () => {
   it("should render children", () => {
-    // Act
     render(<Title>A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).toBeInTheDocument();
   });
 
   it("should have default class", () => {
-    // Act
     render(<Title>A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("af-title", {
-      exact: true,
-    });
+    ).toHaveClass("af-title", { exact: true });
   });
 
   it("should have custom class", () => {
-    // Act
     render(<Title className="custom-class">A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).toHaveClass("af-title custom-class", {
@@ -38,14 +30,12 @@ describe("Title", () => {
   });
 
   it("should have custom class with modifier", () => {
-    // Act
     render(
       <Title className="custom-class" classModifier="modifier">
         A title
       </Title>,
     );
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).toHaveClass("af-title af-title--modifier custom-class", {
@@ -54,80 +44,79 @@ describe("Title", () => {
   });
 
   it("should not have classModifier attribute", () => {
-    // Act
     render(
       <Title className="custom-class" classModifier="modifier">
         A title
       </Title>,
     );
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
     ).not.toHaveAttribute("classModifier");
   });
 
   it("should have correct heading level", () => {
-    // Act
     render(<Title heading="h3">A title</Title>);
 
-    // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 3 }),
     ).toBeInTheDocument();
   });
 
   it("shouldn't have an accessibility violation <Title/>", async () => {
-    // Act
     const { container } = render(<Title heading="h3">A title</Title>);
 
-    // Assert
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("should be wrapped in a container", async () => {
-    // Act
+  it("should be wrapped in a container", () => {
     render(<Title heading="h3">A title</Title>);
 
-    // Assert
     const container = screen.getByRole("heading", {
       name: /A title/,
       level: 3,
-    }).parentElement as HTMLElement;
-    expect(container.getAttribute("class")).toEqual("af-title--container");
-  });
-
-  it("content left should be child of heading", () => {
-    // Act
-    render(
-      <Title heading="h3" contentLeft={<p>Some content</p>}>
-        A title
-      </Title>,
-    );
-
-    // Assert
-    const heading = screen.getByRole("heading", {
-      level: 3,
-    });
-
-    expect(within(heading).getByText("Some content")).toBeInTheDocument();
-  });
-
-  it("content right should be child of content-right div", () => {
-    // Act
-    render(
-      <Title heading="h3" contentRight={<p>Some content</p>}>
-        A title
-      </Title>,
-    );
-
-    // Assert
-    const container = screen.getByRole("heading", {
-      level: 3,
     }).parentElement!;
+    expect(container).toHaveClass("af-title--container");
+  });
 
-    expect(
-      within(container.childNodes[1] as HTMLElement).getByText("Some content"),
-    ).toBeInTheDocument();
+  it("renders contentLeft inside .content-left wrapper outside the heading", () => {
+    render(
+      <Title heading="h3" contentLeft={<p>Left content</p>}>
+        A title
+      </Title>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading.textContent).not.toContain("Left content");
+
+    const wrapper = screen.getByText("Left content").closest(".content-left");
+    expect(wrapper).not.toBeNull();
+  });
+
+  it("renders contentRight inside .content-right wrapper", () => {
+    render(
+      <Title heading="h3" contentRight={<p>Right content</p>}>
+        A title
+      </Title>,
+    );
+
+    const wrapper = screen.getByText("Right content").closest(".content-right");
+    expect(wrapper).not.toBeNull();
+  });
+
+  it("renders a horizontal divider between left and right contents", () => {
+    render(
+      <Title
+        heading="h3"
+        contentLeft={<span>L</span>}
+        contentRight={<span>R</span>}
+      >
+        A title
+      </Title>,
+    );
+
+    const container = screen.getByRole("heading", { level: 3 }).parentElement!;
+    const content = container.querySelector(".af-title--content")!;
+    expect(content.querySelector("hr.af-divider")).not.toBeNull();
   });
 });


### PR DESCRIPTION
Reprise de #1555 (auteur initial : @synnksou) rebasee sur le layout actuel `canopee-react` / `canopee-css`. La PR d'origine etait basee sur l'ancien `slash/` et n'etait plus mergeable.

`contentLeft` et `contentRight` sortent du `<h2>` et passent dans un wrapper frere `.af-title--content` qui dispose les deux contenus autour d'un `Divider` horizontal. La structure precedente rendait des noeuds React arbitraires (`Link`, `Button`, ...) en enfant du heading, ce qui n'est pas accessible.

Nouvelle structure DOM :

```html
<div class="af-title--container">
  <h2 class="af-title">Title with content</h2>
  <div class="af-title--content">
    <div class="content-left">
      <button type="button" class="af-btn">Click me</button>
    </div>
    <hr class="af-divider af-divider--horizontal" />
    <div class="content-right">
      <a class="af-slash-link" href="/">Click me</a>
    </div>
  </div>
</div>
```

Closes #1444

## Visuel

![Title rework](https://github.com/user-attachments/assets/9d113d60-0389-4040-a64a-b38335ae6c85)

## Notes de rebase

- `Title.tsx` migre vers la nouvelle structure dans `packages/canopee-react/src/distributeur/Title/`.
- `Title.css` est reecrit en CSS plat pour s'aligner sur les autres composants `canopee-css`.
- Les tests Vitest sont mis a jour pour verifier que `contentLeft` et `contentRight` sont rendus hors du heading.
