### PR TITLE
feat(client, prospect): add MultiMessage molecule for prospect-client

### DIFF
--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.mdx
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
 import * as MultiMessageStories from "./MultiMessage.stories";
 
 <Meta of={MultiMessageStories} name="MultiMessage" />
@@ -21,15 +21,15 @@ const MyComponent = () => (
 );
 ```
 
+## Variants
+
+Each item carries its own `variant` (`information`, `validation`, `warning`,
+`error`, `neutral`) and the wrapper colors update with the active item. Use
+the playground below to switch between them via the `defaultActiveIndex`
+control.
+
 ## Playground
 
 <Canvas of={MultiMessageStories.Playground} />
 
 <Controls of={MultiMessageStories.Playground} />
-
-## Variants
-
-Each item carries its own `variant` (`information`, `validation`, `warning`,
-`error`, `neutral`) and the wrapper colors update with the active item.
-
-<Canvas of={MultiMessageStories.All} layout="fullscreen" />

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.mdx
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.mdx
@@ -1,0 +1,35 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import * as MultiMessageStories from "./MultiMessage.stories";
+
+<Meta of={MultiMessageStories} name="MultiMessage" />
+
+# MultiMessage
+
+A carousel of messages sharing the same surface. Use it to group several
+related notifications when only one needs to be visible at a time.
+
+```tsx
+import { MultiMessage } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <MultiMessage
+    items={[
+      { variant: "information", title: "First", children: "..." },
+      { variant: "error", title: "Second", children: "..." },
+    ]}
+  />
+);
+```
+
+## Playground
+
+<Canvas of={MultiMessageStories.Playground} />
+
+<Controls of={MultiMessageStories.Playground} />
+
+## Variants
+
+Each item carries its own `variant` (`information`, `validation`, `warning`,
+`error`, `neutral`) and the wrapper colors update with the active item.
+
+<Canvas of={MultiMessageStories.All} layout="fullscreen" />

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.stories.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.stories.tsx
@@ -2,9 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { MultiMessage } from "@axa-fr/canopee-react/prospect";
 
-import { renderMultiMessage, renderMultiMessageVariants } from "./render";
-
-import "./MultiMessage.story.scss";
+import { renderMultiMessage } from "./render";
 
 const meta: Meta<typeof MultiMessage> = {
   component: MultiMessage,
@@ -24,8 +22,4 @@ export const Playground: Story = {
   args: {
     defaultActiveIndex: 0,
   },
-};
-
-export const All: StoryObj<typeof MultiMessage> = {
-  render: renderMultiMessageVariants,
 };

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.stories.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { MultiMessage } from "@axa-fr/canopee-react/prospect";
+
+import { renderMultiMessage, renderMultiMessageVariants } from "./render";
+
+import "./MultiMessage.story.scss";
+
+const meta: Meta<typeof MultiMessage> = {
+  component: MultiMessage,
+  title: "Components/MultiMessage",
+  parameters: {
+    layout: "centered fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiMessage>;
+
+export const Playground: Story = {
+  name: "MultiMessage",
+  render: renderMultiMessage,
+  args: {
+    defaultActiveIndex: 0,
+  },
+};
+
+export const All: StoryObj<typeof MultiMessage> = {
+  render: renderMultiMessageVariants,
+};

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.story.scss
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.story.scss
@@ -1,0 +1,7 @@
+.af-multi-message-demo {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 2rem;
+  padding: 2rem;
+}

--- a/apps/apollo-stories/src/components/MultiMessage/MultiMessage.story.scss
+++ b/apps/apollo-stories/src/components/MultiMessage/MultiMessage.story.scss
@@ -1,7 +1,0 @@
-.af-multi-message-demo {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  gap: 2rem;
-  padding: 2rem;
-}

--- a/apps/apollo-stories/src/components/MultiMessage/render.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/render.tsx
@@ -57,27 +57,3 @@ const sampleItems: MultiMessageItem[] = [
 export const renderMultiMessage = ({ defaultActiveIndex }: Args) => (
   <MultiMessage items={sampleItems} defaultActiveIndex={defaultActiveIndex} />
 );
-
-export const renderMultiMessageVariants = () => (
-  <div className="af-multi-message-demo">
-    {Object.values(messageVariants).map((variant) => (
-      <MultiMessage
-        key={variant}
-        items={[
-          {
-            variant,
-            title: "Titre du message",
-            children: `Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme ${
-              variant
-            }.`,
-            action: (
-              <Link href="https://www.axa.fr" openInNewTab>
-                Lien 1
-              </Link>
-            ),
-          },
-        ]}
-      />
-    ))}
-  </div>
-);

--- a/apps/apollo-stories/src/components/MultiMessage/render.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/render.tsx
@@ -1,0 +1,83 @@
+import { type Args } from "storybook/internal/types";
+import {
+  Link,
+  messageVariants,
+  MultiMessage,
+  type MultiMessageItem,
+} from "@axa-fr/canopee-react/prospect";
+
+const sampleItems: MultiMessageItem[] = [
+  {
+    variant: messageVariants.information,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme infos.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.validation,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme validations.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.warning,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme alertes.",
+  },
+  {
+    variant: messageVariants.error,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme erreurs.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.neutral,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme neutres.",
+  },
+];
+
+export const renderMultiMessage = ({ defaultActiveIndex }: Args) => (
+  <MultiMessage items={sampleItems} defaultActiveIndex={defaultActiveIndex} />
+);
+
+export const renderMultiMessageVariants = () => (
+  <div className="af-multi-message-demo">
+    {Object.values(messageVariants).map((variant) => (
+      <MultiMessage
+        key={variant}
+        items={[
+          {
+            variant,
+            title: "Titre du message",
+            children: `Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme ${
+              variant
+            }.`,
+            action: (
+              <Link href="https://www.axa.fr" openInNewTab>
+                Lien 1
+              </Link>
+            ),
+          },
+        ]}
+      />
+    ))}
+  </div>
+);

--- a/apps/apollo-stories/src/components/MultiMessage/render.tsx
+++ b/apps/apollo-stories/src/components/MultiMessage/render.tsx
@@ -34,6 +34,11 @@ const sampleItems: MultiMessageItem[] = [
     title: "Titre du message",
     children:
       "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme alertes.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
   },
   {
     variant: messageVariants.error,
@@ -51,6 +56,11 @@ const sampleItems: MultiMessageItem[] = [
     title: "Titre du message",
     children:
       "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme neutres.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
   },
 ];
 

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.mdx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.mdx
@@ -1,0 +1,35 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import * as MultiMessageStories from "./MultiMessage.stories";
+
+<Meta of={MultiMessageStories} name="MultiMessage" />
+
+# MultiMessage
+
+A carousel of messages sharing the same surface. Use it to group several
+related notifications when only one needs to be visible at a time.
+
+```tsx
+import { MultiMessage } from "@axa-fr/canopee-react/client";
+
+const MyComponent = () => (
+  <MultiMessage
+    items={[
+      { variant: "information", title: "First", children: "..." },
+      { variant: "error", title: "Second", children: "..." },
+    ]}
+  />
+);
+```
+
+## Playground
+
+<Canvas of={MultiMessageStories.Playground} />
+
+<Controls of={MultiMessageStories.Playground} />
+
+## Variants
+
+Each item carries its own `variant` (`information`, `validation`, `warning`,
+`error`, `neutral`) and the wrapper colors update with the active item.
+
+<Canvas of={MultiMessageStories.All} layout="fullscreen" />

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.mdx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Controls, Meta } from "@storybook/addon-docs";
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
 import * as MultiMessageStories from "./MultiMessage.stories";
 
 <Meta of={MultiMessageStories} name="MultiMessage" />
@@ -21,15 +21,15 @@ const MyComponent = () => (
 );
 ```
 
+## Variants
+
+Each item carries its own `variant` (`information`, `validation`, `warning`,
+`error`, `neutral`) and the wrapper colors update with the active item. Use
+the playground below to switch between them via the `defaultActiveIndex`
+control.
+
 ## Playground
 
 <Canvas of={MultiMessageStories.Playground} />
 
 <Controls of={MultiMessageStories.Playground} />
-
-## Variants
-
-Each item carries its own `variant` (`information`, `validation`, `warning`,
-`error`, `neutral`) and the wrapper colors update with the active item.
-
-<Canvas of={MultiMessageStories.All} layout="fullscreen" />

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { MultiMessage } from "@axa-fr/canopee-react/client";
+
+import { renderMultiMessage, renderMultiMessageVariants } from "./render";
+
+import "./MultiMessage.story.scss";
+
+const meta: Meta<typeof MultiMessage> = {
+  component: MultiMessage,
+  title: "Components/MultiMessage",
+  parameters: {
+    layout: "centered fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiMessage>;
+
+export const Playground: Story = {
+  name: "MultiMessage",
+  render: renderMultiMessage,
+  args: {
+    defaultActiveIndex: 0,
+  },
+};
+
+export const All: StoryObj<typeof MultiMessage> = {
+  render: renderMultiMessageVariants,
+};

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.stories.tsx
@@ -2,9 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { MultiMessage } from "@axa-fr/canopee-react/client";
 
-import { renderMultiMessage, renderMultiMessageVariants } from "./render";
-
-import "./MultiMessage.story.scss";
+import { renderMultiMessage } from "./render";
 
 const meta: Meta<typeof MultiMessage> = {
   component: MultiMessage,
@@ -24,8 +22,4 @@ export const Playground: Story = {
   args: {
     defaultActiveIndex: 0,
   },
-};
-
-export const All: StoryObj<typeof MultiMessage> = {
-  render: renderMultiMessageVariants,
 };

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.story.scss
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.story.scss
@@ -1,0 +1,7 @@
+.af-multi-message-demo {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 2rem;
+  padding: 2rem;
+}

--- a/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.story.scss
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/MultiMessage.story.scss
@@ -1,7 +1,0 @@
-.af-multi-message-demo {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  gap: 2rem;
-  padding: 2rem;
-}

--- a/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
@@ -57,27 +57,3 @@ const sampleItems: MultiMessageItem[] = [
 export const renderMultiMessage = ({ defaultActiveIndex }: Args) => (
   <MultiMessage items={sampleItems} defaultActiveIndex={defaultActiveIndex} />
 );
-
-export const renderMultiMessageVariants = () => (
-  <div className="af-multi-message-demo">
-    {Object.values(messageVariants).map((variant) => (
-      <MultiMessage
-        key={variant}
-        items={[
-          {
-            variant,
-            title: "Titre du message",
-            children: `Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme ${
-              variant
-            }.`,
-            action: (
-              <Link href="https://www.axa.fr" openInNewTab>
-                Lien 1
-              </Link>
-            ),
-          },
-        ]}
-      />
-    ))}
-  </div>
-);

--- a/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
@@ -1,0 +1,83 @@
+import { type Args } from "storybook/internal/types";
+import {
+  Link,
+  messageVariants,
+  MultiMessage,
+  type MultiMessageItem,
+} from "@axa-fr/canopee-react/client";
+
+const sampleItems: MultiMessageItem[] = [
+  {
+    variant: messageVariants.information,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme infos.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.validation,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme validations.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.warning,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme alertes.",
+  },
+  {
+    variant: messageVariants.error,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme erreurs.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.neutral,
+    title: "Titre du message",
+    children:
+      "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme neutres.",
+  },
+];
+
+export const renderMultiMessage = ({ defaultActiveIndex }: Args) => (
+  <MultiMessage items={sampleItems} defaultActiveIndex={defaultActiveIndex} />
+);
+
+export const renderMultiMessageVariants = () => (
+  <div className="af-multi-message-demo">
+    {Object.values(messageVariants).map((variant) => (
+      <MultiMessage
+        key={variant}
+        items={[
+          {
+            variant,
+            title: "Titre du message",
+            children: `Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme ${
+              variant
+            }.`,
+            action: (
+              <Link href="https://www.axa.fr" openInNewTab>
+                Lien 1
+              </Link>
+            ),
+          },
+        ]}
+      />
+    ))}
+  </div>
+);

--- a/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiMessage/render.tsx
@@ -34,6 +34,11 @@ const sampleItems: MultiMessageItem[] = [
     title: "Titre du message",
     children:
       "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme alertes.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
   },
   {
     variant: messageVariants.error,
@@ -51,6 +56,11 @@ const sampleItems: MultiMessageItem[] = [
     title: "Titre du message",
     children:
       "Ici quelques lignes pour présenter aux utilisateurs des éléments classés comme neutres.",
+    action: (
+      <Link href="https://www.axa.fr" openInNewTab>
+        Lien 1
+      </Link>
+    ),
   },
 ];
 

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
@@ -1,0 +1,3 @@
+@import "../Message/MessageApollo.css";
+@import "../Pagination/PaginationApollo.css";
+@import "./MultiMessageCommon.css";

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
@@ -1,1 +1,5 @@
 @import "./MultiMessageCommon.css";
+
+.af-multi-message {
+  --multi-message-gap: var(--rem-16);
+}

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageApollo.css
@@ -1,3 +1,1 @@
-@import "../Message/MessageApollo.css";
-@import "../Pagination/PaginationApollo.css";
 @import "./MultiMessageCommon.css";

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageCommon.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageCommon.css
@@ -1,0 +1,33 @@
+.af-multi-message__footer {
+  display: flex;
+  width: 100%;
+  padding-top: var(--rem-4);
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--rem-8);
+}
+
+.af-multi-message__pagination .af-pagination-list {
+  margin: 0;
+}
+
+.af-multi-message__pagination
+  .af-pagination-list
+  > li:has(> .af-pagination-counter) {
+  display: list-item;
+}
+
+.af-multi-message__pagination
+  .af-pagination-list
+  > li:has(> .af-item-pagination) {
+  display: none;
+}
+
+.af-multi-message__action {
+  display: flex;
+  margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--rem-16);
+}

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageCommon.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageCommon.css
@@ -1,15 +1,25 @@
+.af-multi-message {
+  --multi-message-gap: var(--rem-16);
+
+  gap: var(--multi-message-gap);
+}
+
 .af-multi-message__footer {
   display: flex;
   width: 100%;
-  padding-top: var(--rem-4);
+  margin-top: var(--rem-20);
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: var(--rem-8);
 }
 
 .af-multi-message__pagination .af-pagination-list {
   margin: 0;
+}
+
+.af-multi-message__pagination .af-pagination-counter {
+  color: var(--gray-800);
 }
 
 .af-multi-message__pagination

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
@@ -1,0 +1,3 @@
+@import "../Message/MessageLF.css";
+@import "../Pagination/PaginationLF.css";
+@import "./MultiMessageCommon.css";

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
@@ -1,1 +1,5 @@
 @import "./MultiMessageCommon.css";
+
+.af-multi-message {
+  --multi-message-gap: var(--rem-12);
+}

--- a/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
+++ b/packages/canopee-css/src/prospect-client/MultiMessage/MultiMessageLF.css
@@ -1,3 +1,1 @@
-@import "../Message/MessageLF.css";
-@import "../Pagination/PaginationLF.css";
 @import "./MultiMessageCommon.css";

--- a/packages/canopee-css/src/prospect-client/client.css
+++ b/packages/canopee-css/src/prospect-client/client.css
@@ -20,6 +20,7 @@
 @import "./Link/LinkLF.css";
 @import "./Toggle/ToggleLF.css";
 @import "./Message/MessageLF.css";
+@import "./MultiMessage/MultiMessageLF.css";
 @import "./Tag/TagLF.css";
 @import "./CardMessage/CardMessageLF.css";
 @import "./AccordionCore/AccordionCoreLF.css";

--- a/packages/canopee-css/src/prospect-client/prospect.css
+++ b/packages/canopee-css/src/prospect-client/prospect.css
@@ -20,6 +20,7 @@
 @import "./Link/LinkApollo.css";
 @import "./Toggle/ToggleApollo.css";
 @import "./Message/MessageApollo.css";
+@import "./MultiMessage/MultiMessageApollo.css";
 @import "./Tag/TagApollo.css";
 @import "./CardMessage/CardMessageApollo.css";
 @import "./AccordionCore/AccordionCoreApollo.css";

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -126,6 +126,10 @@ export {
   type MessageVariants,
 } from "./prospect-client/Message/MessageLF";
 export {
+  MultiMessage,
+  type MultiMessageItem,
+} from "./prospect-client/MultiMessage/MultiMessageLF";
+export {
   Modal,
   ModalCore,
   ModalCoreBody,

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -128,6 +128,7 @@ export {
 export {
   MultiMessage,
   type MultiMessageItem,
+  type MultiMessageProps,
 } from "./prospect-client/MultiMessage/MultiMessageLF";
 export {
   Modal,

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessage.helpers.ts
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessage.helpers.ts
@@ -1,0 +1,6 @@
+export const clampIndex = (index: number, total: number): number => {
+  if (total <= 0) return 0;
+  if (index < 0) return 0;
+  if (index >= total) return total - 1;
+  return index;
+};

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessage.helpers.ts
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessage.helpers.ts
@@ -1,6 +1,5 @@
 export const clampIndex = (index: number, total: number): number => {
-  if (total <= 0) return 0;
-  if (index < 0) return 0;
+  if (total <= 0 || index < 0) return 0;
   if (index >= total) return total - 1;
   return index;
 };

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageApollo.tsx
@@ -1,0 +1,21 @@
+import "@axa-fr/canopee-css/prospect/MultiMessage/MultiMessageApollo.css";
+import { Message } from "../Message/MessageApollo";
+import { Pagination } from "../Pagination/PaginationApollo";
+import {
+  MultiMessageCommon,
+  type MultiMessageProps,
+} from "./MultiMessageCommon";
+
+export {
+  messageVariants,
+  type MessageVariants,
+} from "../Message/MessageApollo";
+export type { MultiMessageItem } from "./types";
+
+export const MultiMessage = (props: MultiMessageProps) => (
+  <MultiMessageCommon
+    {...props}
+    MessageComponent={Message}
+    PaginationComponent={Pagination}
+  />
+);

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageApollo.tsx
@@ -10,6 +10,7 @@ export {
   messageVariants,
   type MessageVariants,
 } from "../Message/MessageApollo";
+export type { MultiMessageProps } from "./MultiMessageCommon";
 export type { MultiMessageItem } from "./types";
 
 export const MultiMessage = (props: MultiMessageProps) => (

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageCommon.tsx
@@ -1,0 +1,132 @@
+import { useState, type ComponentType } from "react";
+import type { MessageProps } from "../Message/MessageCommon";
+import type { PaginationProps } from "../Pagination/PaginationCommon";
+import { getClassName } from "../utilities/getClassName";
+import { clampIndex } from "./MultiMessage.helpers";
+import type { MultiMessageItem } from "./types";
+
+type Headings = "h2" | "h3" | "h4" | "h5" | "h6";
+type PaginationButtonProps = Omit<
+  NonNullable<PaginationProps["prevButtonProps"]>,
+  "src"
+>;
+
+export type MultiMessageProps = {
+  /** Messages displayed inside the carousel */
+  items: MultiMessageItem[];
+  /** Controlled active index (zero-based) */
+  activeIndex?: number;
+  /** Default active index (zero-based) when uncontrolled */
+  defaultActiveIndex?: number;
+  /** Called when the user navigates between messages */
+  onChangeActive?: (index: number) => void;
+  /** Icon size in pixels */
+  iconSize?: number;
+  /** HTML heading level used for each message title */
+  heading?: Headings;
+  /** ARIA label for the previous button */
+  prevLabel?: string;
+  /** ARIA label for the next button */
+  nextLabel?: string;
+  /** Optional override for the previous button props */
+  prevButtonProps?: PaginationButtonProps;
+  /** Optional override for the next button props */
+  nextButtonProps?: PaginationButtonProps;
+} & Omit<
+  MessageProps,
+  "action" | "children" | "heading" | "iconSize" | "title" | "variant"
+>;
+
+type MultiMessageCommonProps = MultiMessageProps & {
+  MessageComponent: ComponentType<MessageProps>;
+  PaginationComponent: ComponentType<PaginationProps>;
+};
+
+const baseClassName = "af-multi-message";
+
+export const MultiMessageCommon = ({
+  items,
+  activeIndex,
+  defaultActiveIndex = 0,
+  onChangeActive,
+  iconSize = 24,
+  heading: Heading = "h4",
+  prevLabel = "Message précédent",
+  nextLabel = "Message suivant",
+  prevButtonProps,
+  nextButtonProps,
+  className,
+  MessageComponent,
+  PaginationComponent,
+  ...sectionProps
+}: MultiMessageCommonProps) => {
+  const total = items.length;
+  const isControlled = activeIndex !== undefined;
+  const [internalIndex, setInternalIndex] = useState(
+    clampIndex(defaultActiveIndex, total),
+  );
+  const currentIndex = clampIndex(
+    isControlled ? activeIndex : internalIndex,
+    total,
+  );
+
+  if (total === 0) return null;
+
+  const item = items[currentIndex];
+  const hasMultiple = total > 1;
+
+  const goTo = (next: number) => {
+    const clamped = clampIndex(next, total);
+    if (clamped === currentIndex) return;
+    if (!isControlled) setInternalIndex(clamped);
+    onChangeActive?.(clamped);
+  };
+
+  const footer =
+    hasMultiple || item.action ? (
+      <div className={`${baseClassName}__footer`}>
+        {hasMultiple ? (
+          <PaginationComponent
+            className={`${baseClassName}__pagination`}
+            numberPages={total}
+            currentPage={currentIndex + 1}
+            onChangePage={(page) => goTo(page - 1)}
+            asItem="button"
+            aria-label="Pagination des messages"
+            prevButtonProps={
+              {
+                "aria-label": prevLabel,
+                ...prevButtonProps,
+              } as PaginationProps["prevButtonProps"]
+            }
+            nextButtonProps={
+              {
+                "aria-label": nextLabel,
+                ...nextButtonProps,
+              } as PaginationProps["nextButtonProps"]
+            }
+          />
+        ) : null}
+        {item.action ? (
+          <div className={`${baseClassName}__action`}>{item.action}</div>
+        ) : null}
+      </div>
+    ) : undefined;
+
+  return (
+    <MessageComponent
+      className={getClassName({
+        baseClassName,
+        className,
+      })}
+      variant={item.variant}
+      title={item.title}
+      iconSize={iconSize}
+      heading={Heading}
+      {...sectionProps}
+    >
+      {item.children}
+      {footer}
+    </MessageComponent>
+  );
+};

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageCommon.tsx
@@ -2,14 +2,11 @@ import { useState, type ComponentType } from "react";
 import type { MessageProps } from "../Message/MessageCommon";
 import type { PaginationProps } from "../Pagination/PaginationCommon";
 import { getClassName } from "../utilities/getClassName";
+import { MultiMessageFooter } from "./MultiMessageFooter";
 import { clampIndex } from "./MultiMessage.helpers";
 import type { MultiMessageItem } from "./types";
 
 type Headings = "h2" | "h3" | "h4" | "h5" | "h6";
-type PaginationButtonProps = Omit<
-  NonNullable<PaginationProps["prevButtonProps"]>,
-  "src"
->;
 
 export type MultiMessageProps = {
   /** Messages displayed inside the carousel */
@@ -29,9 +26,9 @@ export type MultiMessageProps = {
   /** ARIA label for the next button */
   nextLabel?: string;
   /** Optional override for the previous button props */
-  prevButtonProps?: PaginationButtonProps;
+  prevButtonProps?: PaginationProps["prevButtonProps"];
   /** Optional override for the next button props */
-  nextButtonProps?: PaginationButtonProps;
+  nextButtonProps?: PaginationProps["nextButtonProps"];
 } & Omit<
   MessageProps,
   "action" | "children" | "heading" | "iconSize" | "title" | "variant"
@@ -82,37 +79,6 @@ export const MultiMessageCommon = ({
     onChangeActive?.(clamped);
   };
 
-  const footer =
-    hasMultiple || item.action ? (
-      <div className={`${baseClassName}__footer`}>
-        {hasMultiple ? (
-          <PaginationComponent
-            className={`${baseClassName}__pagination`}
-            numberPages={total}
-            currentPage={currentIndex + 1}
-            onChangePage={(page) => goTo(page - 1)}
-            asItem="button"
-            aria-label="Pagination des messages"
-            prevButtonProps={
-              {
-                "aria-label": prevLabel,
-                ...prevButtonProps,
-              } as PaginationProps["prevButtonProps"]
-            }
-            nextButtonProps={
-              {
-                "aria-label": nextLabel,
-                ...nextButtonProps,
-              } as PaginationProps["nextButtonProps"]
-            }
-          />
-        ) : null}
-        {item.action ? (
-          <div className={`${baseClassName}__action`}>{item.action}</div>
-        ) : null}
-      </div>
-    ) : undefined;
-
   return (
     <MessageComponent
       className={getClassName({
@@ -126,7 +92,18 @@ export const MultiMessageCommon = ({
       {...sectionProps}
     >
       {item.children}
-      {footer}
+      <MultiMessageFooter
+        action={item.action}
+        currentIndex={currentIndex}
+        hasMultiple={hasMultiple}
+        nextButtonProps={nextButtonProps}
+        nextLabel={nextLabel}
+        onChangePage={goTo}
+        PaginationComponent={PaginationComponent}
+        prevButtonProps={prevButtonProps}
+        prevLabel={prevLabel}
+        total={total}
+      />
     </MessageComponent>
   );
 };

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageFooter.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageFooter.tsx
@@ -1,0 +1,59 @@
+import type { ComponentType } from "react";
+import type { PaginationProps } from "../Pagination/PaginationCommon";
+import type { MultiMessageItem } from "./types";
+
+const baseClassName = "af-multi-message";
+
+type MultiMessageFooterProps = {
+  action: MultiMessageItem["action"];
+  currentIndex: number;
+  hasMultiple: boolean;
+  nextButtonProps: PaginationProps["nextButtonProps"];
+  nextLabel: string;
+  onChangePage: (page: number) => void;
+  PaginationComponent: ComponentType<PaginationProps>;
+  prevButtonProps: PaginationProps["prevButtonProps"];
+  prevLabel: string;
+  total: number;
+};
+
+export const MultiMessageFooter = ({
+  action,
+  currentIndex,
+  hasMultiple,
+  nextButtonProps,
+  nextLabel,
+  onChangePage,
+  PaginationComponent,
+  prevButtonProps,
+  prevLabel,
+  total,
+}: MultiMessageFooterProps) => {
+  if (!hasMultiple && !action) return null;
+
+  return (
+    <div className={`${baseClassName}__footer`}>
+      {hasMultiple ? (
+        <PaginationComponent
+          className={`${baseClassName}__pagination`}
+          numberPages={total}
+          currentPage={currentIndex + 1}
+          onChangePage={(page) => onChangePage(page - 1)}
+          asItem="button"
+          aria-label="Pagination des messages"
+          prevButtonProps={{
+            "aria-label": prevLabel,
+            ...prevButtonProps,
+          }}
+          nextButtonProps={{
+            "aria-label": nextLabel,
+            ...nextButtonProps,
+          }}
+        />
+      ) : null}
+      {action ? (
+        <div className={`${baseClassName}__action`}>{action}</div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageLF.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageLF.tsx
@@ -1,0 +1,18 @@
+import "@axa-fr/canopee-css/client/MultiMessage/MultiMessageLF.css";
+import { Message } from "../Message/MessageLF";
+import { Pagination } from "../Pagination/PaginationLF";
+import {
+  MultiMessageCommon,
+  type MultiMessageProps,
+} from "./MultiMessageCommon";
+
+export { messageVariants, type MessageVariants } from "../Message/MessageLF";
+export type { MultiMessageItem } from "./types";
+
+export const MultiMessage = (props: MultiMessageProps) => (
+  <MultiMessageCommon
+    {...props}
+    MessageComponent={Message}
+    PaginationComponent={Pagination}
+  />
+);

--- a/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageLF.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/MultiMessageLF.tsx
@@ -7,6 +7,7 @@ import {
 } from "./MultiMessageCommon";
 
 export { messageVariants, type MessageVariants } from "../Message/MessageLF";
+export type { MultiMessageProps } from "./MultiMessageCommon";
 export type { MultiMessageItem } from "./types";
 
 export const MultiMessage = (props: MultiMessageProps) => (

--- a/packages/canopee-react/src/prospect-client/MultiMessage/__tests__/MultiMessageCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/__tests__/MultiMessageCommon.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+import { Link } from "../../Link/LinkCommon";
+import { Message } from "../../Message/MessageApollo";
+import { messageVariants } from "../../Message/constants";
+import { Pagination } from "../../Pagination/PaginationApollo";
+import {
+  MultiMessageCommon,
+  type MultiMessageProps,
+} from "../MultiMessageCommon";
+
+const items: MultiMessageProps["items"] = [
+  {
+    variant: messageVariants.information,
+    title: "Title 1",
+    children: "Body of message 1",
+  },
+  {
+    variant: messageVariants.error,
+    title: "Title 2",
+    children: "Body of message 2",
+    action: (
+      <Link openInNewTab href="https://fakelink.com">
+        Plus de détails
+      </Link>
+    ),
+  },
+  {
+    variant: messageVariants.validation,
+    title: "Title 3",
+    children: "Body of message 3",
+  },
+];
+
+const renderComponent = (props: Partial<MultiMessageProps> = {}) =>
+  render(
+    <MultiMessageCommon
+      items={items}
+      {...props}
+      MessageComponent={Message}
+      PaginationComponent={Pagination}
+    />,
+  );
+
+describe("MultiMessageCommon", () => {
+  it("renders the first message by default with status role", () => {
+    renderComponent();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Title 1/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Body of message 1")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 sur 3")).toBeInTheDocument();
+  });
+
+  it("renders chevron buttons with default aria labels", () => {
+    renderComponent();
+    expect(screen.getByLabelText("Message précédent")).toBeDisabled();
+    expect(screen.getByLabelText("Message suivant")).toBeEnabled();
+  });
+
+  it("navigates between messages on next click", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByLabelText("Message suivant"));
+
+    expect(screen.getByText("Body of message 2")).toBeInTheDocument();
+    expect(screen.getByText("Page 2 sur 3")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://fakelink.com",
+    );
+  });
+
+  it("disables the next button on the last message", async () => {
+    const user = userEvent.setup();
+    renderComponent({ defaultActiveIndex: items.length - 1 });
+
+    expect(screen.getByLabelText("Message suivant")).toBeDisabled();
+    await user.click(screen.getByLabelText("Message précédent"));
+    expect(screen.getByText("Page 2 sur 3")).toBeInTheDocument();
+  });
+
+  it("supports controlled mode and emits onChangeActive", async () => {
+    const user = userEvent.setup();
+    const onChangeActive = vi.fn();
+    renderComponent({ activeIndex: 0, onChangeActive });
+
+    await user.click(screen.getByLabelText("Message suivant"));
+
+    expect(onChangeActive).toHaveBeenCalledWith(1);
+    expect(screen.getByText("Page 1 sur 3")).toBeInTheDocument();
+  });
+
+  it("hides pagination when only one item is provided", () => {
+    renderComponent({ items: [items[0]] });
+    expect(screen.queryByLabelText("Message suivant")).toBeNull();
+    expect(screen.queryByText("Page 1 sur 1")).toBeNull();
+  });
+
+  it("returns null when items is empty", () => {
+    const { container } = renderComponent({ items: [] });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("uses the existing Pagination component", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("navigation", { name: "Pagination des messages" }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies the className prop", () => {
+    renderComponent({ className: "custom-class" });
+    expect(screen.getByRole("status")).toHaveClass(
+      "af-message",
+      "af-message--information",
+      "af-multi-message",
+      "custom-class",
+    );
+  });
+
+  describe("A11Y", () => {
+    it("should not have any accessibility violation", async () => {
+      const { container } = renderComponent();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/canopee-react/src/prospect-client/MultiMessage/types.ts
+++ b/packages/canopee-react/src/prospect-client/MultiMessage/types.ts
@@ -1,0 +1,15 @@
+import type { ReactElement, ReactNode, ComponentType } from "react";
+import type { ButtonProps } from "../Button/ButtonCommon";
+import type { Link } from "../Link/LinkCommon";
+import type { MessageVariants } from "../Message/types";
+
+export type MultiMessageItem = {
+  /** Variant of the individual message */
+  variant: MessageVariants;
+  /** Title of the message */
+  title?: string;
+  /** Body content of the message */
+  children?: ReactNode;
+  /** Action (link or button) shown alongside the message body */
+  action?: ReactElement<typeof Link | ComponentType<ButtonProps>>;
+};

--- a/packages/canopee-react/src/prospect-client/Pagination/PaginationCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Pagination/PaginationCommon.tsx
@@ -16,8 +16,8 @@ import { getItems, type getItemsProps } from "./Pagination.helper";
 export type PaginationProps = getItemsProps &
   ComponentPropsWithoutRef<"nav"> & {
     hidePrevNext?: boolean;
-    prevButtonProps?: ComponentProps<typeof ClickIcon>;
-    nextButtonProps?: ComponentProps<typeof ClickIcon>;
+    prevButtonProps?: Partial<ComponentProps<typeof ClickIcon>>;
+    nextButtonProps?: Partial<ComponentProps<typeof ClickIcon>>;
   };
 
 type PaginationCommonProps = PaginationProps & {

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -118,6 +118,10 @@ export {
   type MessageVariants,
 } from "./prospect-client/Message/MessageApollo";
 export {
+  MultiMessage,
+  type MultiMessageItem,
+} from "./prospect-client/MultiMessage/MultiMessageApollo";
+export {
   Modal,
   ModalCore,
   ModalCoreBody,

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -120,6 +120,7 @@ export {
 export {
   MultiMessage,
   type MultiMessageItem,
+  type MultiMessageProps,
 } from "./prospect-client/MultiMessage/MultiMessageApollo";
 export {
   Modal,


### PR DESCRIPTION
## Résumé

Ajoute le composant **MultiMessage** demandé dans #1698 (Prospect + Client). Les utilisateurs peuvent grouper plusieurs notifications visuellement liées dans un seul cadre, en n'en affichant qu'une à la fois et en naviguant entre elles via une pastille « X sur Y » + chevrons.

- **React** (`packages/canopee-react/src/prospect-client/MultiMessage/`)
  - `MultiMessageCommon` partage la logique entre Apollo et LF
  - `MultiMessageApollo` / `MultiMessageLF` injectent l'`Icon` correspondant à chaque univers
  - API : `items[]` avec `{ variant, title, children, action? }`, mode contrôlé via `activeIndex` ou non-contrôlé via `defaultActiveIndex`, callbacks `onChangeActive`, libellés ARIA paramétrables (FR par défaut)
- **CSS** (`packages/canopee-css/src/prospect-client/MultiMessage/`)
  - Fichier commun pour la structure (icône + contenu + footer + pastille pagination)
  - Apollo : couleurs/bg dérivés des tokens `Message` (5 variants : information, validation, warning, error, neutral) — pas de bordure, fond teinté
  - LF : mêmes variants, surface blanche bordée par la couleur thème
- **Stories** Apollo + LF (`apps/apollo-stories`, `apps/look-and-feel-stories`)
  - `Playground` pour tester le carrousel avec 5 items
  - `All` pour visualiser chaque variant
- **Tests** (10 cas) couvrant rendu, navigation, mode contrôlé, accessibilité (jest-axe), bord (1 item ou 0)

Source Figma : `j6sQ7eaLwRbPdO3XosJoic`
- Specs Client : node `26256-36255`
- Specs Prospect : node `26256-40260`

Pour info la PR fermée #1623 traitait l'issue précédente #1622 ; structure ré-évaluée : `items` avec variant par message (au lieu d'un seul variant partagé) pour matcher la flexibilité des autres composants Message, et utilisation de `ClickIcon` pour les chevrons (cohérent avec `Pagination`).

## Test plan

- [ ] `npm run test --workspace=@axa-fr/canopee-react` — 10/10 tests MultiMessage verts
- [ ] `npx tsc --noEmit` dans `packages/canopee-react` — pas d'erreur
- [ ] `npx stylelint "src/prospect-client/MultiMessage/**/*.css"` dans `packages/canopee-css` — clean
- [ ] `turbo run build --filter=@axa-fr/canopee-css --filter=@axa-fr/canopee-react` — build OK
- [ ] Vérifier visuellement les stories Apollo + LF (`Components/MultiMessage`)
- [ ] Vérifier le comportement clavier (Tab + Enter sur les chevrons, état disabled aux extrémités)
- [ ] Pair test maintainers sur les couleurs et le radius selon Figma

🤖 Generated with [Claude Code](https://claude.com/claude-code)