### PR TITLE
feat(distributeur): add ItemFormHelper component

### DIFF
--- a/apps/slash-stories/src/Form/ItemFormHelper.mdx
+++ b/apps/slash-stories/src/Form/ItemFormHelper.mdx
@@ -1,0 +1,34 @@
+import { Canvas, Controls, Meta } from "@storybook/blocks";
+import * as ItemFormHelperStories from "./ItemFormHelper.stories";
+
+<Meta of={ItemFormHelperStories} />
+
+# ItemFormHelper
+
+`ItemFormHelper` is a small status row used inside a form helper to show the
+progress of a given step. Each item carries an icon and a label, and switches
+visual state through the `variant` prop.
+
+```tsx
+import { ItemFormHelper } from "@axa-fr/canopee-react/distributeur";
+
+export const MyFormHelper = () => (
+  <ItemFormHelper variant="inprogress" label="Identité" />
+);
+```
+
+## Variants
+
+The `variant` prop drives the icon and the default label:
+
+- `todo` — step is pending (default label: "à compléter").
+- `inprogress` — step is currently being filled (default label: "en cours").
+- `validated` — step has been completed (default label: "validé").
+
+Pass a `label` to override the default text.
+
+## Playground
+
+<Canvas of={ItemFormHelperStories.Default} />
+
+<Controls of={ItemFormHelperStories.Default} />

--- a/apps/slash-stories/src/Form/ItemFormHelper.mdx
+++ b/apps/slash-stories/src/Form/ItemFormHelper.mdx
@@ -1,0 +1,34 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as ItemFormHelperStories from "./ItemFormHelper.stories";
+
+<Meta of={ItemFormHelperStories} />
+
+# ItemFormHelper
+
+`ItemFormHelper` is a small status row used inside a form helper to show the
+progress of a given step. Each item carries an icon and a label, and switches
+visual state through the `variant` prop.
+
+```tsx
+import { ItemFormHelper } from "@axa-fr/canopee-react/distributeur";
+
+export const MyFormHelper = () => (
+  <ItemFormHelper variant="inprogress" label="Identité" />
+);
+```
+
+## Variants
+
+The `variant` prop drives the icon and the default label:
+
+- `todo` — step is pending (default label: "à compléter").
+- `inprogress` — step is currently being filled (default label: "en cours").
+- `validated` — step has been completed (default label: "validé").
+
+Pass a `label` to override the default text.
+
+## Playground
+
+<Canvas of={ItemFormHelperStories.Default} />
+
+<Controls of={ItemFormHelperStories.Default} />

--- a/apps/slash-stories/src/Form/ItemFormHelper.stories.tsx
+++ b/apps/slash-stories/src/Form/ItemFormHelper.stories.tsx
@@ -1,0 +1,22 @@
+import { ItemFormHelper } from "@axa-fr/canopee-react/distributeur";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ItemFormHelper> = {
+  title: "Form/ItemFormHelper",
+  component: ItemFormHelper,
+  argTypes: {
+    variant: {
+      options: ["todo", "inprogress", "validated"],
+      control: { type: "select" },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof ItemFormHelper> = {
+  name: "Item Form Helper",
+  args: {
+    variant: "todo",
+  },
+};

--- a/packages/canopee-css/src/distributeur/ItemFormHelper/ItemFormHelper.css
+++ b/packages/canopee-css/src/distributeur/ItemFormHelper/ItemFormHelper.css
@@ -1,0 +1,21 @@
+.af-item-form-helper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: "Source Sans Pro", sans-serif;
+  color: var(--grey80);
+}
+
+.af-item-form-helper--todo {
+  fill: var(--axablue80);
+}
+
+.af-item-form-helper--inprogress {
+  fill: var(--axablue80);
+}
+
+.af-item-form-helper--validated {
+  margin: 0;
+  color: var(--green40);
+  fill: var(--green40);
+}

--- a/packages/canopee-css/src/distributeur/distributeur.css
+++ b/packages/canopee-css/src/distributeur/distributeur.css
@@ -38,3 +38,4 @@
 @import "./Popover/Popover.css";
 @import "./Loader/Loader.css";
 @import "./CardData/CardData.css";
+@import "./ItemFormHelper/ItemFormHelper.css";

--- a/packages/canopee-css/src/distributeur/distributeur.css
+++ b/packages/canopee-css/src/distributeur/distributeur.css
@@ -39,3 +39,4 @@
 @import "./Loader/Loader.css";
 @import "./CardData/CardData.css";
 @import "./MandatoryMention/MandatoryMention.css";
+@import "./ItemFormHelper/ItemFormHelper.css";

--- a/packages/canopee-css/src/distributeur/distributeur.css
+++ b/packages/canopee-css/src/distributeur/distributeur.css
@@ -44,3 +44,4 @@
 @import "./CardData/CardData.css";
 @import "./MandatoryMention/MandatoryMention.css";
 @import "./Timeline/Timeline.css";
+@import "./ItemFormHelper/ItemFormHelper.css";

--- a/packages/canopee-react/src/distributeur.ts
+++ b/packages/canopee-react/src/distributeur.ts
@@ -136,3 +136,9 @@ export {
   type EditorialMessageProps,
   type EditorialMessageType,
 } from "./distributeur/EditorialMessage/EditorialMessage";
+
+export {
+  ItemFormHelper,
+  type ItemFormHelperProps,
+  type ItemFormHelperVariant,
+} from "./distributeur/ItemFormHelper/ItemFormHelper";

--- a/packages/canopee-react/src/distributeur.ts
+++ b/packages/canopee-react/src/distributeur.ts
@@ -137,3 +137,9 @@ export {
   type EditorialMessageProps,
   type EditorialMessageType,
 } from "./distributeur/EditorialMessage/EditorialMessage";
+
+export {
+  ItemFormHelper,
+  type ItemFormHelperProps,
+  type ItemFormHelperVariant,
+} from "./distributeur/ItemFormHelper/ItemFormHelper";

--- a/packages/canopee-react/src/distributeur.ts
+++ b/packages/canopee-react/src/distributeur.ts
@@ -150,3 +150,9 @@ export {
   type TimelineProps,
   type TimelineVariants,
 } from "./distributeur/Timeline/Timeline";
+
+export {
+  ItemFormHelper,
+  type ItemFormHelperProps,
+  type ItemFormHelperVariant,
+} from "./distributeur/ItemFormHelper/ItemFormHelper";

--- a/packages/canopee-react/src/distributeur/ItemFormHelper/ItemFormHelper.tsx
+++ b/packages/canopee-react/src/distributeur/ItemFormHelper/ItemFormHelper.tsx
@@ -1,0 +1,53 @@
+import "@axa-fr/canopee-css/distributeur/ItemFormHelper/ItemFormHelper.css";
+import checkSvg from "@material-symbols/svg-400/outlined/check.svg";
+import toDoSvg from "@material-symbols/svg-400/outlined/circle.svg";
+import wipSvg from "@material-symbols/svg-400/outlined/circle-fill.svg";
+import { Svg } from "../Svg";
+import { getClassName } from "../utilities/helpers/getClassName";
+
+export type ItemFormHelperVariant = "todo" | "inprogress" | "validated";
+
+export type ItemFormHelperProps = {
+  variant: ItemFormHelperVariant;
+  label?: string;
+  className?: string;
+};
+
+const variants: Record<
+  ItemFormHelperVariant,
+  { icon: string; defaultLabel: string }
+> = {
+  todo: {
+    icon: toDoSvg,
+    defaultLabel: "à compléter",
+  },
+  inprogress: {
+    icon: wipSvg,
+    defaultLabel: "en cours",
+  },
+  validated: {
+    icon: checkSvg,
+    defaultLabel: "validé",
+  },
+};
+
+export const ItemFormHelper = ({
+  variant,
+  label,
+  className,
+}: ItemFormHelperProps) => {
+  const { icon, defaultLabel } = variants[variant];
+  const displayLabel = label ?? defaultLabel;
+  const componentClassName = getClassName({
+    baseClassName: "af-item-form-helper",
+    modifiers: [variant],
+    className,
+  });
+
+  return (
+    <div className={componentClassName}>
+      <Svg src={icon} width={12} height={12} />
+      <span>{displayLabel}</span>
+    </div>
+  );
+};

--- a/packages/canopee-react/src/distributeur/ItemFormHelper/__tests__/ItemFormHelper.test.tsx
+++ b/packages/canopee-react/src/distributeur/ItemFormHelper/__tests__/ItemFormHelper.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ItemFormHelper } from "../ItemFormHelper";
+
+describe("ItemFormHelper", () => {
+  it("renders the default label and modifier class for todo", () => {
+    render(<ItemFormHelper variant="todo" />);
+
+    expect(screen.getByText("à compléter")).toBeInTheDocument();
+    expect(screen.getByText("à compléter").parentElement).toHaveClass(
+      "af-item-form-helper",
+      "af-item-form-helper--todo",
+    );
+  });
+
+  it("renders the default label and modifier class for inprogress", () => {
+    render(<ItemFormHelper variant="inprogress" />);
+
+    expect(screen.getByText("en cours")).toBeInTheDocument();
+    expect(screen.getByText("en cours").parentElement).toHaveClass(
+      "af-item-form-helper",
+      "af-item-form-helper--inprogress",
+    );
+  });
+
+  it("renders the default label and modifier class for validated", () => {
+    render(<ItemFormHelper variant="validated" />);
+
+    expect(screen.getByText("validé")).toBeInTheDocument();
+    expect(screen.getByText("validé").parentElement).toHaveClass(
+      "af-item-form-helper",
+      "af-item-form-helper--validated",
+    );
+  });
+
+  it("renders a custom label when provided", () => {
+    render(<ItemFormHelper variant="validated" label="Tâche terminée" />);
+
+    expect(screen.getByText("Tâche terminée")).toBeInTheDocument();
+  });
+
+  it("forwards an additional className", () => {
+    render(<ItemFormHelper variant="todo" className="custom" />);
+
+    expect(screen.getByText("à compléter").parentElement).toHaveClass("custom");
+  });
+});

--- a/plugins/canopee-distributeur/skills/canopee-distributeur/SKILL.md
+++ b/plugins/canopee-distributeur/skills/canopee-distributeur/SKILL.md
@@ -162,7 +162,7 @@ Disponibles via `@axa-fr/canopee-react/distributeur-experimental` — API instab
 | `Modal` / `BooleanModal`                                    | [08-modal.md](./references/08-modal.md)                         | Fenêtres modales, tailles sm/default/lg               |
 | `Table`                                                     | [09-table.md](./references/09-table.md)                         | Tableaux avec THead/TBody/Th/Td, pagination           |
 | `Tabs`                                                      | [12-tabs.md](./references/12-tabs.md)                           | Navigation par onglets                                |
-| `Steps` / `VerticalStep`                                    | [13-steps.md](./references/13-steps.md)                         | Indicateur de progression horizontale/verticale       |
+| `Steps` / `VerticalStep` / `ItemFormHelper`                 | [13-steps.md](./references/13-steps.md)                         | Progression horizontale/verticale, état d'une section |
 | `Restitution` / `SectionRestitution` / `ArticleRestitution` | [14-restitution.md](./references/14-restitution.md)             | Affichage récapitulatif label/valeur en lecture seule |
 | `Popover`                                                   | [23-popover.md](./references/23-popover.md)                     | Infobulle au clic ou au survol                        |
 | `HelpButton`                                                | [24-help-button.md](./references/24-help-button.md)             | Bouton d'aide contextuelle (wrap Popover)             |
@@ -179,6 +179,7 @@ Disponibles via `@axa-fr/canopee-react/distributeur-experimental` — API instab
 - **Accordion** : `default` · `white` · `light`
 - **Radio** : `classic` · `default` · `inline` · `cardRadio`
 - **Checkbox** : `classic` · `default` · `inline` · `toggle`
+- **ItemFormHelper** : `todo` · `inprogress` · `validated`
 
 ## Accessibilité — points clés
 

--- a/plugins/canopee-distributeur/skills/canopee-distributeur/references/13-steps.md
+++ b/plugins/canopee-distributeur/skills/canopee-distributeur/references/13-steps.md
@@ -1,17 +1,23 @@
 # Steps (Étapes)
 
 ## Présentation
-Le composant Steps affiche un indicateur de progression horizontal. Le composant VerticalStep permet de créer un stepper vertical avec gestion des modes édition/validation/verrouillage.
+Le composant Steps affiche un indicateur de progression horizontal. Le composant VerticalStep permet de créer un stepper vertical avec gestion des modes édition/validation/verrouillage. Le composant ItemFormHelper affiche l'état d'avancement d'une section de formulaire (à compléter / en cours / validé).
 
 ## Import
 ```tsx
-import { Steps, Step, VerticalStep } from "@axa-fr/canopee-react/distributeur";
+import {
+  Steps,
+  Step,
+  VerticalStep,
+  ItemFormHelper,
+} from "@axa-fr/canopee-react/distributeur";
 ```
 
 ## Composants
 - **Steps** : Conteneur des étapes horizontales
 - **Step** : Étape individuelle dans le flux horizontal
 - **VerticalStep** : Étape verticale avec gestion de mode (édition, validation, verrouillage)
+- **ItemFormHelper** : Indicateur d'état d'avancement d'une section de formulaire
 
 ## Steps horizontales
 
@@ -224,9 +230,61 @@ Par défaut, le composant génère un `aria-label` de la forme `"Étape vertical
 {/* aria-label="Étape verticale Configuration (completed)" */}
 ```
 
+## ItemFormHelper
+
+`ItemFormHelper` est un atome qui signale l'état d'avancement d'une section de formulaire. Il se place à côté d'un titre de section ou dans une zone d'aide, et affiche une icône plus un libellé.
+
+### Props — ItemFormHelper
+
+| Prop | Type | Défaut | Description |
+|------|------|--------|-------------|
+| `variant` | `"todo" \| "inprogress" \| "validated"` | **Obligatoire** | État d'avancement : pilote l'icône, la couleur et le libellé par défaut |
+| `label` | `string` | Libellé par défaut du `variant` | Remplace le libellé par défaut |
+| `className` | `string` | - | Classe CSS additionnelle, ajoutée après le modifier BEM |
+
+Le type `ItemFormHelperVariant` et le type `ItemFormHelperProps` sont exportés depuis `@axa-fr/canopee-react/distributeur`.
+
+### Variants
+
+| Variant | Icône | Couleur | Libellé par défaut |
+|---------|-------|---------|--------------------|
+| `todo` | `circle` (cercle vide) | `--axablue80` | `à compléter` |
+| `inprogress` | `circle-fill` (cercle plein) | `--axablue80` | `en cours` |
+| `validated` | `check` | `--green40` | `validé` |
+
+Les icônes sont fournies par le composant (Material Symbols, rendues via `Svg` en 12 × 12) : rien à passer côté consommateur.
+
+### Exemple
+
+```tsx
+import { ItemFormHelper, Title } from "@axa-fr/canopee-react/distributeur";
+
+const SectionIdentite = () => (
+  <>
+    <Title>Identité</Title>
+    <ItemFormHelper variant="inprogress" />
+  </>
+);
+```
+
+### Libellés personnalisés
+
+```tsx
+<ItemFormHelper variant="todo" label="Pièces justificatives à fournir" />
+<ItemFormHelper variant="validated" label="Tâche terminée" />
+```
+
+### Points d'attention
+
+- Le libellé fait partie du rendu : l'information n'est jamais portée uniquement par la couleur de l'icône.
+- Le composant est un `inline-flex` : il se place naturellement à la suite d'un titre sans casser le flux.
+- Le libellé par défaut est en français ; pour une application multilingue, passer systématiquement `label`.
+
 ## Classes CSS
 - `.af-steps-new` — Conteneur des étapes horizontales
 - `.af-steps-list` — Liste des étapes horizontales
 - `.af-steps-list-step` — Étape individuelle horizontale
 - `.af-vertical-step` — Étape verticale
 - `.af-vertical-step--edition` — Étape verticale en mode édition
+- `.af-item-form-helper` — Indicateur d'état d'une section de formulaire
+- `.af-item-form-helper--todo` / `--inprogress` / `--validated` — Modifiers d'état


### PR DESCRIPTION
Reprise de #1382 (auteur initial : @gaouimounir) rebasée sur le layout actuel `canopee-react` / `canopee-css`. La PR d'origine était basée sur l'ancien `slash/` et n'était plus mergeable.

`ItemFormHelper` est un petit atom qui signale l'état de complétion d'une section de formulaire (à placer à côté d'un titre de section ou d'une zone d'aide). Trois variantes :

- `todo` : icône cercle vide, bleu, label par défaut « à compléter »
- `inprogress` : icône cercle plein, bleu, label par défaut « en cours »
- `validated` : icône check, vert, label par défaut « validé »

Le label peut être surchargé via la prop `label`, et une classe additionnelle peut être passée via `className`.

API : `<ItemFormHelper variant="validated" label="Tâche terminée" />`

Closes #1348

## Visuel

| variant="todo" | variant="inprogress" | variant="validated" |
|---|---|---|
| ![todo](https://github.com/user-attachments/assets/dd228eeb-be01-4018-82a4-4e96d29a89f8) | ![inprogress](https://github.com/user-attachments/assets/dd228eeb-be01-4018-82a4-4e96d29a89f8) | ![validated](https://github.com/user-attachments/assets/dd228eeb-be01-4018-82a4-4e96d29a89f8) |

(Visuels d'origine de la PR #1382 ; un seul screenshot avait été partagé par l'auteur.)

## Notes de rebase

- Composant porté vers `packages/canopee-react/src/distributeur/ItemFormHelper/`
- CSS porté vers `packages/canopee-css/src/distributeur/ItemFormHelper/` et référencé dans `distributeur.css`
- `.scss` d'origine réécrit en `.css` plat (pas de SCSS dans `canopee-css`) ; convention BEM alignée : préfixe `af-item-form-helper` avec modifiers `--todo`, `--inprogress`, `--validated` au lieu de `.item__variant`
- Les noms de variantes de la PR d'origine (`to-do`, `wip`, `validation`) ont été alignés sur les conventions du repo : `todo`, `inprogress`, `validated`
- Composant React utilise le helper `getClassName` du projet pour la concaténation classe + modifiers + className utilisateur
- Tests adaptés pour vérifier les classes BEM (les tests d'origine attendaient des styles inline qui ne correspondaient pas aux règles CSS)
- Story migrée vers les imports `@axa-fr/canopee-react/distributeur` et `@axa-fr/canopee-css` ; classe démo renommée de `.helper` en `.af-item-form-helper-demo` pour éviter les collisions
- Skill `canopee-distributeur` mise à jour : `ItemFormHelper` ajouté au catalogue de `SKILL.md` et documenté dans `references/13-steps.md`
- Le premier commit (`chore(distributeur): make MultiSelect types pickable by tsc-files`) est le même prérequis tooling que dans #1829, #1830, #1831 et #1832 ; il sera supprimé après merge de l'une de ces PRs.
