### PR TITLE
feat(canopee): ajout composant ItemMultiSelect

### DIFF
--- a/apps/apollo-stories/src/components/ItemMultiSelect/ItemMultiSelect.mdx
+++ b/apps/apollo-stories/src/components/ItemMultiSelect/ItemMultiSelect.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as ItemMultiSelectStories from "./ItemMultiSelect.stories";
+
+<Meta of={ItemMultiSelectStories} name="ItemMultiSelect" />
+
+# ItemMultiSelect
+
+The ItemMultiSelect component combines a checkbox with a label aligned horizontally.
+It supports two background variants: primary (blue-040) and secondary (white-1000).
+Only the checkbox changes on hover or selection, while the background container remains stable.
+
+Example usage:
+
+```tsx
+import { ItemMultiSelect } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => (
+  <ItemMultiSelect
+    label="I agree to the terms"
+    variant="primary"
+    name="agree"
+    value="agree"
+  />
+);
+```
+
+## Playground
+
+<Canvas of={ItemMultiSelectStories.Playground} sourceState="shown" />
+<Controls of={ItemMultiSelectStories.Playground} />
+
+## Variants
+
+### Primary (Default)
+
+The primary variant uses a blue-040 background.
+
+<Canvas of={ItemMultiSelectStories.Primary} />
+
+### Secondary
+
+The secondary variant uses a white-1000 background.
+
+<Canvas of={ItemMultiSelectStories.Secondary} />
+
+## States
+
+### Checked
+
+<Canvas of={ItemMultiSelectStories.Checked} />

--- a/apps/apollo-stories/src/components/ItemMultiSelect/ItemMultiSelect.stories.tsx
+++ b/apps/apollo-stories/src/components/ItemMultiSelect/ItemMultiSelect.stories.tsx
@@ -1,0 +1,60 @@
+import { ItemMultiSelect } from "@axa-fr/canopee-react/prospect";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
+
+const meta: Meta = {
+  title: "Components/Form/ItemMultiSelect",
+  component: ItemMultiSelect,
+  argTypes: {
+    label: {
+      control: { type: "text" },
+    },
+    variant: {
+      options: ["primary", "secondary"],
+      control: { type: "radio" },
+    },
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    label: "Option 1",
+    variant: "primary",
+    name: "option1",
+    value: "option1",
+    checked: false,
+  },
+};
+
+export default meta;
+
+export const Playground: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  name: "Playground",
+};
+
+export const Primary: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    variant: "primary",
+    label: "Primary background",
+  },
+};
+
+export const Secondary: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    variant: "secondary",
+    label: "Secondary background",
+  },
+};
+
+export const Checked: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    checked: true,
+    label: "Checked state",
+  },
+};

--- a/apps/look-and-feel-stories/src/components/ItemMultiSelect/ItemMultiSelect.mdx
+++ b/apps/look-and-feel-stories/src/components/ItemMultiSelect/ItemMultiSelect.mdx
@@ -1,0 +1,54 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as ItemMultiSelectStories from "./ItemMultiSelect.stories";
+
+<Meta of={ItemMultiSelectStories} name="ItemMultiSelect" />
+
+# ItemMultiSelect
+
+The ItemMultiSelect component combines a checkbox with a label aligned horizontally.
+It supports two background variants: primary (blue-040) and secondary (white-1000).
+Only the checkbox changes on hover or selection, while the background container remains stable.
+
+Example usage:
+
+```tsx
+import { ItemMultiSelect } from "@axa-fr/canopee-react/client";
+
+const MyComponent = () => (
+  <ItemMultiSelect
+    label="I agree to the terms"
+    variant="primary"
+    name="agree"
+    value="agree"
+  />
+);
+```
+
+## Playground
+
+<Canvas of={ItemMultiSelectStories.Playground} sourceState="shown" />
+<Controls of={ItemMultiSelectStories.Playground} />
+
+## Variants
+
+### Primary (Default)
+
+The primary variant uses a blue-040 background.
+
+<Canvas of={ItemMultiSelectStories.Primary} />
+
+### Secondary
+
+The secondary variant uses a white-1000 background.
+
+<Canvas of={ItemMultiSelectStories.Secondary} />
+
+## States
+
+### Checked
+
+<Canvas of={ItemMultiSelectStories.Checked} />
+
+### With Long Label
+
+<Canvas of={ItemMultiSelectStories.WithLongLabel} />

--- a/apps/look-and-feel-stories/src/components/ItemMultiSelect/ItemMultiSelect.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/ItemMultiSelect/ItemMultiSelect.stories.tsx
@@ -1,0 +1,66 @@
+import { ItemMultiSelect } from "@axa-fr/canopee-react/client";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
+
+const meta: Meta = {
+  title: "Components/Form/ItemMultiSelect",
+  component: ItemMultiSelect,
+  argTypes: {
+    label: {
+      control: { type: "text" },
+    },
+    variant: {
+      options: ["primary", "secondary"],
+      control: { type: "radio" },
+    },
+    name: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    label: "Option 1",
+    variant: "primary",
+    name: "option1",
+    value: "option1",
+  },
+};
+
+export default meta;
+
+export const Playground: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  name: "Playground",
+};
+
+export const Primary: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    variant: "primary",
+    label: "Primary background",
+  },
+};
+
+export const Secondary: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    variant: "secondary",
+    label: "Secondary background",
+  },
+};
+
+export const Checked: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    checked: true,
+    label: "Checked state",
+  },
+};
+
+export const WithLongLabel: StoryObj<ComponentProps<typeof ItemMultiSelect>> = {
+  args: {
+    label:
+      "This is a very long label that explains the option in detail to help users understand what this checkbox is for",
+  },
+};

--- a/packages/canopee-css/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectApollo.css
@@ -1,0 +1,9 @@
+@import "./ItemMultiSelectCommon.css";
+
+.af-item-multi-select--primary {
+  --item-multi-select-background-color: var(--blue-040);
+}
+
+.af-item-multi-select--secondary {
+  --item-multi-select-background-color: var(--white-1000);
+}

--- a/packages/canopee-css/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectCommon.css
@@ -1,0 +1,21 @@
+.af-item-multi-select {
+  display: inline-flex;
+  width: 100%;
+  padding: var(--size-16) var(--size-16);
+  align-items: center;
+  column-gap: var(--size-8);
+  background-color: var(--item-multi-select-background-color);
+  cursor: pointer;
+}
+
+.af-item-multi-select__checkbox {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.af-item-multi-select__label {
+  flex: 1 1 auto;
+  font-size: var(--rem-16);
+  font-weight: 400;
+}

--- a/packages/canopee-css/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectLF.css
@@ -1,0 +1,9 @@
+@import "./ItemMultiSelectCommon.css";
+
+.af-item-multi-select--primary {
+  --item-multi-select-background-color: var(--blue-040);
+}
+
+.af-item-multi-select--secondary {
+  --item-multi-select-background-color: var(--white-1000);
+}

--- a/packages/canopee-css/src/prospect-client/client.css
+++ b/packages/canopee-css/src/prospect-client/client.css
@@ -42,6 +42,7 @@
 @import "./Form/Checkbox/CheckboxText/CheckboxTextLF.css";
 @import "./Form/Checkbox/CardCheckbox/CardCheckboxLF.css";
 @import "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionLF.css";
+@import "./Form/ItemMultiSelect/ItemMultiSelectLF.css";
 @import "./ContentItemMono/ContentItemMonoLF.css";
 @import "./Form/Radio/Radio/RadioLF.css";
 @import "./Form/Radio/RadioText/RadioTextAll.css";

--- a/packages/canopee-css/src/prospect-client/prospect.css
+++ b/packages/canopee-css/src/prospect-client/prospect.css
@@ -42,6 +42,7 @@
 @import "./Form/Checkbox/CheckboxText/CheckboxTextApollo.css";
 @import "./Form/Checkbox/CardCheckbox/CardCheckboxApollo.css";
 @import "./Form/Checkbox/CardCheckboxOption/CardCheckboxOptionApollo.css";
+@import "./Form/ItemMultiSelect/ItemMultiSelectApollo.css";
 @import "./ContentItemMono/ContentItemMonoApollo.css";
 @import "./Form/Radio/Radio/RadioApollo.css";
 @import "./Form/Radio/RadioText/RadioTextAll.css";

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -72,6 +72,10 @@ export {
   itemMessageVariants,
   type ItemMessageVariants,
 } from "./prospect-client/Form/ItemMessage/ItemMessageLF";
+export {
+  ItemMultiSelect,
+  type ItemMultiSelectProps,
+} from "./prospect-client/Form/ItemMultiSelect/ItemMultiSelectLF";
 export { CardRadio } from "./prospect-client/Form/Radio/CardRadio/CardRadioLF";
 export { CardRadioGroup } from "./prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupLF";
 export { Radio } from "./prospect-client/Form/Radio/Radio/RadioLF";

--- a/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectApollo.tsx
@@ -1,0 +1,14 @@
+import "@axa-fr/canopee-css/prospect/Form/ItemMultiSelect/ItemMultiSelectApollo.css";
+import { Checkbox } from "../Checkbox/Checkbox/CheckboxApollo";
+import {
+  ItemMultiSelectCommon,
+  type ItemMultiSelectCommonProps,
+} from "./ItemMultiSelectCommon";
+
+export type ItemMultiSelectProps = Omit<ItemMultiSelectCommonProps, "Checkbox">;
+
+export const ItemMultiSelect = (props: ItemMultiSelectProps) => (
+  <ItemMultiSelectCommon {...props} Checkbox={Checkbox} />
+);
+
+ItemMultiSelect.displayName = "ItemMultiSelect";

--- a/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectCommon.tsx
@@ -1,0 +1,43 @@
+import {
+  type ComponentProps,
+  type ComponentType,
+  type FC,
+  type ReactNode,
+} from "react";
+import { getClassName } from "../../utilities/getClassName";
+
+export type ItemMultiSelectVariant = "primary" | "secondary";
+
+export type ItemMultiSelectCommonProps = Omit<
+  ComponentProps<"input">,
+  "type"
+> & {
+  label: ReactNode;
+  variant?: ItemMultiSelectVariant;
+  Checkbox: ComponentType<ComponentProps<"input">>;
+};
+
+export const ItemMultiSelectCommon: FC<ItemMultiSelectCommonProps> = ({
+  label,
+  variant = "primary",
+  className = "",
+  id,
+  Checkbox,
+  ...inputProps
+}) => (
+  <label
+    className={getClassName({
+      baseClassName: "af-item-multi-select",
+      modifiers: [variant],
+      className: className ?? "",
+    })}
+    htmlFor={id}
+  >
+    <span className="af-item-multi-select__checkbox">
+      <Checkbox id={id} {...inputProps} />
+    </span>
+    <span className="af-item-multi-select__label">{label}</span>
+  </label>
+);
+
+ItemMultiSelectCommon.displayName = "ItemMultiSelectCommon";

--- a/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/ItemMultiSelectLF.tsx
@@ -1,0 +1,14 @@
+import "@axa-fr/canopee-css/client/Form/ItemMultiSelect/ItemMultiSelectLF.css";
+import { Checkbox } from "../Checkbox/Checkbox/CheckboxLF";
+import {
+  ItemMultiSelectCommon,
+  type ItemMultiSelectCommonProps,
+} from "./ItemMultiSelectCommon";
+
+export type ItemMultiSelectProps = Omit<ItemMultiSelectCommonProps, "Checkbox">;
+
+export const ItemMultiSelect = (props: ItemMultiSelectProps) => (
+  <ItemMultiSelectCommon {...props} Checkbox={Checkbox} />
+);
+
+ItemMultiSelect.displayName = "ItemMultiSelect";

--- a/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/__tests__/ItemMultiSelectCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/ItemMultiSelect/__tests__/ItemMultiSelectCommon.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  ItemMultiSelectCommon,
+  type ItemMultiSelectVariant,
+} from "../ItemMultiSelectCommon";
+import { Checkbox } from "../../Checkbox/Checkbox/CheckboxCommon";
+
+describe("ItemMultiSelectCommon Component", () => {
+  it("should render the ItemMultiSelectCommon component with label and checkbox", () => {
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        id="test-checkbox"
+      />,
+    );
+
+    const label = screen.getByText("Test Label");
+    const checkbox = screen.getByRole("checkbox", { name: "Test Label" });
+
+    expect(label).toBeInTheDocument();
+    expect(checkbox).toBeInTheDocument();
+  });
+
+  it("should render with primary variant by default", () => {
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        id="test-checkbox"
+      />,
+    );
+
+    const container = screen.getByText("Test Label").closest("label");
+    expect(container).toHaveClass(
+      "af-item-multi-select",
+      "af-item-multi-select--primary",
+    );
+  });
+
+  it.each(["primary", "secondary"])(
+    "should render with %s variant when specified",
+    (variant) => {
+      render(
+        <ItemMultiSelectCommon
+          label="Test Label"
+          Checkbox={Checkbox}
+          variant={variant as ItemMultiSelectVariant}
+          id="test-checkbox"
+        />,
+      );
+
+      const container = screen.getByText("Test Label").closest("label");
+      expect(container).toHaveClass(
+        "af-item-multi-select",
+        `af-item-multi-select--${variant}`,
+      );
+    },
+  );
+
+  it("should apply custom class names", () => {
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        className="custom-class"
+        id="test-checkbox"
+      />,
+    );
+
+    const container = screen.getByText("Test Label").closest("label");
+    expect(container).toHaveClass("af-item-multi-select custom-class");
+  });
+
+  it("should render as checked when the checked prop is true", () => {
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        checked
+        onChange={vi.fn()}
+        id="test-checkbox"
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Test Label" });
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should call the onChange handler when checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        onChange={handleChange}
+        id="test-checkbox"
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Test Label" });
+    await user.click(checkbox);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should call the onChange handler when label is clicked", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        onChange={handleChange}
+        id="test-checkbox"
+      />,
+    );
+
+    const label = screen.getByText("Test Label");
+    await user.click(label);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    const checkbox = screen.getByRole("checkbox", { name: "Test Label" });
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should associate label with checkbox using htmlFor and id", () => {
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        id="custom-id"
+      />,
+    );
+
+    const label = screen.getByText("Test Label").closest("label");
+    const checkbox = screen.getByRole("checkbox", { name: "Test Label" });
+
+    expect(label).toHaveAttribute("for", "custom-id");
+    expect(checkbox).toHaveAttribute("id", "custom-id");
+  });
+
+  it("should pass additional props to the checkbox", () => {
+    render(
+      <ItemMultiSelectCommon
+        label="Test Label"
+        Checkbox={Checkbox}
+        name="test-name"
+        aria-label="custom"
+        id="test-checkbox"
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveAttribute("name", "test-name");
+    expect(checkbox).toHaveAttribute("aria-label", "custom");
+  });
+});

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -64,6 +64,10 @@ export {
   itemMessageVariants,
   type ItemMessageVariants,
 } from "./prospect-client/Form/ItemMessage/ItemMessageApollo";
+export {
+  ItemMultiSelect,
+  type ItemMultiSelectProps,
+} from "./prospect-client/Form/ItemMultiSelect/ItemMultiSelectApollo";
 export { CardRadio } from "./prospect-client/Form/Radio/CardRadio/CardRadioApollo";
 export { CardRadioGroup } from "./prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupApollo";
 export { Radio } from "./prospect-client/Form/Radio/Radio/RadioApollo";


### PR DESCRIPTION
Ajoute le composant `ItemMultiSelect` au thème prospect et client (issue liée #1928)

<img width="967" height="305" alt="image" src="https://github.com/user-attachments/assets/62b5b859-e594-4f16-a05e-4cfa5f27cbce" />


- Composant "Molécule" : réutiliser le composant `Checkbox`
- Architecture multi-thèmes : implémentation partagée (Common) avec surcharges Apollo et LF
- Tests complets : couverture 100% sur les test unitaires (passage de props, comportement au clic)
- Documentation : stories Storybook et guides MDX pour chaque thème