### PR TITLE
feat(client,prospect): add RadioText component with styles and tests

### DIFF
--- a/apps/apollo-stories/src/components/RadioText/RadioText.mdx
+++ b/apps/apollo-stories/src/components/RadioText/RadioText.mdx
@@ -1,0 +1,25 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as RadioTextStories from "./RadioText.stories";
+
+<Meta of={RadioTextStories} name="RadioText" />
+
+# RadioText
+
+## How to use
+
+```tsx
+import { RadioText } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <RadioText
+    name="option1"
+    value="option1"
+    label="J'accepte de fournir à AXA mes coordonnées ainsi que les données relatives à mon projet et ma situation."
+  />
+);
+```
+
+## Playground
+
+<Canvas of={RadioTextStories.RadioTextStory} sourceState="shown" />
+<Controls of={RadioTextStories.RadioTextStory} />

--- a/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
@@ -1,0 +1,37 @@
+import { RadioText } from "@axa-fr/canopee-react/prospect";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
+
+const meta: Meta = {
+  title: "Components/Form/Radio/RadioText",
+  component: RadioText,
+  argTypes: {
+    label: {
+      control: { type: "text" },
+    },
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    isInvalid: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    label:
+      "J'accepte de fournir à AXA mes coordonnées ainsi que les données relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra me contacter pour m'accompagner.",
+    name: "option1",
+    value: "option1",
+  },
+};
+
+export default meta;
+
+export const RadioTextStory: StoryObj<ComponentProps<typeof RadioText>> = {
+  name: "Playground",
+};

--- a/apps/look-and-feel-stories/src/components/RadioText/RadioText.mdx
+++ b/apps/look-and-feel-stories/src/components/RadioText/RadioText.mdx
@@ -1,0 +1,25 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as RadioTextStories from "./RadioText.stories";
+
+<Meta of={RadioTextStories} name="RadioText" />
+
+# RadioText
+
+## How to use
+
+```tsx
+import { RadioText } from "@axa-fr/canopee-react/client";
+
+const MyComponent = () => (
+  <RadioText
+    name="option1"
+    value="option1"
+    label="J'accepte de fournir à AXA mes coordonnées ainsi que les données relatives à mon projet et ma situation."
+  />
+);
+```
+
+## Playground
+
+<Canvas of={RadioTextStories.RadioTextStory} sourceState="shown" />
+<Controls of={RadioTextStories.RadioTextStory} />

--- a/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
@@ -1,0 +1,37 @@
+import { RadioText } from "@axa-fr/canopee-react/client";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
+
+const meta: Meta = {
+  title: "Components/Form/Radio/RadioText",
+  component: RadioText,
+  argTypes: {
+    label: {
+      control: { type: "text" },
+    },
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    isInvalid: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    label:
+      "J'accepte de fournir à AXA mes coordonnées ainsi que les données relatives à mon projet et ma situation. Ces dernières seront transmises à mon conseiller AXA qui pourra me contacter pour m'accompagner.",
+    name: "option1",
+    value: "option1",
+  },
+};
+
+export default meta;
+
+export const RadioTextStory: StoryObj<ComponentProps<typeof RadioText>> = {
+  name: "Playground",
+};

--- a/packages/canopee-css/src/prospect-client/Form/Radio/RadioText/RadioTextAll.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/RadioText/RadioTextAll.css
@@ -1,0 +1,17 @@
+.af-radio-text {
+  display: flex;
+  align-items: start;
+  gap: var(--rem-8);
+  cursor: pointer;
+}
+
+.af-radio-text__label-content {
+  font-size: var(--rem-16);
+  font-weight: 400;
+  line-height: 1.25;
+  color: var(--gray-1000);
+
+  @media (--desktop-small) {
+    font-size: var(--rem-18);
+  }
+}

--- a/packages/canopee-css/src/prospect-client/client.css
+++ b/packages/canopee-css/src/prospect-client/client.css
@@ -40,6 +40,7 @@
 @import "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.css";
 @import "./ContentItemMono/ContentItemMonoLF.css";
 @import "./Form/Radio/Radio/RadioLF.css";
+@import "./Form/Radio/RadioText/RadioTextAll.css";
 @import "./Form/Radio/CardRadioOption/CardRadioOptionLF.css";
 @import "./Form/Radio/CardRadioGroup/CardRadioGroupLF.css";
 @import "./Form/InputPhone/InputPhoneLF.css";

--- a/packages/canopee-css/src/prospect-client/prospect.css
+++ b/packages/canopee-css/src/prospect-client/prospect.css
@@ -40,6 +40,7 @@
 @import "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css";
 @import "./ContentItemMono/ContentItemMonoApollo.css";
 @import "./Form/Radio/Radio/RadioApollo.css";
+@import "./Form/Radio/RadioText/RadioTextAll.css";
 @import "./Form/Radio/CardRadioOption/CardRadioOptionApollo.css";
 @import "./Form/Radio/CardRadioGroup/CardRadioGroupApollo.css";
 @import "./Form/InputPhone/InputPhoneApollo.css";

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -79,6 +79,10 @@ export {
 } from "./prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupLF";
 export { CardRadioOption } from "./prospect-client/Form/Radio/CardRadioOption/CardRadioOptionLF";
 export { Radio } from "./prospect-client/Form/Radio/Radio/RadioLF";
+export {
+  RadioText,
+  type RadioTextProps,
+} from "./prospect-client/Form/Radio/RadioText/RadioTextLF";
 export { TextArea } from "./prospect-client/Form/TextArea/TextAreaLF";
 export { DebugGrid } from "./prospect-client/Grid/DebugGridLF";
 export {
@@ -98,9 +102,18 @@ export {
   type ItemTabBarProps,
 } from "./prospect-client/ItemTabBar/ItemTabBarLF";
 export {
+  ExitLayout,
+  type ExitLayoutProps,
+  type ExitLayoutWithSubComponents,
+} from "./prospect-client/Layout/ExitLayout/ExitLayoutLF";
+export {
   Footer,
   type FooterProps,
 } from "./prospect-client/Layout/Footer/FooterLF";
+export {
+  FormLayout,
+  type FormLayoutProps,
+} from "./prospect-client/Layout/FormLayout/FormLayout";
 export {
   LevelSelector,
   type LevelSelectorProps,
@@ -108,8 +121,8 @@ export {
 export {
   Link,
   linkVariants,
-  type LinkVariants,
   type LinkProps,
+  type LinkVariants,
 } from "./prospect-client/Link/LinkLF";
 export {
   ClickItem,
@@ -120,6 +133,7 @@ export {
 } from "./prospect-client/List/ClickItem/ClickItemLF";
 export { ContentItemDuo } from "./prospect-client/List/ContentItemDuo/ContentItemDuoLF";
 export { List, type ListProps } from "./prospect-client/List/List/ListLF";
+export { Loader, type LoaderProps } from "./prospect-client/Loader/LoaderLF";
 export {
   Message,
   messageVariants,
@@ -137,6 +151,14 @@ export {
   ModalCoreFooter,
   ModalCoreHeader,
 } from "./prospect-client/Modal/ModalLF";
+export {
+  ErrorPage,
+  type ErrorPageProps,
+} from "./prospect-client/pages/ErrorPage/ErrorPageLF";
+export {
+  ValidPage,
+  type ValidPageProps,
+} from "./prospect-client/pages/ValidPage/ValidPageLF";
 export {
   ItemPagination,
   type ItemPaginationProps,
@@ -166,39 +188,21 @@ export {
   type TabBarProps,
 } from "./prospect-client/TabBar/TabBarLF";
 export {
-  Tag,
-  tagVariants,
-  type TagVariants,
-} from "./prospect-client/Tag/TagLF";
-export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalLF";
-export { Toggle } from "./prospect-client/Toggle/ToggleLF";
-export {
   Table,
-  type TableProps,
-  type HeadColorVariants,
   type BodyColorVariants,
+  type HeadColorVariants,
   type RowSizeVariants,
+  type TableProps,
 } from "./prospect-client/Table/TableLF";
 export {
   TableMobileCard,
   type TableMobileCardProps,
 } from "./prospect-client/TableMobileCard/TableMobileCard";
 export {
-  ExitLayout,
-  type ExitLayoutWithSubComponents,
-  type ExitLayoutProps,
-} from "./prospect-client/Layout/ExitLayout/ExitLayoutLF";
-export {
-  FormLayout,
-  type FormLayoutProps,
-} from "./prospect-client/Layout/FormLayout/FormLayout";
-export {
-  ValidPage,
-  type ValidPageProps,
-} from "./prospect-client/pages/ValidPage/ValidPageLF";
-export {
-  ErrorPage,
-  type ErrorPageProps,
-} from "./prospect-client/pages/ErrorPage/ErrorPageLF";
+  Tag,
+  tagVariants,
+  type TagVariants,
+} from "./prospect-client/Tag/TagLF";
+export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalLF";
+export { Toggle } from "./prospect-client/Toggle/ToggleLF";
 export type { GridContainerProps } from "./prospect-client/utilities/types/GridContainerProps";
-export { Loader, type LoaderProps } from "./prospect-client/Loader/LoaderLF";

--- a/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/RadioTextApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/RadioTextApollo.tsx
@@ -1,0 +1,14 @@
+import "@axa-fr/canopee-css/prospect/Form/Radio/RadioText/RadioTextAll.css";
+import { forwardRef } from "react";
+import { Radio } from "../Radio/RadioApollo";
+import { RadioTextCommon, type RadioTextProps } from "./RadioTextCommon";
+
+export { type RadioTextProps } from "./RadioTextCommon";
+
+export const RadioText = forwardRef<HTMLInputElement, RadioTextProps>(
+  (props, ref) => (
+    <RadioTextCommon {...props} ref={ref} RadioComponent={Radio} />
+  ),
+);
+
+RadioText.displayName = "RadioText";

--- a/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/RadioTextCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/RadioTextCommon.tsx
@@ -1,0 +1,25 @@
+import { type ComponentType, forwardRef, type ReactNode } from "react";
+import type { GridContainerProps } from "../../../utilities/types/GridContainerProps";
+import type { RadioProps } from "../Radio/RadioCommon";
+
+export type RadioTextProps = {
+  label: string | ReactNode;
+  labelProps?: GridContainerProps<"label">;
+} & RadioProps;
+
+export type RadioTextCommonProps = RadioTextProps & {
+  RadioComponent: ComponentType<RadioProps>;
+};
+
+const RadioTextCommon = forwardRef<HTMLInputElement, RadioTextCommonProps>(
+  ({ label, labelProps, RadioComponent, ...inputProps }, ref) => (
+    <label className="af-radio-text" {...labelProps}>
+      <RadioComponent {...inputProps} ref={ref} />
+      <span className="af-radio-text__label-content">{label}</span>
+    </label>
+  ),
+);
+
+RadioTextCommon.displayName = "RadioTextCommon";
+
+export { RadioTextCommon };

--- a/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/RadioTextLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/RadioTextLF.tsx
@@ -1,0 +1,14 @@
+import "@axa-fr/canopee-css/client/Form/Radio/RadioText/RadioTextAll.css";
+import { forwardRef } from "react";
+import { Radio } from "../Radio/RadioLF";
+import { RadioTextCommon, type RadioTextProps } from "./RadioTextCommon";
+
+export { type RadioTextProps } from "./RadioTextCommon";
+
+export const RadioText = forwardRef<HTMLInputElement, RadioTextProps>(
+  (props, ref) => (
+    <RadioTextCommon {...props} ref={ref} RadioComponent={Radio} />
+  ),
+);
+
+RadioText.displayName = "RadioText";

--- a/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/__tests__/RadioText.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/__tests__/RadioText.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { Radio } from "../../Radio/RadioCommon";
+import { RadioTextCommon, type RadioTextProps } from "../RadioTextCommon";
+
+describe("RadioText Component", () => {
+  const RadioText = (props: RadioTextProps) => (
+    <RadioTextCommon {...props} RadioComponent={Radio} />
+  );
+
+  it("should render the label correctly", () => {
+    render(<RadioText label="Option 1" name="test" value="1" />);
+
+    expect(screen.getByRole("radio", { name: "Option 1" })).toBeInTheDocument();
+  });
+
+  it("should handle checked state", () => {
+    render(
+      <RadioText
+        label="Option"
+        name="option"
+        value="1"
+        checked
+        onChange={vi.fn()}
+      />,
+    );
+
+    const radio = screen.getByRole("radio", { name: "Option" });
+    expect(radio).toBeChecked();
+  });
+
+  it("should apply invalid class when isInvalid is true", () => {
+    render(<RadioText label="Option" name="option" value="1" isInvalid />);
+
+    const radio = screen.getByRole("radio", { name: "Option" });
+    expect(radio).toHaveClass("af-radio--invalid");
+  });
+
+  it("should not apply invalid class when isInvalid is false", () => {
+    render(<RadioText label="Option" name="option" value="1" />);
+
+    const radio = screen.getByRole("radio", { name: "Option" });
+    expect(radio).not.toHaveClass("af-radio--invalid");
+  });
+
+  it("should call onChange when clicked", async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RadioText
+        label="Option"
+        name="option"
+        value="1"
+        onChange={handleChange}
+      />,
+    );
+
+    const radio = screen.getByRole("radio", { name: "Option" });
+    await user.click(radio);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use provided id", () => {
+    render(<RadioText label="Option" name="option" value="1" id="custom-id" />);
+
+    const radio = screen.getByRole("radio", { name: "Option" });
+    expect(radio).toHaveAttribute("id", "custom-id");
+  });
+
+  it("should render ReactNode as label", () => {
+    render(
+      <RadioText label={<strong>Bold label</strong>} name="option" value="1" />,
+    );
+
+    expect(screen.getByText("Bold label")).toBeInTheDocument();
+    expect(screen.getByRole("radio")).toBeInTheDocument();
+  });
+});

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -71,6 +71,10 @@ export {
 } from "./prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupApollo";
 export { CardRadioOption } from "./prospect-client/Form/Radio/CardRadioOption/CardRadioOptionApollo";
 export { Radio } from "./prospect-client/Form/Radio/Radio/RadioApollo";
+export {
+  RadioText,
+  type RadioTextProps,
+} from "./prospect-client/Form/Radio/RadioText/RadioTextApollo";
 export { TextArea } from "./prospect-client/Form/TextArea/TextAreaApollo";
 export { DebugGrid } from "./prospect-client/Grid/DebugGridApollo";
 export {
@@ -90,9 +94,18 @@ export {
   type ItemTabBarProps,
 } from "./prospect-client/ItemTabBar/ItemTabBarApollo";
 export {
+  ExitLayout,
+  type ExitLayoutProps,
+  type ExitLayoutWithSubComponents,
+} from "./prospect-client/Layout/ExitLayout/ExitLayoutApollo";
+export {
   Footer,
   type FooterProps,
 } from "./prospect-client/Layout/Footer/FooterApollo";
+export {
+  FormLayout,
+  type FormLayoutProps,
+} from "./prospect-client/Layout/FormLayout/FormLayout";
 export {
   LevelSelector,
   type LevelSelectorProps,
@@ -100,8 +113,8 @@ export {
 export {
   Link,
   linkVariants,
-  type LinkVariants,
   type LinkProps,
+  type LinkVariants,
 } from "./prospect-client/Link/LinkApollo";
 export {
   ClickItem,
@@ -112,6 +125,10 @@ export {
 } from "./prospect-client/List/ClickItem/ClickItemApollo";
 export { ContentItemDuo } from "./prospect-client/List/ContentItemDuo/ContentItemDuoApollo";
 export { List, type ListProps } from "./prospect-client/List/List/ListApollo";
+export {
+  Loader,
+  type LoaderProps,
+} from "./prospect-client/Loader/LoaderApollo";
 export {
   Message,
   messageVariants,
@@ -129,6 +146,14 @@ export {
   ModalCoreFooter,
   ModalCoreHeader,
 } from "./prospect-client/Modal/ModalApollo";
+export {
+  ErrorPage,
+  type ErrorPageProps,
+} from "./prospect-client/pages/ErrorPage/ErrorPageApollo";
+export {
+  ValidPage,
+  type ValidPageProps,
+} from "./prospect-client/pages/ValidPage/ValidPageApollo";
 export {
   ItemPagination,
   type ItemPaginationProps,
@@ -158,39 +183,18 @@ export {
   type TabBarProps,
 } from "./prospect-client/TabBar/TabBarApollo";
 export {
+  Table,
+  type BodyColorVariants,
+  type HeadColorVariants,
+  type RowSizeVariants,
+  type TableProps,
+} from "./prospect-client/Table/TableApollo";
+export { TableMobileCard } from "./prospect-client/TableMobileCard/TableMobileCard";
+export {
   Tag,
   tagVariants,
   type TagVariants,
 } from "./prospect-client/Tag/TagApollo";
 export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalApollo";
 export { Toggle } from "./prospect-client/Toggle/ToggleApollo";
-export {
-  Table,
-  type TableProps,
-  type HeadColorVariants,
-  type BodyColorVariants,
-  type RowSizeVariants,
-} from "./prospect-client/Table/TableApollo";
-export { TableMobileCard } from "./prospect-client/TableMobileCard/TableMobileCard";
-export {
-  ExitLayout,
-  type ExitLayoutWithSubComponents,
-  type ExitLayoutProps,
-} from "./prospect-client/Layout/ExitLayout/ExitLayoutApollo";
-export {
-  FormLayout,
-  type FormLayoutProps,
-} from "./prospect-client/Layout/FormLayout/FormLayout";
-export {
-  ValidPage,
-  type ValidPageProps,
-} from "./prospect-client/pages/ValidPage/ValidPageApollo";
-export {
-  ErrorPage,
-  type ErrorPageProps,
-} from "./prospect-client/pages/ErrorPage/ErrorPageApollo";
 export type { GridContainerProps } from "./prospect-client/utilities/types/GridContainerProps";
-export {
-  Loader,
-  type LoaderProps,
-} from "./prospect-client/Loader/LoaderApollo";


### PR DESCRIPTION
This pull request introduces a new `RadioText` component to both the "prospect" and "client" design systems, including its implementation, documentation, Storybook stories, CSS styling, and comprehensive tests. The changes ensure that `RadioText` is available for use in both Apollo and Look & Feel (LF) themes, with full support in the component libraries and storybooks.

**Component Implementation and Exports:**

- Added the `RadioText` component for both Apollo (`RadioTextApollo.tsx`) and LF (`RadioTextLF.tsx`) themes, using a shared `RadioTextCommon` implementation. The component is now exported from both `prospect.ts` and `client.ts` entry points, making it available for consumers of the respective packages. [[1]](diffhunk://#diff-b20b2fe6e6ee7dc7a694c1d41fb3a42412aeb76f10fcb5bd65f3d3052e007af1R1-R11) [[2]](diffhunk://#diff-9d3f59639286c395e71527153a4fd7cdc305bc3be22cc73d9619466e54a9a711R1-R11) [[3]](diffhunk://#diff-574f4e943fbef71363adfca10317c491cfb183fb77ae0a3e4113b3aeea76310fR1-R26) [[4]](diffhunk://#diff-e87b39861a4819d64f9d6c3e1709ce8e70049c19a8d12026a192befb1610627cR74) [[5]](diffhunk://#diff-54654aba4f8e1ee05b377151a8a01e5038e328ba215034343aa55c03b431968bR82)

**Documentation and Storybook Integration:**

- Created MDX documentation and Storybook stories for `RadioText` in both Apollo and Look & Feel storybook apps, including usage examples and playground controls for interactive exploration. [[1]](diffhunk://#diff-210f3a3232f05012f48f05206c4c35da3258a9b3d60da918a00ba9eaa28f74e0R1-R25) [[2]](diffhunk://#diff-327ee3d704494fb9e242a328bbe22f336aed6de96be2461da378ebbeb24416acR1-R37) [[3]](diffhunk://#diff-6c7a9c2be8cf1257506b17722f3707a72ab8a85223ef8bbf79b93931cf712e94R1-R25) [[4]](diffhunk://#diff-5834c74107c78fe6e22db12af7e674481d24e2f45d40c668e2e4254e43b9e9e5R1-R37)

**Styling:**

- Added new CSS styles for the `RadioText` component and integrated them into both the Apollo and LF CSS bundles, ensuring consistent appearance across themes. [[1]](diffhunk://#diff-fc058e81d4b6cb8e842e69ec5759290a17dbe81445492e51357cffddd89cfdfaR1-R17) [[2]](diffhunk://#diff-7637875dc9f96bd0f9238527128c03fd755a2464ee3ddac1ea3a425f03440b67R42) [[3]](diffhunk://#diff-04bb828dd98ef9e7bef9cbbb1dcf81d9275b7a54f441376fc0251ba089585475R42)

**Testing:**

- Introduced a comprehensive test suite for `RadioTextCommon`, verifying correct rendering, checked state, invalid state handling, event handling, custom IDs, and support for ReactNode labels.