### PR TITLE
ci(design-system): group dependabot prs for gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,14 @@ updates:
       - dependency-name: "*storybook*" # ignore all storybook packages
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+     minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
-      - "gh-actions"      
+      - "gh-actions"


### PR DESCRIPTION
Instead of creating a PRs per GH Action,
this will group them together for all the minor and patch updates. This will make it easier to review and merge them.