### PR TITLE
fix(client,prospect): rename orange-100 to orange-050 in tokens

### DIFF
--- a/apps/apollo-stories/src/fondations/Tokens/Tokens.mdx
+++ b/apps/apollo-stories/src/fondations/Tokens/Tokens.mdx
@@ -353,7 +353,7 @@
     </tr>
     <tr>
       <td>
-        <code>**--orange-100**</code>
+        <code>**--orange-050**</code>
       </td>
       <td>hsl(355deg, 100%, 98%)</td>
       <td>
@@ -362,7 +362,7 @@
             display: "inline-block",
             width: "1.5em",
             height: "1.5em",
-            backgroundColor: "var(--orange-100)",
+            backgroundColor: "var(--orange-050)",
             border: "1px solid #ccc",
           }}
         ></span>

--- a/apps/look-and-feel-stories/src/fondations/Tokens/Tokens.mdx
+++ b/apps/look-and-feel-stories/src/fondations/Tokens/Tokens.mdx
@@ -353,7 +353,7 @@
     </tr>
     <tr>
       <td>
-        <code>**--orange-100**</code>
+        <code>**--orange-050**</code>
       </td>
       <td>hsl(355deg, 100%, 98%)</td>
       <td>
@@ -362,7 +362,7 @@
             display: "inline-block",
             width: "1.5em",
             height: "1.5em",
-            backgroundColor: "var(--orange-100)",
+            backgroundColor: "var(--orange-050)",
             border: "1px solid #ccc",
           }}
         ></span>

--- a/packages/canopee-css/src/prospect-client/CardMessage/CardMessageLF.css
+++ b/packages/canopee-css/src/prospect-client/CardMessage/CardMessageLF.css
@@ -12,7 +12,7 @@
 }
 
 .af-card-message--warning {
-  --card-message-background-color: var(--orange-100);
+  --card-message-background-color: var(--orange-050);
   --card-message-text-color: var(--orange-1050);
   --card-message-border-color: var(--orange-1050);
 }

--- a/packages/canopee-css/src/prospect-client/common/tokens.css
+++ b/packages/canopee-css/src/prospect-client/common/tokens.css
@@ -104,7 +104,7 @@
   --orange-1050: hsl(19deg, 82%, 41%);
   --orange-1000: hsl(19deg, 82%, 43%);
   --orange-800: hsl(19deg, 63%, 55%);
-  --orange-100: hsl(355deg, 100%, 98%);
+  --orange-050: hsl(355deg, 100%, 98%);
 
   /* ⛔ legacy names colors - DO NOT USE */
   --warning-120: var(--orange-1050);
@@ -114,7 +114,7 @@
   --color-btn-business: var(--orange-1000);
   --warning-80: var(--orange-800);
   --color-btn-business-light: var(--orange-800);
-  --color-orange-100: var(--orange-100);
+  --color-orange-100: var(--orange-050);
 
   /* ORANGE PRIMITIVES **************************************************************/
 


### PR DESCRIPTION
This pull request standardizes the naming and usage of the orange color token across the codebase by replacing `--orange-100` with `--orange-050` wherever the color value `hsl(355deg, 100%, 98%)` is used. This improves consistency in both the CSS tokens and documentation.

**Design tokens and CSS updates:**

* Renamed the CSS variable `--orange-100` to `--orange-050` and updated its value to `hsl(355deg, 100%, 98%)` in `tokens.css`. Also updated the alias `--color-orange-100` to point to `--orange-050` instead of `--orange-100`. [[1]](diffhunk://#diff-a4e7ba6311c9f4dabfe33b04817bae05500b27d9ea06cec598c129ca98d2c671L107-R107) [[2]](diffhunk://#diff-a4e7ba6311c9f4dabfe33b04817bae05500b27d9ea06cec598c129ca98d2c671L117-R117)
* Updated the `CardMessageLF.css` warning background color to use the new `--orange-050` token instead of `--orange-100`.

**Documentation updates:**

* Updated references and visual examples of the orange color token in the `Tokens.mdx` documentation files for both `apollo-stories` and `look-and-feel-stories` to use `--orange-050` instead of `--orange-100`. [[1]](diffhunk://#diff-17125ff9bc000765c5a7e339653243123c4664daf1552bc53b17425b19c5eebfL356-R356) [[2]](diffhunk://#diff-17125ff9bc000765c5a7e339653243123c4664daf1552bc53b17425b19c5eebfL365-R365)