### PR TITLE
feat(distributeur): deprecate classModifier props

### DIFF
--- a/apps/slash-stories/src/Accordion.mdx
+++ b/apps/slash-stories/src/Accordion.mdx
@@ -37,7 +37,9 @@ Afterwards, the component becomes uncontrolled and only the user can close it vi
 
 ### Light version
 
-The `light` classModifier can be set on the `Accordion` component to use a lighter version of the accordion.
+The `light` variant can be set on the `Accordion` component to use a lighter version of the accordion.
+
+> **Deprecated prop**: The `classModifier` prop on `CollapseCard` (and internal `Header`) is deprecated. Use `className` instead.
 
 <Canvas of={AccordionStories.Light} />
 <Controls of={AccordionStories.Light} />

--- a/apps/slash-stories/src/Action.mdx
+++ b/apps/slash-stories/src/Action.mdx
@@ -5,6 +5,8 @@ import * as ActionStories from "./Action.stories.tsx";
 
 ## Action
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ### Import
 
 ```tsx

--- a/apps/slash-stories/src/Form/Checkbox.mdx
+++ b/apps/slash-stories/src/Form/Checkbox.mdx
@@ -68,7 +68,7 @@ import {
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.
 
 ### Modifiers
 

--- a/apps/slash-stories/src/Form/Choice.mdx
+++ b/apps/slash-stories/src/Form/Choice.mdx
@@ -29,4 +29,4 @@ You can see them in action in the stories above.
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.

--- a/apps/slash-stories/src/Form/Date.mdx
+++ b/apps/slash-stories/src/Form/Date.mdx
@@ -28,4 +28,4 @@ The component without the label is a bare-bones version of the component. It is 
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.

--- a/apps/slash-stories/src/Form/FileInput.mdx
+++ b/apps/slash-stories/src/Form/FileInput.mdx
@@ -46,7 +46,7 @@ export default FileInputReturn;
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.
 
 ## File
 

--- a/apps/slash-stories/src/Form/Number.mdx
+++ b/apps/slash-stories/src/Form/Number.mdx
@@ -104,4 +104,4 @@ export default NumberInputReturn;
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.

--- a/apps/slash-stories/src/Form/Pass.mdx
+++ b/apps/slash-stories/src/Form/Pass.mdx
@@ -20,10 +20,12 @@ import { Pass } from "@axa-fr/canopee-react/distributeur";
 
 ### Modifiers
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` with the appropriate BEM modifier class instead (e.g. `className="af-form__pass--good"`).
+
 <table>
   <thead>
     <tr>
-      <th>classModifiers</th>
+      <th>CSS modifiers (via className)</th>
     </tr>
   </thead>
   <tbody>
@@ -52,7 +54,7 @@ const PassInput = () => (
   <form className="af-form" name="myform">
     <Pass
       id="uniqueid"
-      classModifier="good"
+      className="af-form__pass--good"
       onChange={(e) => {
         console.log(e);
       }}
@@ -111,4 +113,4 @@ export default PassInputReturn;
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.

--- a/apps/slash-stories/src/Form/Radio.mdx
+++ b/apps/slash-stories/src/Form/Radio.mdx
@@ -69,4 +69,4 @@ const MyRadioCard = () => (
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.

--- a/apps/slash-stories/src/Form/Select.mdx
+++ b/apps/slash-stories/src/Form/Select.mdx
@@ -24,7 +24,7 @@ This is the complete component, with label, description, and error message.
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.
 
 ### Status messages
 

--- a/apps/slash-stories/src/Form/Text.mdx
+++ b/apps/slash-stories/src/Form/Text.mdx
@@ -74,7 +74,7 @@ export default textInputReturn;
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but _might_ disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.
 
 ## TextInput Error
 

--- a/apps/slash-stories/src/Form/Textarea.mdx
+++ b/apps/slash-stories/src/Form/Textarea.mdx
@@ -81,4 +81,4 @@ export default TextareaInputReturn;
 
 The component can be required. In that case, the label will be followed by a red asterisk. In order to make the component required, set the `required` prop to `true`.
 
-Alternatively you can to add to the `classModifier` the value `required`. This behaviour exists to keep backward compatibility but might disapear in the future.
+Alternatively you can add to the `classModifier` the value `required`. This behaviour exists for backward compatibility. Note that `classModifier` is deprecated; use the native `required` prop instead.

--- a/apps/slash-stories/src/HelpButton.mdx
+++ b/apps/slash-stories/src/HelpButton.mdx
@@ -5,6 +5,8 @@ import * as HelpButtonStories from "./HelpButton.stories";
 
 # HelpButton
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 The `HelpButton` component is the easiest way to create tooltips in the slash design-system.
 It wraps around the more customisable `Popover` component with defaults styles. By default the element to be hovered/clicked is a blue circle button with a cursive `i` inside.
 

--- a/apps/slash-stories/src/Layout/Header.mdx
+++ b/apps/slash-stories/src/Layout/Header.mdx
@@ -6,6 +6,8 @@ import * as HeaderAgentStories from "./Header.stories";
 
 # Header
 
+> **Deprecated prop**: The `classModifier` prop is deprecated on `Header`, `Name`, `User`, `Infos`, and `NavBar` components. Use `className` to add custom CSS modifier classes instead.
+
 ## Import
 
 ```tsx

--- a/apps/slash-stories/src/Layout/Infos/Infos.mdx
+++ b/apps/slash-stories/src/Layout/Infos/Infos.mdx
@@ -6,6 +6,8 @@ import * as InfosStories from "./Infos.stories";
 
 # Infos
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ## Import
 
 ```tsx

--- a/apps/slash-stories/src/Layout/Name/Name.mdx
+++ b/apps/slash-stories/src/Layout/Name/Name.mdx
@@ -5,6 +5,8 @@ import * as NameStories from "./Name.stories";
 
 # Name
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ## Import
 
 ```tsx

--- a/apps/slash-stories/src/Layout/User/User.mdx
+++ b/apps/slash-stories/src/Layout/User/User.mdx
@@ -5,6 +5,8 @@ import * as UserStories from "./User.stories";
 
 # User
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ## Import
 
 ```tsx

--- a/apps/slash-stories/src/Loader.mdx
+++ b/apps/slash-stories/src/Loader.mdx
@@ -5,6 +5,8 @@ import * as LoaderStories from "./Loader.stories";
 
 # Loader
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 The loader is a component to disable part of your application to express an unspecified wait time or display the length of a process.
 
 ```tsx

--- a/apps/slash-stories/src/Modal/Modal.mdx
+++ b/apps/slash-stories/src/Modal/Modal.mdx
@@ -7,6 +7,8 @@ import * as ModalStories from "./Modal.stories";
 
 # Modal
 
+> **Deprecated prop**: The `classModifier` prop on `ModalHeader`, `ModalHeaderBase`, `ModalBody`, and `ModalFooter` is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ## Components
 
 Modals are built of composable components:
@@ -65,8 +67,8 @@ export const YourComponent = () => {
         <ModalHeader title="Modal Title" onCancel={() => {}} />
         <ModalBody>
           <p>
-            Voici une version avec un header classique du composant Modal. Un
-            classModifier "lg" a été mis pour montrer une version plus large
+            Voici une version avec un header classique du composant Modal. Un la
+            propriété `size="lg"` a été mise pour montrer une version plus large
             d'une modale. Il est existe également un modifier "sm", pour les
             modales plus petites. Mais il est possible d'ajouter son propre
             modifier pour personnaliser selon ses besoins avec un peu de CSS.
@@ -120,11 +122,11 @@ export const YourComponent = () => {
         <ModalBody>
           <p>
             Voici une version avec un header customisé à l'aide du composant
-            Modal.HeaderBase. Un classModifier "lg" a été mis pour montrer une
-            version plus large d'une modale. Il est existe également un modifier
-            "sm", pour les modales plus petites. Mais il est possible d'ajouter
-            son propre modifier pour personnaliser selon ses besoins avec un peu
-            de CSS.
+            Modal.HeaderBase. La propriété `size="lg"` a été mise pour montrer
+            une version plus large d'une modale. Il est existe également un
+            modifier "sm", pour les modales plus petites. Mais il est possible
+            d'ajouter son propre modifier pour personnaliser selon ses besoins
+            avec un peu de CSS.
           </p>
         </ModalBody>
         <ModalFooter>

--- a/apps/slash-stories/src/Modal/Modal.mdx
+++ b/apps/slash-stories/src/Modal/Modal.mdx
@@ -7,6 +7,8 @@ import * as ModalStories from "./Modal.stories";
 
 # Modal
 
+> **Deprecated prop**: The `classModifier` prop on `ModalHeader`, `ModalHeaderBase`, `ModalBody`, and `ModalFooter` is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ## Components
 
 Modals are built of composable components:
@@ -65,8 +67,8 @@ export const YourComponent = () => {
         <ModalHeader title="Modal Title" onCancel={() => {}} />
         <ModalBody>
           <p>
-            Voici une version avec un header classique du composant Modal. Un
-            classModifier "lg" a été mis pour montrer une version plus large
+            Voici une version avec un header classique du composant Modal. La
+            propriété `size="lg"` a été mise pour montrer une version plus large
             d'une modale. Il est existe également un modifier "sm", pour les
             modales plus petites. Mais il est possible d'ajouter son propre
             modifier pour personnaliser selon ses besoins avec un peu de CSS.
@@ -120,11 +122,11 @@ export const YourComponent = () => {
         <ModalBody>
           <p>
             Voici une version avec un header customisé à l'aide du composant
-            Modal.HeaderBase. Un classModifier "lg" a été mis pour montrer une
-            version plus large d'une modale. Il est existe également un modifier
-            "sm", pour les modales plus petites. Mais il est possible d'ajouter
-            son propre modifier pour personnaliser selon ses besoins avec un peu
-            de CSS.
+            Modal.HeaderBase. La propriété `size="lg"` a été mise pour montrer
+            une version plus large d'une modale. Il est existe également un
+            modifier "sm", pour les modales plus petites. Mais il est possible
+            d'ajouter son propre modifier pour personnaliser selon ses besoins
+            avec un peu de CSS.
           </p>
         </ModalBody>
         <ModalFooter>

--- a/apps/slash-stories/src/Popover.mdx
+++ b/apps/slash-stories/src/Popover.mdx
@@ -5,6 +5,8 @@ import * as PopoverStories from "./Popover.stories";
 
 # Popover
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 A popover is a element that appears on top of the content when the user clicks
 or hovers over another element.
 

--- a/apps/slash-stories/src/Restitution.mdx
+++ b/apps/slash-stories/src/Restitution.mdx
@@ -5,6 +5,8 @@ import * as RestitutionStories from "./Restitution.stories.tsx";
 
 ## Restitution
 
+> **Deprecated prop**: The `classModifier` prop is deprecated on all Restitution components. Use `className` with the appropriate BEM modifier class instead (e.g. `className="af-restitution--lg"`).
+
 The Restitution components are a group of related components that are used to
 display recapitulative data. The main component is `ArticleRestitution` which is
 a container for the other components.
@@ -50,7 +52,7 @@ const RightTitle = () => (
 );
 
 export const Restititution = () => (
-  <ArticleRestitution classModifier="lg">
+  <ArticleRestitution className="af-restitution--lg">
     <HeaderRestitution
       title="Tarifs"
       subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)"
@@ -62,7 +64,10 @@ export const Restititution = () => (
           <Restitution label="TA">99,99 %</Restitution>
           <Restitution label="EURO">EURO</Restitution>
           <Restitution label="TT" />
-          <Restitution label="Garanties complémentaires" classModifier="marge">
+          <Restitution
+            label="Garanties complémentaires"
+            className="af-restitution__listdef--marge"
+          >
             <RestitutionList
               values={[
                 "Vol au domicile",
@@ -74,11 +79,14 @@ export const Restititution = () => (
             />
           </Restitution>
         </SectionRestitutionColumn>
-        <SectionRestitutionColumn classModifier="test">
+        <SectionRestitutionColumn className="col-sm-12 col-md-12 col-lg-6 col-xl-6 col-xl-6--test">
           <Restitution label="TA">99,99 %</Restitution>
           <Restitution label="EURO">EURO</Restitution>
           <Restitution label="TT" />
-          <Restitution label="Garanties complémentaires" classModifier="marge">
+          <Restitution
+            label="Garanties complémentaires"
+            className="af-restitution__listdef--marge"
+          >
             <RestitutionList
               values={[
                 "Vol au domicile",
@@ -97,7 +105,10 @@ export const Restititution = () => (
           <Restitution label="TA">99,99 %</Restitution>
           <Restitution label="EURO">EURO</Restitution>
           <Restitution label="TT" />
-          <Restitution label="Garanties complémentaires" classModifier="marge">
+          <Restitution
+            label="Garanties complémentaires"
+            className="af-restitution__listdef--marge"
+          >
             <RestitutionList
               values={[
                 "Vol au domicile",
@@ -114,7 +125,10 @@ export const Restititution = () => (
           <Restitution label="EURO">
             <span style={{ textDecoration: "underline" }}>EURO</span>
           </Restitution>
-          <Restitution label="Garanties complémentaires" classModifier="marge">
+          <Restitution
+            label="Garanties complémentaires"
+            className="af-restitution__listdef--marge"
+          >
             <RestitutionList
               values={[
                 "Vol au domicile",

--- a/apps/slash-stories/src/Steps.mdx
+++ b/apps/slash-stories/src/Steps.mdx
@@ -5,6 +5,8 @@ import * as StepsStories from "./Steps.stories";
 
 # Steps
 
+> **Deprecated prop**: The `classModifier` prop on `Steps` and `StepBase` is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 1. [Import](#import)
 2. [Steps](#steps-use)
 
@@ -24,7 +26,7 @@ import { Steps, Step, StepBase } from "@axa-fr/canopee-react/distributeur";
 
 ```javascript
 const MyComponent = () => (
-  <Steps classModifier="" className="">
+  <Steps>
     <Step
       id="id1"
       href="/etape1"

--- a/apps/slash-stories/src/Table.mdx
+++ b/apps/slash-stories/src/Table.mdx
@@ -5,6 +5,8 @@ import * as Stories from "./Table.stories.tsx";
 
 # Table
 
+> **Deprecated prop**: The `classModifier` prop is deprecated on all Table components (`Table`, `THead`, `TBody`, `Tr`, `Th`, `Td`). Use `className` to add custom CSS modifier classes instead.
+
 The design system provides components that are simple wrappers around the HTML table elements.
 
 <table>

--- a/apps/slash-stories/src/Title.mdx
+++ b/apps/slash-stories/src/Title.mdx
@@ -5,15 +5,15 @@ import * as TitleStories from "./Title.stories";
 
 ## Title
 
+> **Deprecated prop**: The `classModifier` prop is deprecated. Use `className` to add custom CSS modifier classes instead.
+
 ### Use of Title
 
 ```tsx
 import { Title } from "@axa-fr/canopee-react/distributeur";
 
 export const MyComponent = () => (
-  <Title classModifier="af-title" className="">
-    Sample Title
-  </Title>
+  <Title className="af-title--custom">Sample Title</Title>
 );
 ```
 
@@ -27,8 +27,7 @@ import { Title } from "@axa-fr/canopee-react/distributeur";
 
 export const MyComponent = () => (
   <Title
-    classModifier="af-title"
-    className=""
+    className="af-title--custom"
     contentLeft={<Button>Left button</Button>}
     contentRight={<Button>Right button</Button>}
   >

--- a/packages/canopee-css/src/distributeur/Popover/Popover.css
+++ b/packages/canopee-css/src/distributeur/Popover/Popover.css
@@ -33,8 +33,3 @@
 .af-popover__container-pop .af-subtitle::after {
   display: none;
 }
-
-.af-popover__container--small .af-btn--circle {
-  width: 2rem;
-  height: 2rem;
-}

--- a/packages/canopee-react/src/distributeur/Accordion/Accordion.tsx
+++ b/packages/canopee-react/src/distributeur/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import "@axa-fr/canopee-css/distributeur/Accordion/Accordion.css";
 import React, { useId } from "react";
-import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
+import { getClassName } from "../utilities/helpers/getClassName";
 import { CollapseCard, type CollapseProps } from "./CollapseCard";
 import type { AccordionVariant, TDefaultProps } from "./types";
 
@@ -24,10 +24,13 @@ const Accordion = ({
   children,
   onlyOne = false,
 }: EnhancedProps) => {
-  const componentClassName = getComponentClassNameWithUserClassname({
-    componentClassName: defaultClassName,
-    userClassName: className,
-    classModifier: classModifier || (variant !== "default" && variant) || "",
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: [
+      variant !== "default" ? variant : undefined,
+      ...(classModifier?.split(" ") ?? []),
+    ],
+    className,
   });
 
   const id = useId();

--- a/packages/canopee-react/src/distributeur/Accordion/Accordion.tsx
+++ b/packages/canopee-react/src/distributeur/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import "@axa-fr/canopee-css/distributeur/Accordion/Accordion.css";
 import React, { useId } from "react";
-import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
+import { getClassName } from "../utilities/helpers/getClassName";
 import { CollapseCard, type CollapseProps } from "./CollapseCard";
 import type { AccordionVariant, TDefaultProps } from "./types";
 
@@ -24,10 +24,13 @@ const Accordion = ({
   children,
   onlyOne = false,
 }: EnhancedProps) => {
-  const componentClassName = getComponentClassNameWithUserClassname({
-    componentClassName: defaultClassName,
-    userClassName: className,
-    classModifier: classModifier || (variant !== "default" && variant) || "",
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: [
+      variant !== "default" && variant,
+      ...(classModifier?.split(" ") ?? []),
+    ],
+    className,
   });
 
   const id = useId();

--- a/packages/canopee-react/src/distributeur/Accordion/CollapseCard.tsx
+++ b/packages/canopee-react/src/distributeur/Accordion/CollapseCard.tsx
@@ -1,5 +1,5 @@
 import type { DetailsHTMLAttributes, ReactNode } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 import { Body } from "./Body";
 import { Header } from "./Header";
 import type { AccordionActions, AccordionVariant } from "./types";
@@ -12,6 +12,7 @@ export type CollapseProps = {
   name?: string;
   onToggle?: DetailsHTMLAttributes<HTMLDetailsElement>["onToggle"];
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   actions?: AccordionActions;
   variant?: AccordionVariant;
@@ -34,11 +35,11 @@ export const CollapseCard = ({
   let newClassModifier = open ? "open" : "";
   newClassModifier += ` ${classModifier}`;
 
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-accordion__details",
+    modifiers: newClassModifier.trim().split(" "),
     className,
-    newClassModifier.trim(),
-    "af-accordion__details",
-  );
+  });
 
   return (
     <details

--- a/packages/canopee-react/src/distributeur/Accordion/Header.tsx
+++ b/packages/canopee-react/src/distributeur/Accordion/Header.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Button } from "../Button/Button";
 import { Svg } from "../Svg/Svg";
 import { Title } from "../Title/Title";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 import type { AccordionActions, AccordionVariant } from "./types";
 
 const defaultClassName = "af-accordion__item-header";
@@ -17,6 +17,7 @@ export type HeaderToggleElement = {
 export type HeaderProps = {
   children: React.ReactNode;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   id?: string;
   actions?: AccordionActions;
@@ -31,11 +32,11 @@ const Header = ({
   actions,
   variant,
 }: HeaderProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <summary className={componentClassName} id={id}>

--- a/packages/canopee-react/src/distributeur/Action/Action.tsx
+++ b/packages/canopee-react/src/distributeur/Action/Action.tsx
@@ -1,18 +1,23 @@
 import "@axa-fr/canopee-css/distributeur/Action/Action.css";
+import classNames from "classnames";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type ActionCoreProps = ComponentPropsWithoutRef<"a"> & {
   icon: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
 export const Action = forwardRef<HTMLAnchorElement, ActionCoreProps>(
   ({ icon, className, classModifier, ...otherProps }, ref) => {
-    const componentClassName = getComponentClassName(
-      className,
-      classModifier,
-      "btn af-btn--circle",
+    const componentClassName = classNames(
+      "btn",
+      getClassName({
+        baseClassName: "af-btn--circle",
+        modifiers: classModifier?.split(" "),
+        className,
+      }),
     );
     return (
       <a {...otherProps} className={componentClassName} ref={ref}>

--- a/packages/canopee-react/src/distributeur/Form/Checkbox/CheckboxItem.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Checkbox/CheckboxItem.tsx
@@ -11,11 +11,13 @@ import "@axa-fr/canopee-css/distributeur/Form/Checkbox/Checkbox.css";
 import { Svg } from "../../Svg";
 
 type Props = Omit<ComponentPropsWithoutRef<"input">, "type"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   optionClassName?: string;
   children?: ReactNode;
   label?: ReactNode;
   isChecked?: boolean;
+  variant?: "error" | "warning";
 };
 
 const CheckboxItem = forwardRef<HTMLInputElement, Props>(
@@ -29,6 +31,7 @@ const CheckboxItem = forwardRef<HTMLInputElement, Props>(
       isChecked,
       className,
       classModifier,
+      variant,
       ...otherProps
     }: Props,
     inputRef,
@@ -41,6 +44,7 @@ const CheckboxItem = forwardRef<HTMLInputElement, Props>(
       classModifier ?? "",
       "af-form__checkbox",
       disabled,
+      variant,
     );
     return (
       <div className={optionClassName}>

--- a/packages/canopee-react/src/distributeur/Form/Choice/Choice.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Choice/Choice.tsx
@@ -12,6 +12,7 @@ type Props = Omit<ComponentProps<typeof Radio>, "options" | "value"> & {
   name?: string;
   options?: Array<Omit<Option, "value"> & { value: boolean }>;
   value?: boolean | string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 

--- a/packages/canopee-react/src/distributeur/Form/Choice/__tests__/Choice.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Choice/__tests__/Choice.test.tsx
@@ -23,10 +23,13 @@ describe("Choice", () => {
 
     // Assert
     expect(screen.getAllByRole("radio")[0].parentElement).toHaveClass(
-      "af-form__radio-custom af-form__radio-custom--custom-class",
-      {
-        exact: true,
-      },
+      "af-form__radio",
+    );
+    expect(screen.getAllByRole("radio")[0].parentElement).toHaveClass(
+      "af-form__radio--custom-class",
+    );
+    expect(screen.getAllByRole("radio")[0].parentElement).toHaveClass(
+      "af-form__radio-custom",
     );
   });
 

--- a/packages/canopee-react/src/distributeur/Form/Date/Date.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Date/Date.tsx
@@ -1,9 +1,10 @@
 import "@axa-fr/canopee-css/distributeur/Form/Date/Date.css";
 import { type ComponentPropsWithRef, forwardRef } from "react";
-import { getComponentClassName } from "../../utilities";
 import { formatDateInputValue } from "../../utilities/helpers/date";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "value"> & {
+  /** @deprecated Use `className` and the native `disabled`/`required` props instead. */
   classModifier?: string;
   defaultValue?: Date | string;
   value?: Date | string;
@@ -11,11 +12,11 @@ type Props = Omit<ComponentPropsWithRef<"input">, "value"> & {
 
 const Date = forwardRef<HTMLInputElement, Props>(
   ({ className, classModifier, defaultValue, value, ...otherProps }, ref) => {
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-date",
+      modifiers: classModifier?.split(" "),
       className,
-      classModifier,
-      "af-form__input-date",
-    );
+    });
 
     return (
       <input

--- a/packages/canopee-react/src/distributeur/Form/Date/__tests__/Date.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Date/__tests__/Date.test.tsx
@@ -26,9 +26,12 @@ describe("Date", () => {
     );
 
     // Assert
-    expect(screen.getByTestId("myElement")).toHaveClass("custom-class", {
-      exact: true,
-    });
+    expect(screen.getByTestId("myElement")).toHaveClass(
+      "af-form__input-date custom-class",
+      {
+        exact: true,
+      },
+    );
   });
 
   it("should have custom class and modifier", () => {
@@ -44,7 +47,7 @@ describe("Date", () => {
 
     // Assert
     expect(screen.getByTestId("myElement")).toHaveClass(
-      "custom-class custom-class--modifier",
+      "af-form__input-date af-form__input-date--modifier custom-class",
       {
         exact: true,
       },

--- a/packages/canopee-react/src/distributeur/Form/File/File.tsx
+++ b/packages/canopee-react/src/distributeur/Form/File/File.tsx
@@ -6,11 +6,12 @@ import {
   useDropzone,
 } from "react-dropzone";
 import { Button } from "../../Button/Button";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 import type { FileActions } from "./constants";
 
 type Dropzone = DropzoneInputProps & DropzoneOptions;
 type Props = Omit<Dropzone, "onDrop" | "onChange"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   label?: string;
   icon?: string;
@@ -106,11 +107,11 @@ const File = ({
     disabled,
   });
 
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-form__file-input",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-form__file-input",
-  );
+  });
 
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Form/Number/Number.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Number/Number.tsx
@@ -1,8 +1,9 @@
 import "@axa-fr/canopee-css/distributeur/Form/Text/Text.css";
 import { type ComponentPropsWithRef, forwardRef, useId } from "react";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "type"> & {
+  /** @deprecated Use `className` and the native `required` prop instead. */
   classModifier?: string;
 };
 
@@ -10,11 +11,11 @@ const Number = forwardRef<HTMLInputElement, Props>(
   ({ id, className, classModifier, required, ...otherProps }, inputRef) => {
     const inputUseId = useId();
     const inputId = id ?? inputUseId;
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-text",
+      modifiers: classModifier?.split(" "),
       className,
-      classModifier,
-      "af-form__input-text",
-    );
+    });
     return (
       <input
         className={componentClassName}

--- a/packages/canopee-react/src/distributeur/Form/Number/__tests__/Number.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Number/__tests__/Number.test.tsx
@@ -18,9 +18,12 @@ describe("Number", () => {
     render(<Number value="999" className="custom-class" />);
 
     // Assert
-    expect(screen.getByRole("spinbutton")).toHaveClass("custom-class", {
-      exact: true,
-    });
+    expect(screen.getByRole("spinbutton")).toHaveClass(
+      "af-form__input-text custom-class",
+      {
+        exact: true,
+      },
+    );
   });
 
   it("should have custom class and modifier", () => {
@@ -31,7 +34,7 @@ describe("Number", () => {
 
     // Assert
     expect(screen.getByRole("spinbutton")).toHaveClass(
-      "custom-class custom-class--modifier",
+      "af-form__input-text af-form__input-text--modifier custom-class",
       {
         exact: true,
       },

--- a/packages/canopee-react/src/distributeur/Form/Pass/Pass.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Pass/Pass.tsx
@@ -1,11 +1,15 @@
 import { type ComponentPropsWithRef, forwardRef } from "react";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 import "@axa-fr/canopee-css/distributeur/Form/Pass/Pass.css";
 
+type PassStrength = "bad" | "okay" | "good" | "verygood" | "excellent";
+
 type Props = Omit<ComponentPropsWithRef<"input">, "type" | "role"> & {
   type?: "text" | "password";
+  /** @deprecated Use `className` and the native `required` prop instead. */
   classModifier?: string;
+  strength?: PassStrength;
   onToggleType: () => void;
 };
 
@@ -16,15 +20,16 @@ const Pass = forwardRef<HTMLInputElement, Props>(
       type = "password",
       className,
       classModifier,
+      strength,
       ...inputProps
     },
     inputRef,
   ) => {
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: "af-form__pass",
+      modifiers: [strength, ...(classModifier?.split(" ") ?? [])],
       className,
-      classModifier,
-      "af-form__pass",
-    );
+    });
 
     return (
       <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Form/Pass/Pass.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Pass/Pass.tsx
@@ -9,6 +9,9 @@ type Props = Omit<ComponentPropsWithRef<"input">, "type" | "role"> & {
   onToggleType: () => void;
 };
 
+/**
+ * @deprecated The Pass component is deprecated and will be removed in a future release
+ */
 const Pass = forwardRef<HTMLInputElement, Props>(
   (
     {

--- a/packages/canopee-react/src/distributeur/Form/Pass/PassInput.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Pass/PassInput.tsx
@@ -36,6 +36,9 @@ type Props = Omit<
   "onToggleType" | "type"
 >;
 
+/**
+ * @deprecated The PassInput component is deprecated and will be removed in a future release
+ */
 const PassInput = ({
   children,
   score,

--- a/packages/canopee-react/src/distributeur/Form/Pass/__tests__/Pass.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Pass/__tests__/Pass.test.tsx
@@ -21,7 +21,7 @@ describe("Pass", () => {
 
     // Assert
     expect(screen.getByRole("password").parentElement!).toHaveClass(
-      "custom-class",
+      "af-form__pass custom-class",
       {
         exact: true,
       },
@@ -41,7 +41,7 @@ describe("Pass", () => {
 
     // Assert
     expect(screen.getByRole("password").parentElement!).toHaveClass(
-      "custom-class custom-class--modifier",
+      "af-form__pass af-form__pass--modifier custom-class",
       {
         exact: true,
       },

--- a/packages/canopee-react/src/distributeur/Form/Radio/RadioItem.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Radio/RadioItem.tsx
@@ -8,6 +8,7 @@ import {
 import { getOptionClassName } from "../core";
 
 type Props = Omit<ComponentPropsWithRef<"input">, "checked" | "type"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   optionClassName?: string;
   label?: ReactNode;

--- a/packages/canopee-react/src/distributeur/Form/Select/SelectBase.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Select/SelectBase.tsx
@@ -4,7 +4,7 @@ import {
   forwardRef,
   type OptionHTMLAttributes,
 } from "react";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"select"> & {
   /**
@@ -22,6 +22,7 @@ type Props = ComponentPropsWithoutRef<"select"> & {
    * It allows you to use the `optgroup` tag for example.
    */
   options?: OptionHTMLAttributes<HTMLOptionElement>[];
+  /** @deprecated Use `className` and the native `required` prop instead. */
   classModifier?: string;
 };
 
@@ -41,11 +42,11 @@ const SelectBase = forwardRef<HTMLSelectElement, Props>(
     },
     inputRef,
   ) => {
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-select",
+      modifiers: classModifier?.split(" "),
       className,
-      classModifier,
-      "af-form__input-select",
-    );
+    });
     return (
       <div className="af-form__select-container">
         <select

--- a/packages/canopee-react/src/distributeur/Form/Slider/Slider.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Slider/Slider.tsx
@@ -5,12 +5,13 @@ import {
   type ComponentProps,
   type ReactNode,
 } from "react";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 type RcSliderProps = ComponentProps<typeof RcSlider>;
 type Marks = RcSliderProps["marks"];
 
 type Props = Omit<RcSliderProps, "marks" | "onChange" | "onChangeComplete"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   options: { value: number; label?: string | ReactNode }[];
   id: string;
@@ -63,7 +64,12 @@ const Slider = ({
   );
 
   const componentClassName = useMemo(
-    () => getComponentClassName(className, classModifier, "af-slider"),
+    () =>
+      getClassName({
+        baseClassName: "af-slider",
+        modifiers: classModifier?.split(" "),
+        className,
+      }),
     [className, classModifier],
   );
 

--- a/packages/canopee-react/src/distributeur/Form/Text/Text.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Text/Text.tsx
@@ -1,18 +1,19 @@
 import "@axa-fr/canopee-css/distributeur/Form/Text/Text.css";
 import { type ComponentPropsWithRef, forwardRef } from "react";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithRef<"input"> & {
+  /** @deprecated Use `className` and the native `required` prop instead. */
   classModifier?: string;
 };
 
 const Text = forwardRef<HTMLInputElement, Props>(
   ({ className, classModifier, required, ...otherProps }, inputRef) => {
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-text",
+      modifiers: classModifier?.split(" "),
       className,
-      classModifier,
-      "af-form__input-text",
-    );
+    });
 
     return (
       <input

--- a/packages/canopee-react/src/distributeur/Form/Text/__tests__/Text.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Text/__tests__/Text.test.tsx
@@ -18,9 +18,12 @@ describe("Text", () => {
     render(<Text value="Hello World" className="custom-class" />);
 
     // Assert
-    expect(screen.getByRole("textbox")).toHaveClass("custom-class", {
-      exact: true,
-    });
+    expect(screen.getByRole("textbox")).toHaveClass(
+      "af-form__input-text custom-class",
+      {
+        exact: true,
+      },
+    );
   });
 
   it("should have custom class and modifier", () => {
@@ -35,7 +38,7 @@ describe("Text", () => {
 
     // Assert
     expect(screen.getByRole("textbox")).toHaveClass(
-      "custom-class custom-class--modifier",
+      "af-form__input-text af-form__input-text--modifier custom-class",
       {
         exact: true,
       },

--- a/packages/canopee-react/src/distributeur/Form/Textarea/Textarea.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Textarea/Textarea.tsx
@@ -1,9 +1,10 @@
 import "@axa-fr/canopee-css/distributeur/Form/Textarea/Textarea.css";
 import { type ComponentPropsWithoutRef, forwardRef, useId } from "react";
 
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"textarea"> & {
+  /** @deprecated Use `className` and the native `required` prop instead. */
   classModifier?: string;
 };
 
@@ -11,11 +12,11 @@ const Textarea = forwardRef<HTMLTextAreaElement, Props>(
   ({ id, className, classModifier, ...otherProps }, inputRef) => {
     const inputUseId = useId();
     const inputId = id ?? inputUseId;
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: "af-form__input-textarea",
+      modifiers: classModifier?.split(" "),
       className,
-      classModifier,
-      "af-form__input-textarea",
-    );
+    });
 
     return (
       <textarea

--- a/packages/canopee-react/src/distributeur/Form/Textarea/__tests__/Textarea.test.tsx
+++ b/packages/canopee-react/src/distributeur/Form/Textarea/__tests__/Textarea.test.tsx
@@ -24,9 +24,12 @@ describe("Textarea", () => {
     render(<Textarea className="custom-class">A textarea</Textarea>);
 
     // Assert
-    expect(screen.getByRole("textbox")).toHaveClass("custom-class", {
-      exact: true,
-    });
+    expect(screen.getByRole("textbox")).toHaveClass(
+      "af-form__input-textarea custom-class",
+      {
+        exact: true,
+      },
+    );
   });
 
   it("should have custom class with modifier", () => {
@@ -39,7 +42,7 @@ describe("Textarea", () => {
 
     // Assert
     expect(screen.getByRole("textbox")).toHaveClass(
-      "custom-class custom-class--modifier",
+      "af-form__input-textarea af-form__input-textarea--modifier custom-class",
       {
         exact: true,
       },

--- a/packages/canopee-react/src/distributeur/Form/core/getOptionClassName.ts
+++ b/packages/canopee-react/src/distributeur/Form/core/getOptionClassName.ts
@@ -1,21 +1,19 @@
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 export function getOptionClassName(
   className: string,
   classModifier: string,
   defaultClassName: string,
   disabled: boolean,
+  variant?: string,
 ) {
-  const classModifierWithDisabled = [
-    classModifier,
-    disabled ? "disabled" : undefined,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return getComponentClassName(
+  return getClassName({
+    baseClassName: defaultClassName,
+    modifiers: [
+      variant,
+      ...(classModifier?.split(" ") ?? []),
+      disabled ? "disabled" : undefined,
+    ],
     className,
-    classModifierWithDisabled,
-    defaultClassName,
-  );
+  });
 }

--- a/packages/canopee-react/src/distributeur/Form/core/getOptionClassName.ts
+++ b/packages/canopee-react/src/distributeur/Form/core/getOptionClassName.ts
@@ -1,21 +1,19 @@
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 export function getOptionClassName(
   className: string,
   classModifier: string,
   defaultClassName: string,
   disabled: boolean,
+  variant?: string,
 ) {
-  const classModifierWithDisabled = [
-    classModifier,
-    disabled ? "disabled" : undefined,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return getComponentClassName(
+  return getClassName({
+    baseClassName: defaultClassName,
+    modifiers: [
+      variant,
+      ...(classModifier?.split(" ") ?? []),
+      disabled && "disabled",
+    ],
     className,
-    classModifierWithDisabled,
-    defaultClassName,
-  );
+  });
 }

--- a/packages/canopee-react/src/distributeur/HelpButton/index.tsx
+++ b/packages/canopee-react/src/distributeur/HelpButton/index.tsx
@@ -1,7 +1,8 @@
 import "@axa-fr/canopee-css/distributeur/Action/Action.css";
+import classNames from "classnames";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { Popover } from "../Popover";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type HelpProps = Omit<
   ComponentPropsWithoutRef<typeof Popover>,
@@ -18,10 +19,12 @@ export const HelpButton = ({
   placement = "right",
   helpButtonContent = <span className="af-more-help">i</span>,
 }: HelpProps) => {
-  const buttonClassName = getComponentClassName(
-    "btn af-btn--circle",
-    classModifier,
-    "",
+  const buttonClassName = classNames(
+    "btn",
+    getClassName({
+      baseClassName: "af-btn--circle",
+      modifiers: classModifier?.split(" "),
+    }),
   );
 
   return (

--- a/packages/canopee-react/src/distributeur/Layout/Header/Header.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/Header.tsx
@@ -1,22 +1,23 @@
 import "@axa-fr/canopee-css/distributeur/Layout/Header/Header.css";
 import classNames from "classnames";
 import { type ReactNode } from "react";
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 const defaultClassName = "af-header";
 
 type Props = {
   children: ReactNode;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   className?: string;
 };
 
 const Header = ({ classModifier, className, children }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={classNames("af-container", componentClassName)}>

--- a/packages/canopee-react/src/distributeur/Layout/Header/Infos/Infos.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/Infos/Infos.tsx
@@ -1,7 +1,7 @@
 import infoIcon from "@material-symbols/svg-400/outlined/info-fill.svg";
 import { Fragment, type ReactNode } from "react";
-import { getComponentClassName } from "../../../utilities";
 import { generateId } from "../../../utilities/helpers/generateId";
+import { getClassName } from "../../../utilities/helpers/getClassName";
 
 import "@axa-fr/canopee-css/distributeur/Layout/Header/Infos/Infos.css";
 import { Svg } from "../../../Svg";
@@ -15,17 +15,18 @@ export type TInfo = {
 };
 
 type InfosProps = {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   className?: string;
   infos: TInfo[];
 };
 
 const Infos = ({ infos, className, classModifier }: InfosProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Layout/Header/Name/Name.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/Name/Name.tsx
@@ -1,12 +1,13 @@
 import "@axa-fr/canopee-css/distributeur/Layout/Header/Logo/Logo.css";
 import "@axa-fr/canopee-css/distributeur/Layout/Header/Name/Name.css";
 import { type MouseEvent } from "react";
-import { getComponentClassName } from "../../../utilities";
+import { getClassName } from "../../../utilities/helpers/getClassName";
 
 const defaultClassName = "af-header__name";
 
 type Props = {
   alt?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   className?: string;
   img?: string;
@@ -24,11 +25,11 @@ const Name = ({
   subtitle,
   title,
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarBase.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/NavBar/NavBarBase.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import type { FocusEvent, MouseEvent, ReactNode } from "react";
-import { getComponentClassName } from "../../../utilities";
+import { getClassName } from "../../../utilities/helpers/getClassName";
 
 const defaultClassName = "af-nav-container";
 
@@ -11,6 +11,7 @@ type Props = {
   isMenuFocused?: boolean;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   handleKeys: (key: string) => void;
   onFocus: (action: { e: FocusEvent<HTMLUListElement> }) => void;
@@ -31,11 +32,11 @@ const NavBarBase = ({
   onBlur,
   children,
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={classNames("af-container", componentClassName)}>

--- a/packages/canopee-react/src/distributeur/Layout/Header/User/User.tsx
+++ b/packages/canopee-react/src/distributeur/Layout/Header/User/User.tsx
@@ -1,6 +1,6 @@
 import "@axa-fr/canopee-css/distributeur/Layout/Header/User/User.css";
 import type { MouseEvent, ReactNode } from "react";
-import { getComponentClassName } from "../../../utilities";
+import { getClassName } from "../../../utilities/helpers/getClassName";
 import { InnerUser } from "./InnerUser";
 
 const defaultClassName = "af-info-user";
@@ -25,6 +25,7 @@ type Props = {
    * <User classModifier="custom-class" />
    * ```
    * This will apply the class `af-info-user--custom-class` to the component.
+   * @deprecated Use `className` instead.
    */
   classModifier?: string;
   /**
@@ -73,11 +74,11 @@ const User = ({
   onClick,
   title = "Voir mon profil",
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Loader/Loader.tsx
+++ b/packages/canopee-react/src/distributeur/Loader/Loader.tsx
@@ -1,6 +1,6 @@
 import "@axa-fr/canopee-css/distributeur/Loader/Loader.css";
 import { type ReactNode } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type LoaderMode = "none" | "get" | "post" | "delete" | "update" | "error";
 
@@ -26,6 +26,7 @@ type LoaderProps = {
   mode: LoaderMode;
   text?: string;
   children: ReactNode;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -36,11 +37,11 @@ export const Loader = ({
   classModifier,
   mode = "none",
 }: LoaderProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-loader",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-loader",
-  );
+  });
   const message = text || getText(mode);
   const isLoaderVisible = mode !== "none";
   const isLoaderInError = mode === "error";

--- a/packages/canopee-react/src/distributeur/Messages/Message.tsx
+++ b/packages/canopee-react/src/distributeur/Messages/Message.tsx
@@ -7,7 +7,7 @@ import warningSvg from "@material-symbols/svg-400/outlined/warning-fill.svg";
 
 import type { MouseEventHandler, PropsWithChildren, ReactNode } from "react";
 import { Svg } from "../Svg";
-import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type MessageVariants = "error" | "warning" | "info" | "success";
 
@@ -95,10 +95,10 @@ export const Message = ({
 }: PropsWithChildren<MessageProps>) => {
   const safeVariant = getVariant(classModifier, variant);
 
-  const componentClassName = getComponentClassNameWithUserClassname({
-    componentClassName: "af-alert",
-    userClassName: className,
-    classModifier: safeVariant,
+  const componentClassName = getClassName({
+    baseClassName: "af-alert",
+    modifiers: [safeVariant],
+    className,
   });
 
   const iconSrc = icon ?? getIconUrl(safeVariant);

--- a/packages/canopee-react/src/distributeur/ModalAgent/__tests__/Modal.test.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/__tests__/Modal.test.tsx
@@ -279,8 +279,8 @@ describe("ModalHeader", () => {
 
     const banner = screen.getByRole("banner");
     expect(banner).toHaveClass("custom-header-class");
-    expect(banner).toHaveClass("custom-header-class--custom-modifier");
-    expect(banner).not.toHaveClass("af-modal__header");
+    expect(banner).toHaveClass("af-modal__header--custom-modifier");
+    expect(banner).toHaveClass("af-modal__header");
   });
 });
 
@@ -302,8 +302,8 @@ describe("ModalBody", () => {
 
     const body = screen.getByText(/My Modal Body/i);
     expect(body).toHaveClass("custom-body-class");
-    expect(body).toHaveClass("custom-body-class--custom-modifier");
-    expect(body).not.toHaveClass("af-modal__body");
+    expect(body).toHaveClass("af-modal__body--custom-modifier");
+    expect(body).toHaveClass("af-modal__body");
   });
 });
 
@@ -329,7 +329,7 @@ describe("ModalFooter", () => {
 
     const footer = screen.getByText(/my modal footer/i);
     expect(footer).toHaveClass("custom-footer-class");
-    expect(footer).toHaveClass("custom-footer-class--custom-modifier");
-    expect(footer).not.toHaveClass("af-modal__footer");
+    expect(footer).toHaveClass("af-modal__footer--custom-modifier");
+    expect(footer).toHaveClass("af-modal__footer");
   });
 });

--- a/packages/canopee-react/src/distributeur/ModalAgent/components/Body.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/components/Body.tsx
@@ -1,6 +1,7 @@
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 export type BodyProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -10,11 +11,11 @@ const Body = ({
   classModifier,
   ...otherProps
 }: BodyProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-modal__body",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-modal__body",
-  );
+  });
   return (
     <section className={componentClassName} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/ModalAgent/components/Footer.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/components/Footer.tsx
@@ -1,15 +1,16 @@
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 export type FooterProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
 const Footer = ({ classModifier, className, ...rest }: FooterProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-modal__footer",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-modal__footer",
-  );
+  });
 
   return <footer {...rest} className={componentClassName} />;
 };

--- a/packages/canopee-react/src/distributeur/ModalAgent/components/Header.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/components/Header.tsx
@@ -1,6 +1,7 @@
 import closeIcon from "@material-symbols/svg-400/outlined/close.svg";
 import type { MouseEventHandler, ReactNode } from "react";
-import { getComponentClassName, Svg } from "../../../distributeur";
+import { Svg } from "../../../distributeur";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 export type HeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   /**
@@ -22,6 +23,7 @@ export type HeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   closeButtonAriaLabel?: string;
   /**
    * Class modifier for the header. Can be used to apply custom styles.
+   * @deprecated Use `className` instead.
    */
   classModifier?: string;
   /**
@@ -39,11 +41,11 @@ const Header = ({
   children,
   ...props
 }: HeaderProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-modal__header",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-modal__header",
-  );
+  });
 
   return (
     <header className={componentClassName} {...props}>

--- a/packages/canopee-react/src/distributeur/ModalAgent/components/HeaderBase.tsx
+++ b/packages/canopee-react/src/distributeur/ModalAgent/components/HeaderBase.tsx
@@ -1,15 +1,16 @@
-import { getComponentClassName } from "../../utilities";
+import { getClassName } from "../../utilities/helpers/getClassName";
 
 export type HeaderBaseProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
 const HeaderBase = ({ classModifier, className, ...rest }: HeaderBaseProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-modal__header",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-modal__header",
-  );
+  });
 
   return <header {...rest} className={componentClassName} />;
 };

--- a/packages/canopee-react/src/distributeur/Popover/AnimatedPopover.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/AnimatedPopover.tsx
@@ -7,7 +7,7 @@ import {
   useFloating,
 } from "@floating-ui/react";
 import React, { useRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 const defaultClassName = "af-popover__container";
 
@@ -17,6 +17,7 @@ type PropsAnimatedPopover = {
   isOpen: boolean;
   target: React.ReactNode;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   onMouseEnter?: (event: React.MouseEvent) => void;
   onMouseLeave?: (event: React.MouseEvent) => void;
@@ -32,11 +33,11 @@ export const AnimatedPopover = ({
   onMouseEnter,
   onMouseLeave,
 }: PropsAnimatedPopover) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" ") ?? [],
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   const [referenceElement, setReferenceElement] = React.useState(null);
   const [popperElement, setPopperElement] = React.useState(null);

--- a/packages/canopee-react/src/distributeur/Popover/Popover.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/Popover.tsx
@@ -6,6 +6,7 @@ import { PopoverOver } from "./PopoverOver";
 
 type Props = {
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   placement?: Placement;
   mode: PopoverModes;

--- a/packages/canopee-react/src/distributeur/Popover/Popover.types.ts
+++ b/packages/canopee-react/src/distributeur/Popover/Popover.types.ts
@@ -4,7 +4,9 @@ export type PopoverModes = "hover" | "click";
 
 export type PopoverProps = {
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
+  size?: "small";
   placement?: Placement;
   children?: React.ReactNode;
   element: React.ReactNode;

--- a/packages/canopee-react/src/distributeur/Popover/PopoverBase.tsx
+++ b/packages/canopee-react/src/distributeur/Popover/PopoverBase.tsx
@@ -4,11 +4,10 @@ import { AnimatedPopover } from "./AnimatedPopover";
 
 import "@axa-fr/canopee-css/distributeur/Popover/Popover.css";
 
-const defaultClassName = "af-popover__container";
-
 type Props = {
   placement?: Placement;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   element: React.ReactNode;
   children: React.ReactNode | React.ReactNode[];
@@ -21,7 +20,7 @@ const PopoverBase = ({
   children,
   isOpen,
   placement = "right",
-  className = defaultClassName,
+  className,
   classModifier,
   element,
   onMouseEnter,

--- a/packages/canopee-react/src/distributeur/Restitution/ArticleRestitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/ArticleRestitution.tsx
@@ -1,7 +1,8 @@
 import type { ComponentPropsWithoutRef, PropsWithChildren } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type ArticleRestitutionProps = ComponentPropsWithoutRef<"article"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -11,11 +12,11 @@ export const ArticleRestitution = ({
   classModifier,
   ...otherProps
 }: PropsWithChildren<ArticleRestitutionProps>) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-restitution",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-restitution",
-  );
+  });
   return (
     <article className={componentClassName} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Restitution/HeaderRestitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/HeaderRestitution.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type HeaderRestitutionProps = {
   className?: string;
   title: React.ReactNode;
   subtitle?: React.ReactNode;
   rightTitle?: React.ReactNode;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -16,11 +17,11 @@ export const HeaderRestitution = ({
   className,
   classModifier,
 }: HeaderRestitutionProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-restitution__header",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-restitution__header",
-  );
+  });
   return (
     <header className={componentClassName}>
       <div className="af-restitution__header-left">

--- a/packages/canopee-react/src/distributeur/Restitution/Restitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/Restitution.tsx
@@ -1,9 +1,11 @@
 import type { ComponentPropsWithoutRef, PropsWithChildren } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type RestitutionProps = ComponentPropsWithoutRef<"dl"> & {
   label: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
+  variant?: "marge";
 };
 
 export const Restitution = ({
@@ -11,12 +13,13 @@ export const Restitution = ({
   children = "-",
   className,
   classModifier,
+  variant,
 }: PropsWithChildren<RestitutionProps>) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-restitution__listdef",
+    modifiers: [variant, ...(classModifier?.split(" ") ?? [])],
     className,
-    classModifier,
-    "af-restitution__listdef",
-  );
+  });
   return (
     <dl className={componentClassName}>
       <dt className="af-restitution__listdef-item">

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitution.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitution.tsx
@@ -1,8 +1,9 @@
 import type { PropsWithChildren } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type SectionRestitutionProps = {
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -11,10 +12,10 @@ export const SectionRestitution = ({
   className,
   classModifier,
 }: PropsWithChildren<SectionRestitutionProps>) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-restitution__content",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-restitution__content",
-  );
+  });
   return <section className={componentClassName}>{children}</section>;
 };

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionColumn.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionColumn.tsx
@@ -1,10 +1,12 @@
+import classNames from "classnames";
 import type { PropsWithChildren } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 import { SectionRestitutionTitle } from "./SectionRestitutionTitle";
 
 export type SectionRestitutionColumnProps = {
   className?: string;
   title?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -14,10 +16,15 @@ export const SectionRestitutionColumn = ({
   title,
   classModifier,
 }: PropsWithChildren<SectionRestitutionColumnProps>) => {
-  const componentClassName = getComponentClassName(
-    className,
-    classModifier,
+  const baseClassName = className
+    ? getClassName({
+        baseClassName: className,
+        modifiers: classModifier?.split(" "),
+      })
+    : null;
+  const componentClassName = classNames(
     "col-sm-12 col-md-12 col-lg-6 col-xl-6",
+    baseClassName,
   );
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionRow.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionRow.tsx
@@ -1,5 +1,6 @@
+import classNames from "classnames";
 import type { PropsWithChildren } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 import { SectionRestitutionTitle } from "./SectionRestitutionTitle";
 
 const DEFAULT_CLASSNAME = "col col-sm-12 col-md-12 col-lg-12 col-xl-12";
@@ -8,21 +9,25 @@ export type SectionRestitutionRowProps = {
   title?: React.ReactNode;
   classNameContainer?: string;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
 export const SectionRestitutionRow = ({
   title,
-  className = DEFAULT_CLASSNAME,
+  className,
   classNameContainer = "row af-restitution__content-left",
   children,
   classModifier,
 }: PropsWithChildren<SectionRestitutionRowProps>) => {
-  const componentClassName = getComponentClassName(
-    className,
-    classModifier,
-    DEFAULT_CLASSNAME,
-  );
+  const baseClassName = className
+    ? getClassName({
+        baseClassName: className,
+        modifiers: classModifier?.split(" "),
+      })
+    : null;
+
+  const componentClassName = classNames(DEFAULT_CLASSNAME, baseClassName);
   return (
     <div className={componentClassName}>
       {title ? <SectionRestitutionTitle title={title} /> : null}

--- a/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionTitle.tsx
+++ b/packages/canopee-react/src/distributeur/Restitution/SectionRestitutionTitle.tsx
@@ -1,8 +1,9 @@
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type SectionRestitutionTitleProps = {
   title: React.ReactNode;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -11,10 +12,10 @@ export const SectionRestitutionTitle = ({
   className,
   classModifier,
 }: SectionRestitutionTitleProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-restitution__content-title",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-restitution__content-title",
-  );
+  });
   return <h4 className={componentClassName}>{title}</h4>;
 };

--- a/packages/canopee-react/src/distributeur/Steps/StepBase.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/StepBase.tsx
@@ -1,13 +1,15 @@
 import checkSvg from "@material-symbols/svg-400/outlined/check.svg";
 import chevronSvg from "@material-symbols/svg-400/outlined/chevron_right.svg";
 import type { ReactNode } from "react";
-import { getComponentClassName, Svg } from "../../distributeur";
+import { Svg } from "../../distributeur";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type StepBaseProps = {
   id: string;
   title: string;
   children?: ReactNode;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   /**
    * Label to add to the title as state indication (e.g. "in progress", "to come"...)
@@ -28,11 +30,11 @@ const StepBase = ({
   classModifier,
   stateLabel,
 }: StepBaseProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-steps-list-step",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-steps-list-step",
-  );
+  });
 
   const outputTitle = stateLabel ? `${title} (${stateLabel})` : title;
   return (

--- a/packages/canopee-react/src/distributeur/Steps/Steps.tsx
+++ b/packages/canopee-react/src/distributeur/Steps/Steps.tsx
@@ -1,23 +1,20 @@
 import type { ReactNode } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 const defaultClassName = "af-steps-new";
 
 type Props = {
   children: ReactNode;
   className?: string;
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
-const Steps = ({
-  children,
-  className = defaultClassName,
-  classModifier,
-}: Props) => {
-  const componentClassName = getComponentClassName(
+const Steps = ({ children, className, classModifier }: Props) => {
+  const componentClassName = getClassName({
+    baseClassName: defaultClassName,
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    defaultClassName,
-  );
+  });
 
   return (
     <div className={componentClassName}>

--- a/packages/canopee-react/src/distributeur/Table/TBody.tsx
+++ b/packages/canopee-react/src/distributeur/Table/TBody.tsx
@@ -1,7 +1,8 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"tbody"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -11,11 +12,11 @@ const TBody = ({
   classModifier,
   ...otherProps
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-table__body",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-table__body",
-  );
+  });
   return (
     <tbody className={componentClassName} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Table/THead.tsx
+++ b/packages/canopee-react/src/distributeur/Table/THead.tsx
@@ -1,7 +1,8 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"thead"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -11,11 +12,11 @@ const THead = ({
   classModifier,
   ...otherProps
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-table__thead",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-table__thead",
-  );
+  });
   return (
     <thead className={componentClassName} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Table/Table.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Table.tsx
@@ -1,5 +1,5 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 import { TBody } from "./TBody";
 import { THead } from "./THead";
 import { Td } from "./Td";
@@ -9,6 +9,7 @@ import { Tr } from "./Tr";
 import "@axa-fr/canopee-css/distributeur/Table/Table.css";
 
 type TableProps = ComponentPropsWithoutRef<"table"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -18,11 +19,11 @@ const Table = ({
   children,
   ...othersProps
 }: TableProps) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-table",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-table",
-  );
+  });
   return (
     <table className={componentClassName} {...othersProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Table/Td.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Td.tsx
@@ -1,7 +1,8 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"td"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -12,11 +13,11 @@ const Td = ({
   classModifier,
   ...otherProps
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-table__cell",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-table__cell",
-  );
+  });
   return (
     <td className={componentClassName} key={id} id={id} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Table/Th.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Th.tsx
@@ -1,8 +1,10 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"th"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
+  sortable?: boolean;
 };
 
 const Th = ({
@@ -10,13 +12,14 @@ const Th = ({
   id,
   className,
   classModifier,
+  sortable,
   ...otherProps
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-table__th",
+    modifiers: [sortable && "sortable", ...(classModifier?.split(" ") ?? [])],
     className,
-    classModifier,
-    "af-table__th",
-  );
+  });
   return (
     <th className={componentClassName} key={id} id={id} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Table/Tr.tsx
+++ b/packages/canopee-react/src/distributeur/Table/Tr.tsx
@@ -1,7 +1,8 @@
 import { type ComponentPropsWithoutRef } from "react";
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type Props = ComponentPropsWithoutRef<"tr"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
 };
 
@@ -12,11 +13,11 @@ const Tr = ({
   classModifier,
   ...otherProps
 }: Props) => {
-  const componentClassName = getComponentClassName(
+  const componentClassName = getClassName({
+    baseClassName: "af-table__tr",
+    modifiers: classModifier?.split(" "),
     className,
-    classModifier,
-    "af-table__tr",
-  );
+  });
   return (
     <tr className={componentClassName} key={id} {...otherProps}>
       {children}

--- a/packages/canopee-react/src/distributeur/Tag/Tag.tsx
+++ b/packages/canopee-react/src/distributeur/Tag/Tag.tsx
@@ -4,7 +4,7 @@ import {
   type PropsWithChildren,
   forwardRef,
 } from "react";
-import { getComponentClassNameWithUserClassname } from "../utilities/helpers/getComponentClassName";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 export type TagVariants =
   | "success"
@@ -49,17 +49,17 @@ export const Tag = forwardRef<HTMLSpanElement, PropsWithChildren<TagProps>>(
   ({ children, className, classModifier, variant, ...otherProps }, ref) => {
     const actualModifier = variant || classModifier || "default";
 
-    const componentClassName = getComponentClassNameWithUserClassname({
-      userClassName: className,
-      classModifier: actualModifier,
-      componentClassName: "af-tag",
+    const componentClassName = getClassName({
+      baseClassName: "af-tag",
+      modifiers: [actualModifier],
+      className,
     });
 
     // Kept for backward compatibility. May be removed in a future version
-    const badgeClassName = getComponentClassNameWithUserClassname({
-      userClassName: className,
-      classModifier: actualModifier,
-      componentClassName: "af-badge",
+    const badgeClassName = getClassName({
+      baseClassName: "af-badge",
+      modifiers: [actualModifier],
+      className,
     });
 
     return (

--- a/packages/canopee-react/src/distributeur/Title/Title.tsx
+++ b/packages/canopee-react/src/distributeur/Title/Title.tsx
@@ -7,11 +7,12 @@ import {
   forwardRef,
 } from "react";
 
-import { getComponentClassName } from "../utilities";
+import { getClassName } from "../utilities/helpers/getClassName";
 
 type Headings = "h2" | "h3" | "h4";
 
 type TitleProps = ComponentPropsWithRef<"h2"> & {
+  /** @deprecated Use `className` instead. */
   classModifier?: string;
   heading?: Headings;
   contentLeft?: ReactElement;
@@ -36,11 +37,11 @@ export const Title = forwardRef<
     },
     ref,
   ) => {
-    const componentClassName = getComponentClassName(
+    const componentClassName = getClassName({
+      baseClassName: baseClass,
+      modifiers: classModifier?.split(" "),
       className,
-      classModifier,
-      baseClass,
-    );
+    });
 
     return (
       <div className={`${baseClass}--container`}>

--- a/packages/canopee-react/src/distributeur/Title/__tests__/Title.test.tsx
+++ b/packages/canopee-react/src/distributeur/Title/__tests__/Title.test.tsx
@@ -32,7 +32,7 @@ describe("Title", () => {
     // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("custom-class", {
+    ).toHaveClass("af-title custom-class", {
       exact: true,
     });
   });
@@ -48,7 +48,7 @@ describe("Title", () => {
     // Assert
     expect(
       screen.getByRole("heading", { name: /A title/, level: 2 }),
-    ).toHaveClass("custom-class custom-class--modifier", {
+    ).toHaveClass("af-title af-title--modifier custom-class", {
       exact: true,
     });
   });


### PR DESCRIPTION
All components that previously relied on `classModifier` to apply CSS variants now expose dedicated typed props:

- Popover: `size?: "small"`
- Table/Th: `sortable?: boolean`
- Form/Pass: `strength?: "bad" | "okay" | "good" | "verygood" | "excellent"`
- Form/CheckboxItem: `variant?: "error" | "warning"`
- Restitution: `variant?: "marge"`

The `classModifier` prop is marked `@deprecated` on all components. Use `className` for custom classes, and the new typed props for variants.

When `className` is provided, the component's default base class is now always present in the output. Previously, `className` replaced the base class entirely.