### PR TITLE
feat(client,prospect): add TagList component

### DIFF
--- a/apps/apollo-stories/src/components/TagList/TagList.mdx
+++ b/apps/apollo-stories/src/components/TagList/TagList.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as TagListStories from "./TagList.stories";
+
+<Meta of={TagListStories} name="TagList" />
+
+# TagList
+
+Displays a list of `Tag` components. When the number of tags exceeds the `hideThreshold` (default: 2), only the first tags are shown and a `+N` tag indicates the number of hidden tags.
+
+### Import
+
+```tsx
+import { Tag, TagList } from "@axa-fr/canopee-react/prospect";
+```
+
+### Use
+
+```tsx
+export const TagListComponent = () => (
+  <TagList>
+    <Tag>Remboursement</Tag>
+    <Tag>Santé</Tag>
+    <Tag>Auto</Tag>
+  </TagList>
+);
+```
+
+## Playground
+
+<Canvas of={TagListStories.Default} />
+
+<Controls of={TagListStories.Default} />
+
+## With overflow
+
+When the number of `Tag` components exceeds `hideThreshold`, the extra tags are hidden and replaced by a `+N` tag.
+
+<Canvas of={TagListStories.WithOverflow} />
+
+## Custom threshold
+
+<Canvas of={TagListStories.CustomThreshold} />
+
+## Props
+
+| Prop            | Type        | Default | Description                                            |
+| --------------- | ----------- | ------- | ------------------------------------------------------ |
+| `children`      | `ReactNode` | -       | Child `Tag` components to display                      |
+| `hideThreshold` | `number`    | `2`     | Max number of visible tags before showing the `+N` tag |
+| `className`     | `string`    | `''`    | Custom CSS classes added to the container              |

--- a/apps/apollo-stories/src/components/TagList/TagList.stories.tsx
+++ b/apps/apollo-stories/src/components/TagList/TagList.stories.tsx
@@ -1,0 +1,49 @@
+import { Tag, TagList } from "@axa-fr/canopee-react/prospect";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TagList> = {
+  title: "Components/TagList",
+  component: TagList,
+  args: {
+    hideThreshold: 2,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TagList>;
+
+export const Default: Story = {
+  name: "TagList",
+  render: (args) => (
+    <TagList {...args}>
+      <Tag>Remboursement</Tag>
+      <Tag>Santé</Tag>
+    </TagList>
+  ),
+};
+
+export const WithOverflow: Story = {
+  name: "TagList with overflow",
+  render: (args) => (
+    <TagList {...args}>
+      <Tag>Remboursement</Tag>
+      <Tag>Santé</Tag>
+      <Tag>Auto</Tag>
+      <Tag>Habitation</Tag>
+      <Tag>Prévoyance</Tag>
+    </TagList>
+  ),
+};
+
+export const CustomThreshold: Story = {
+  name: "TagList with custom threshold",
+  render: (args) => (
+    <TagList {...args} hideThreshold={3}>
+      <Tag>Remboursement</Tag>
+      <Tag>Santé</Tag>
+      <Tag>Auto</Tag>
+      <Tag>Habitation</Tag>
+    </TagList>
+  ),
+};

--- a/apps/look-and-feel-stories/src/components/TagList/TagList.mdx
+++ b/apps/look-and-feel-stories/src/components/TagList/TagList.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as TagListStories from "./TagList.stories";
+
+<Meta of={TagListStories} name="TagList" />
+
+# TagList
+
+Displays a list of `Tag` components. When the number of tags exceeds the `hideThreshold` (default: 2), only the first tags are shown and a `+N` tag indicates the number of hidden tags.
+
+### Import
+
+```tsx
+import { Tag, TagList } from "@axa-fr/canopee-react/client";
+```
+
+### Use
+
+```tsx
+export const TagListComponent = () => (
+  <TagList>
+    <Tag>Remboursement</Tag>
+    <Tag>Santé</Tag>
+    <Tag>Auto</Tag>
+  </TagList>
+);
+```
+
+## Playground
+
+<Canvas of={TagListStories.Default} />
+
+<Controls of={TagListStories.Default} />
+
+## With overflow
+
+When the number of `Tag` components exceeds `hideThreshold`, the extra tags are hidden and replaced by a `+N` tag.
+
+<Canvas of={TagListStories.WithOverflow} />
+
+## Custom threshold
+
+<Canvas of={TagListStories.CustomThreshold} />
+
+## Props
+
+| Prop            | Type        | Default | Description                                            |
+| --------------- | ----------- | ------- | ------------------------------------------------------ |
+| `children`      | `ReactNode` | -       | Child `Tag` components to display                      |
+| `hideThreshold` | `number`    | `2`     | Max number of visible tags before showing the `+N` tag |
+| `className`     | `string`    | `''`    | Custom CSS classes added to the container              |

--- a/apps/look-and-feel-stories/src/components/TagList/TagList.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/TagList/TagList.stories.tsx
@@ -1,0 +1,49 @@
+import { Tag, TagList } from "@axa-fr/canopee-react/client";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TagList> = {
+  title: "Components/TagList",
+  component: TagList,
+  args: {
+    hideThreshold: 2,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TagList>;
+
+export const Default: Story = {
+  name: "TagList",
+  render: (args) => (
+    <TagList {...args}>
+      <Tag>Remboursement</Tag>
+      <Tag>Santé</Tag>
+    </TagList>
+  ),
+};
+
+export const WithOverflow: Story = {
+  name: "TagList with overflow",
+  render: (args) => (
+    <TagList {...args}>
+      <Tag>Remboursement</Tag>
+      <Tag>Santé</Tag>
+      <Tag>Auto</Tag>
+      <Tag>Habitation</Tag>
+      <Tag>Prévoyance</Tag>
+    </TagList>
+  ),
+};
+
+export const CustomThreshold: Story = {
+  name: "TagList with custom threshold",
+  render: (args) => (
+    <TagList {...args} hideThreshold={3}>
+      <Tag>Remboursement</Tag>
+      <Tag>Santé</Tag>
+      <Tag>Auto</Tag>
+      <Tag>Habitation</Tag>
+    </TagList>
+  ),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -418,6 +418,9 @@
     },
     "node_modules/@axa-fr/design-system-look-and-feel-css": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@axa-fr/design-system-look-and-feel-css/-/design-system-look-and-feel-css-3.2.0.tgz",
+      "integrity": "sha512-mvgXMTJ6RnyCtYxPrkVbMggREGgwP9m2AVymCARb5fmcmJu1BL4IgHD1CvKJj/KgGaJ8X0THG3js0VAWDqWnXg==",
+      "deprecated": "This package is no longer maintained. Please use @axa-fr/design-system-apollo-css",
       "license": "MIT",
       "peerDependencies": {
         "@material-symbols/svg-400": ">= 0.19.0"

--- a/packages/canopee-css/src/prospect-client/TagList/TagListAll.css
+++ b/packages/canopee-css/src/prospect-client/TagList/TagListAll.css
@@ -1,0 +1,5 @@
+.af-tag-list {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--rem-8);
+}

--- a/packages/canopee-css/src/prospect-client/client.css
+++ b/packages/canopee-css/src/prospect-client/client.css
@@ -24,6 +24,7 @@
 @import "./Message/MessageLF.css";
 @import "./MultiMessage/MultiMessageLF.css";
 @import "./Tag/TagLF.css";
+@import "./TagList/TagListAll.css";
 @import "./CardMessage/CardMessageLF.css";
 @import "./AccordionCore/AccordionCoreLF.css";
 @import "./ProgressBar/ProgressBarLF.css";

--- a/packages/canopee-css/src/prospect-client/prospect.css
+++ b/packages/canopee-css/src/prospect-client/prospect.css
@@ -24,6 +24,7 @@
 @import "./Message/MessageApollo.css";
 @import "./MultiMessage/MultiMessageApollo.css";
 @import "./Tag/TagApollo.css";
+@import "./TagList/TagListAll.css";
 @import "./CardMessage/CardMessageApollo.css";
 @import "./AccordionCore/AccordionCoreApollo.css";
 @import "./ProgressBar/ProgressBarApollo.css";

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -204,6 +204,10 @@ export {
   tagVariants,
   type TagVariants,
 } from "./prospect-client/Tag/TagLF";
+export {
+  TagList,
+  type TagListProps,
+} from "./prospect-client/TagList/TagListLF";
 export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalLF";
 export { Toggle } from "./prospect-client/Toggle/ToggleLF";
 export type { GridContainerProps } from "./prospect-client/utilities/types/GridContainerProps";

--- a/packages/canopee-react/src/prospect-client/TagList/TagListApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/TagList/TagListApollo.tsx
@@ -1,0 +1,12 @@
+import { Tag } from "../Tag/TagCommon";
+import {
+  TagListCommon,
+  type TagListProps as TagListCommonProps,
+} from "./TagListCommon";
+import "@axa-fr/canopee-css/prospect/TagList/TagListAll.css";
+
+export type TagListProps = Omit<TagListCommonProps, "OverflowTag">;
+
+export const TagList = (props: TagListProps) => (
+  <TagListCommon {...props} OverflowTag={Tag} />
+);

--- a/packages/canopee-react/src/prospect-client/TagList/TagListCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/TagList/TagListCommon.tsx
@@ -1,0 +1,41 @@
+import {
+  Children,
+  isValidElement,
+  type ComponentType,
+  type ReactNode,
+} from "react";
+import { getClassName } from "../utilities/getClassName";
+
+export type TagListProps = {
+  children: ReactNode;
+  hideThreshold?: number;
+  className?: string;
+  OverflowTag: ComponentType<{ children: ReactNode }>;
+};
+
+export const TagListCommon = ({
+  children,
+  hideThreshold = 2,
+  className = "",
+  OverflowTag,
+}: TagListProps) => {
+  const childArray = Children.toArray(children).filter(isValidElement);
+  const total = childArray.length;
+  const isOverflowing = total > hideThreshold;
+  const visibleChildren = isOverflowing
+    ? childArray.slice(0, hideThreshold)
+    : childArray;
+  const hiddenCount = total - hideThreshold;
+
+  return (
+    <div
+      className={getClassName({
+        baseClassName: "af-tag-list",
+        className,
+      })}
+    >
+      {visibleChildren}
+      {isOverflowing ? <OverflowTag>+{hiddenCount}</OverflowTag> : null}
+    </div>
+  );
+};

--- a/packages/canopee-react/src/prospect-client/TagList/TagListLF.tsx
+++ b/packages/canopee-react/src/prospect-client/TagList/TagListLF.tsx
@@ -1,0 +1,12 @@
+import { Tag } from "../Tag/TagCommon";
+import {
+  TagListCommon,
+  type TagListProps as TagListCommonProps,
+} from "./TagListCommon";
+import "@axa-fr/canopee-css/client/TagList/TagListAll.css";
+
+export type TagListProps = Omit<TagListCommonProps, "OverflowTag">;
+
+export const TagList = (props: TagListProps) => (
+  <TagListCommon {...props} OverflowTag={Tag} />
+);

--- a/packages/canopee-react/src/prospect-client/TagList/__tests__/TagList.test.tsx
+++ b/packages/canopee-react/src/prospect-client/TagList/__tests__/TagList.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { describe, expect, it } from "vitest";
+import { Tag } from "../../Tag/TagCommon";
+import { TagListCommon } from "../TagListCommon";
+
+const renderTagList = (count: number, hideThreshold?: number) =>
+  render(
+    <TagListCommon OverflowTag={Tag} hideThreshold={hideThreshold}>
+      {Array.from({ length: count }, (_, i) => (
+        <Tag key={i}>{`Tag ${i + 1}`}</Tag>
+      ))}
+    </TagListCommon>,
+  );
+
+describe("TagListCommon", () => {
+  it("renders all tags when count is below hideThreshold", () => {
+    renderTagList(2);
+
+    expect(screen.getByText("Tag 1")).toBeInTheDocument();
+    expect(screen.getByText("Tag 2")).toBeInTheDocument();
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it("renders all tags when count equals hideThreshold", () => {
+    renderTagList(2, 2);
+
+    expect(screen.getByText("Tag 1")).toBeInTheDocument();
+    expect(screen.getByText("Tag 2")).toBeInTheDocument();
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it("shows only first 2 tags and overflow tag when count exceeds hideThreshold", () => {
+    renderTagList(5);
+
+    expect(screen.getByText("Tag 1")).toBeInTheDocument();
+    expect(screen.getByText("Tag 2")).toBeInTheDocument();
+    expect(screen.queryByText("Tag 3")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tag 4")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tag 5")).not.toBeInTheDocument();
+    expect(screen.getByText("+3")).toBeInTheDocument();
+  });
+
+  it("respects a custom hideThreshold", () => {
+    renderTagList(4, 3);
+
+    expect(screen.getByText("Tag 1")).toBeInTheDocument();
+    expect(screen.getByText("Tag 2")).toBeInTheDocument();
+    expect(screen.getByText("Tag 3")).toBeInTheDocument();
+    expect(screen.queryByText("Tag 4")).not.toBeInTheDocument();
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+
+  it("applies the af-tag-list BEM class to the container", () => {
+    const { container } = renderTagList(1);
+
+    expect(container.firstChild).toHaveClass("af-tag-list");
+  });
+
+  it("merges custom className with af-tag-list", () => {
+    const { container } = render(
+      <TagListCommon OverflowTag={Tag} className="custom-class">
+        <Tag>Tag 1</Tag>
+      </TagListCommon>,
+    );
+
+    expect(container.firstChild).toHaveClass("af-tag-list");
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("should not have accessibility violations", async () => {
+    const { container } = renderTagList(5);
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -196,6 +196,10 @@ export {
   tagVariants,
   type TagVariants,
 } from "./prospect-client/Tag/TagApollo";
+export {
+  TagList,
+  type TagListProps,
+} from "./prospect-client/TagList/TagListApollo";
 export { TimelineVertical } from "./prospect-client/TimelineVertical/TimelineVerticalApollo";
 export { Toggle } from "./prospect-client/Toggle/ToggleApollo";
 export type { GridContainerProps } from "./prospect-client/utilities/types/GridContainerProps";


### PR DESCRIPTION
Ajoute le composant `TagList` pour les univers Prospect (Apollo) et Client (Look & Feel) du Design System Canopée. (issue liée #1931)

<img width="154" height="106" alt="image" src="https://github.com/user-attachments/assets/288ba5f2-77ac-4683-a6e1-80b52867607f" />

- Composant "Molécule" : affiche une liste de `Tag` enfants 
- Gestion du dépassement : masque les tags au-delà du seuil (défaut: 2) et affiche un tag +N pour indiquer le nombre de tags masqués
- Architecture multi-thèmes : implémentation partagée (Common) avec surcharges Apollo et LF
- Tests complets : couverture 100% des cas d'usage (seuil par défaut, personnalisé, overflow, styling custom)
- Documentation : stories Storybook et guides MDX pour chaque thème
- Accessibilité : conforme WCAG 2.1 AA, pas de violations axe