### PR TITLE
Feat/multi select list

### DIFF
--- a/apps/apollo-stories/src/components/MultiSelectList/MultiSelectList.mdx
+++ b/apps/apollo-stories/src/components/MultiSelectList/MultiSelectList.mdx
@@ -1,0 +1,26 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as MultiSelectListStories from "./MultiSelectList.stories";
+
+<Meta of={MultiSelectListStories} name="MultiSelectList" />
+
+# MultiSelectList
+
+To use MultiSelectList import it like this:
+
+```tsx
+import { MultiSelectList } from "@axa-fr/canopee-react/prospect";
+
+const MyComponent = () => <MultiSelectList items={[]} />;
+```
+
+## 3 items
+
+Use this example to display a compact list without scroll behavior.
+
+<Canvas of={MultiSelectListStories.ThreeItems} />
+
+## 6 items (scroll)
+
+Use this example to illustrate the list when more elements are displayed and scrolling becomes visible.
+
+<Canvas of={MultiSelectListStories.SixItemsScroll} />

--- a/apps/apollo-stories/src/components/MultiSelectList/MultiSelectList.stories.tsx
+++ b/apps/apollo-stories/src/components/MultiSelectList/MultiSelectList.stories.tsx
@@ -1,0 +1,49 @@
+import {
+  MultiSelectList,
+  type MultiSelectListProps,
+} from "@axa-fr/canopee-react/prospect";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof MultiSelectList> = {
+  title: "Components/Form/MultiSelectList",
+  component: MultiSelectList,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiSelectList>;
+
+const threeItems: MultiSelectListProps["items"] = [
+  { id: "item-1", label: "Option 1" },
+  {
+    id: "item-2",
+    label: "Option 2",
+    checked: true,
+  },
+  { id: "item-3", label: "Option 3" },
+];
+
+const sixItems: MultiSelectListProps["items"] = [
+  { id: "item-1", label: "Option 1" },
+  {
+    id: "item-2",
+    label: "Option 2",
+    checked: true,
+  },
+  { id: "item-3", label: "Option 3" },
+  { id: "item-4", label: "Option 4" },
+  { id: "item-5", label: "Option 5" },
+  { id: "item-6", label: "Option 6" },
+];
+
+export const ThreeItems: Story = {
+  args: {
+    items: threeItems,
+  },
+};
+
+export const SixItemsScroll: Story = {
+  args: {
+    items: sixItems,
+  },
+};

--- a/apps/look-and-feel-stories/src/components/MultiSelectList/MultiSelectList.mdx
+++ b/apps/look-and-feel-stories/src/components/MultiSelectList/MultiSelectList.mdx
@@ -1,0 +1,26 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks";
+import * as MultiSelectListStories from "./MultiSelectList.stories";
+
+<Meta of={MultiSelectListStories} name="MultiSelectList" />
+
+# MultiSelectList
+
+To use MultiSelectList import it like this:
+
+```tsx
+import { MultiSelectList } from "@axa-fr/canopee-react/client";
+
+const MyComponent = () => <MultiSelectList items={[]} />;
+```
+
+## 3 items
+
+Use this example to display a compact list without scroll behavior.
+
+<Canvas of={MultiSelectListStories.ThreeItems} />
+
+## 6 items (scroll)
+
+Use this example to illustrate the list when more elements are displayed and scrolling becomes visible.
+
+<Canvas of={MultiSelectListStories.SixItemsScroll} />

--- a/apps/look-and-feel-stories/src/components/MultiSelectList/MultiSelectList.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/MultiSelectList/MultiSelectList.stories.tsx
@@ -1,0 +1,41 @@
+import {
+  MultiSelectList,
+  type MultiSelectListProps,
+} from "@axa-fr/canopee-react/client";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof MultiSelectList> = {
+  title: "Components/Form/MultiSelectList",
+  component: MultiSelectList,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiSelectList>;
+
+const threeItems: MultiSelectListProps["items"] = [
+  { id: "item-1", label: "Option 1" },
+  { id: "item-2", label: "Option 2", checked: true },
+  { id: "item-3", label: "Option 3" },
+];
+
+const sixItems: MultiSelectListProps["items"] = [
+  { id: "item-1", label: "Option 1" },
+  { id: "item-2", label: "Option 2", checked: true },
+  { id: "item-3", label: "Option 3" },
+  { id: "item-4", label: "Option 4" },
+  { id: "item-5", label: "Option 5" },
+  { id: "item-6", label: "Option 6" },
+];
+
+export const ThreeItems: Story = {
+  args: {
+    items: threeItems,
+  },
+};
+
+export const SixItemsScroll: Story = {
+  args: {
+    items: sixItems,
+  },
+};

--- a/packages/canopee-css/src/prospect-client/Form/MultiSelectList/MultiSelectListAll.css
+++ b/packages/canopee-css/src/prospect-client/Form/MultiSelectList/MultiSelectListAll.css
@@ -1,0 +1,15 @@
+.af-multi-select-list {
+  --item-select-height: calc(1lh + (2 * var(--size-16)));
+
+  /* Allow overflow of list items with 5th item partially visible */
+  max-height: calc(4.75 * var(--item-select-height));
+  padding: 0;
+  border-radius: var(--radius-8);
+  overflow: hidden auto;
+  box-shadow: 0 4px 16px -2px var(--gray-250);
+  list-style-type: none;
+}
+
+.af-multi-select-list > li {
+  padding: 0;
+}

--- a/packages/canopee-react/src/client.ts
+++ b/packages/canopee-react/src/client.ts
@@ -82,6 +82,10 @@ export {
   ItemMultiSelect,
   type ItemMultiSelectProps,
 } from "./prospect-client/Form/ItemMultiSelect/ItemMultiSelectLF";
+export {
+  MultiSelectList,
+  type MultiSelectListProps,
+} from "./prospect-client/Form/MultiSelectList/MultiSelectListLF";
 export { CardRadio } from "./prospect-client/Form/Radio/CardRadio/CardRadioLF";
 export { CardRadioGroup } from "./prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupLF";
 export { Radio } from "./prospect-client/Form/Radio/Radio/RadioLF";

--- a/packages/canopee-react/src/prospect-client/Form/MultiSelectList/MultiSelectListApollo.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/MultiSelectList/MultiSelectListApollo.tsx
@@ -1,0 +1,15 @@
+import "@axa-fr/canopee-css/prospect/Form/MultiSelectList/MultiSelectListAll.css";
+import { ItemMultiSelect } from "../ItemMultiSelect/ItemMultiSelectApollo";
+import {
+  MultiSelectListCommon,
+  type MultiSelectListProps,
+} from "./MultiSelectListCommon";
+
+export type { MultiSelectListProps } from "./MultiSelectListCommon";
+
+export const MultiSelectList = (props: MultiSelectListProps) => (
+  <MultiSelectListCommon
+    {...props}
+    ItemMultiSelectComponent={ItemMultiSelect}
+  />
+);

--- a/packages/canopee-react/src/prospect-client/Form/MultiSelectList/MultiSelectListCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/MultiSelectList/MultiSelectListCommon.tsx
@@ -1,0 +1,32 @@
+import type { ComponentType } from "react";
+import type { ListProps } from "../../List/List/ListCommon";
+import type { ItemMultiSelectCommonProps } from "../ItemMultiSelect/ItemMultiSelectCommon";
+
+export type MultiSelectListProps = Omit<
+  ListProps,
+  "children" | "separator" | "onChange"
+> & {
+  items: Omit<ItemMultiSelectCommonProps, "Checkbox">[];
+};
+
+type MultiSelectListCommonProps = MultiSelectListProps & {
+  ItemMultiSelectComponent: ComponentType<
+    Omit<ItemMultiSelectCommonProps, "Checkbox">
+  >;
+};
+
+export const MultiSelectListCommon = ({
+  items,
+  ItemMultiSelectComponent,
+}: MultiSelectListCommonProps) => (
+  <ul className="af-multi-select-list">
+    {items.map((item, index) => (
+      <li key={item.id}>
+        <ItemMultiSelectComponent
+          {...item}
+          variant={index % 2 === 0 ? "primary" : "secondary"}
+        />
+      </li>
+    ))}
+  </ul>
+);

--- a/packages/canopee-react/src/prospect-client/Form/MultiSelectList/MultiSelectListLF.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/MultiSelectList/MultiSelectListLF.tsx
@@ -1,0 +1,15 @@
+import "@axa-fr/canopee-css/client/Form/MultiSelectList/MultiSelectListAll.css";
+import { ItemMultiSelect } from "../ItemMultiSelect/ItemMultiSelectLF";
+import {
+  MultiSelectListCommon,
+  type MultiSelectListProps,
+} from "./MultiSelectListCommon";
+
+export type { MultiSelectListProps } from "./MultiSelectListCommon";
+
+export const MultiSelectList = (props: MultiSelectListProps) => (
+  <MultiSelectListCommon
+    {...props}
+    ItemMultiSelectComponent={ItemMultiSelect}
+  />
+);

--- a/packages/canopee-react/src/prospect-client/Form/MultiSelectList/__tests__/MultiSelectListCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/MultiSelectList/__tests__/MultiSelectListCommon.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { describe, expect, it } from "vitest";
+import { ItemMultiSelect } from "../../ItemMultiSelect/ItemMultiSelectApollo";
+import { MultiSelectListCommon } from "../MultiSelectListCommon";
+
+describe("<MultiSelectListCommon />", () => {
+  const items = [
+    { id: "multiselect-option-1", label: "Option 1" },
+    {
+      id: "multiselect-option-2",
+      label: "Option 2",
+      checked: true,
+    },
+    {
+      id: "multiselect-option-3",
+      label: "Option 3",
+      disabled: true,
+    },
+  ];
+
+  it("should render all list items", () => {
+    render(
+      <MultiSelectListCommon
+        items={items}
+        ItemMultiSelectComponent={ItemMultiSelect}
+      />,
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "Option 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "Option 2" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "Option 3" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should alternate variants between primary and secondary", () => {
+    const { container } = render(
+      <MultiSelectListCommon
+        items={items}
+        ItemMultiSelectComponent={ItemMultiSelect}
+      />,
+    );
+
+    const labels = container.querySelectorAll(".af-item-multi-select");
+    expect(labels[0]).toHaveClass("af-item-multi-select--primary");
+    expect(labels[1]).toHaveClass("af-item-multi-select--secondary");
+    expect(labels[2]).toHaveClass("af-item-multi-select--primary");
+  });
+
+  describe("A11Y", () => {
+    it("shouldn't have an accessibility violation <MultiSelectListCommon />", async () => {
+      const { container } = render(
+        <MultiSelectListCommon
+          items={items}
+          ItemMultiSelectComponent={ItemMultiSelect}
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/canopee-react/src/prospect.ts
+++ b/packages/canopee-react/src/prospect.ts
@@ -74,6 +74,10 @@ export {
   ItemMultiSelect,
   type ItemMultiSelectProps,
 } from "./prospect-client/Form/ItemMultiSelect/ItemMultiSelectApollo";
+export {
+  MultiSelectList,
+  type MultiSelectListProps,
+} from "./prospect-client/Form/MultiSelectList/MultiSelectListApollo";
 export { CardRadio } from "./prospect-client/Form/Radio/CardRadio/CardRadioApollo";
 export { CardRadioGroup } from "./prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupApollo";
 export { Radio } from "./prospect-client/Form/Radio/Radio/RadioApollo";


### PR DESCRIPTION
Ajout du nouveau composant `MultiSelectList` (lié à #1929)

<img width="576" height="271" alt="image" src="https://github.com/user-attachments/assets/b4968b91-1762-4b15-afbd-d95eed7e038e" />

Composant "Molécule" : réutilise le composant ItemMultiSelect
Architecture multi-thèmes : implémentation partagée (Common) avec surcharges Apollo et LF.
Tests complets : couverture 100% sur les test unitaires (passage de props, comportement au clic)
Documentation : stories Storybook et guides MDX pour chaque thème