### PR TITLE
fix(client, prospect): correct CardCheckbox options orientation and expose mode prop

### DIFF
--- a/apps/apollo-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
+++ b/apps/apollo-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
@@ -42,6 +42,14 @@ const meta: Meta = {
         type: { summary: '"vertical" | "horizontal"' },
       },
     },
+    mode: {
+      control: { type: "inline-radio" },
+      options: [undefined, "text"],
+      table: {
+        defaultValue: { summary: "undefined" },
+        type: { summary: '"text"' },
+      },
+    },
     label: {
       control: "text",
     },

--- a/apps/look-and-feel-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/CardCheckbox/CardCheckbox.stories.tsx
@@ -42,6 +42,14 @@ const meta: Meta = {
         type: { summary: '"vertical" | "horizontal"' },
       },
     },
+    mode: {
+      control: { type: "inline-radio" },
+      options: [undefined, "text"],
+      table: {
+        defaultValue: { summary: "undefined" },
+        type: { summary: '"text"' },
+      },
+    },
     label: {
       control: "text",
     },

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.css
@@ -46,9 +46,9 @@
 }
 
 .af-card-checkbox__options--vertical {
-  flex-direction: row;
+  flex-direction: column;
 }
 
 .af-card-checkbox__options--horizontal {
-  flex-direction: column;
+  flex-direction: row;
 }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.css
@@ -47,10 +47,10 @@
   }
 
   .af-card-checkbox__options--vertical {
-    flex-direction: row;
+    flex-direction: column;
   }
 
   .af-card-checkbox__options--horizontal {
-    flex-direction: column;
+    flex-direction: row;
   }
 }

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -45,6 +45,7 @@ export {
   CardCheckbox,
   /** @deprecated Use `CardCheckbox` instead. */
   CardCheckbox as CheckboxCard,
+  type CardCheckboxProps,
 } from "./prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF";
 export { CardCheckboxOption } from "./prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF";
 export { Checkbox } from "./prospect-client/Form/Checkbox/Checkbox/CheckboxLF";

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -47,7 +47,10 @@ export {
   Fieldset,
   type FieldsetProps,
 } from "./prospect-client/Fieldset/FieldsetLF";
-export { CardCheckbox } from "./prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF";
+export {
+  CardCheckbox,
+  type CardCheckboxProps,
+} from "./prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF";
 export { CardCheckboxOption } from "./prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF";
 export { Checkbox } from "./prospect-client/Form/Checkbox/Checkbox/CheckboxLF";
 export { CheckboxText } from "./prospect-client/Form/Checkbox/CheckboxText/CheckboxTextLF";

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo.tsx
@@ -8,6 +8,8 @@ import {
 
 import "@axa-fr/canopee-css/prospect/Form/Checkbox/CardCheckbox/CardCheckboxApollo.css";
 
+export type { CardCheckboxProps };
+
 export const CardCheckbox = (props: CardCheckboxProps) => (
   <CardCheckboxCommon
     {...props}

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxLF.tsx
@@ -8,6 +8,8 @@ import {
 
 import "@axa-fr/canopee-css/client/Form/Checkbox/CardCheckbox/CardCheckboxLF.css";
 
+export type { CardCheckboxProps };
+
 export const CardCheckbox = (props: CardCheckboxProps) => (
   <CardCheckboxCommon
     {...props}

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -45,6 +45,7 @@ export {
   CardCheckbox,
   /** @deprecated Use `CardCheckbox` instead. */
   CardCheckbox as CheckboxCard,
+  type CardCheckboxProps,
 } from "./prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo";
 export { CardCheckboxOption } from "./prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo";
 export { Checkbox } from "./prospect-client/Form/Checkbox/Checkbox/CheckboxApollo";

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -47,7 +47,10 @@ export {
   Fieldset,
   type FieldsetProps,
 } from "./prospect-client/Fieldset/FieldsetApollo";
-export { CardCheckbox } from "./prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo";
+export {
+  CardCheckbox,
+  type CardCheckboxProps,
+} from "./prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxApollo";
 export { CardCheckboxOption } from "./prospect-client/Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo";
 export { Checkbox } from "./prospect-client/Form/Checkbox/Checkbox/CheckboxApollo";
 export { CheckboxText } from "./prospect-client/Form/Checkbox/CheckboxText/CheckboxTextApollo";

--- a/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
+++ b/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
@@ -68,14 +68,15 @@ Groupe de checkboxes en mode carte (vertical ou horizontal). Peut fonctionner en
 ### Import
 
 ```tsx
-import { CardCheckbox } from "@axa-fr/canopee-react/prospect";
+import { CardCheckbox, type CardCheckboxProps } from "@axa-fr/canopee-react/prospect";
 ```
 
 ### Props
 
 ```tsx
 type CardCheckboxProps = {
-  type?: "vertical" | "horizontal";  // Orientation des cartes (défaut: "vertical")
+  type?: "vertical" | "horizontal";  // vertical = cartes empilées en colonne,
+                                     // horizontal = cartes alignées en ligne (défaut: "vertical")
   mode?: "text";                      // Mode CheckboxText au lieu de cartes
   label: ReactNode;                   // Label du groupe (légende)
   description?: ReactNode;


### PR DESCRIPTION
Fixes two bugs on `CardCheckbox` (shared `CardCheckboxCommon`, both Look & Feel and Apollo), reported while consuming the component in React.

### 1. `type` vertical/horizontal inverted (CSS)

The container `flex-direction` was swapped, so the layout was the opposite of the prop name.

- `packages/canopee-css/src/prospect-client/Form/Checkbox/CardCheckbox/CardCheckboxCommon.css`

```css
.af-card-checkbox__options--vertical {
  flex-direction: column; /* was: row */
}

.af-card-checkbox__options--horizontal {
  flex-direction: row; /* was: column */
}
```

Now `type="vertical"` stacks the options (column) and `type="horizontal"` lays them in a row — matching the documented default (`vertical`) and consistent with the sibling `CardCheckboxOption`, which already maps `--horizontal` to `row`.

> [!WARNING]
> **Visual change for existing consumers.** Anyone relying on the previous (inverted) behaviour — or working around it by using the opposite value — will see the layout direction flip. Worth a changelog note / version-bump consideration.

### 2. `mode` prop not discoverable

- **Stories**: added the `mode` argType in both `CardCheckbox.stories.tsx` (apollo + look-and-feel) so it appears in the Storybook controls/props table (it was defined on the component but never listed).
- **React exports**: re-exported `CardCheckboxProps` from the `prospect` / `client` entry points (matching `Card` / `Fieldset`), so consumers can `import type { CardCheckboxProps }`.

### Notes

- Chromatic baselines for CardCheckbox will update (the orientation now renders correctly) — they need re-approval.
- No API change beyond the new type re-export; `type` / `mode` prop names are unchanged.

Closes #1871
