### PR TITLE
fix(client,prospect): add --warning and --hover-warning variant for checkbox(#1813)

### DIFF
--- a/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     "aria-invalid": { type: "boolean" },
+    hasWarning: { type: "boolean" },
     errorId: {
       table: {
         disable: true,

--- a/apps/look-and-feel-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     "aria-invalid": { type: "boolean" },
+    hasWarning: { type: "boolean" },
     errorId: {
       table: {
         disable: true,

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
@@ -26,4 +26,14 @@
       --checkbox-border-width: 3px;
     }
   }
+
+  &[class*="--warning"]:not(:checked) {
+    --checkbox-border-color: var(--orange-1050);
+    --checkbox-border-width: 2px;
+
+    &:hover,
+    &:focus-within {
+      --checkbox-border-width: 3px;
+    }
+  }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -26,4 +26,14 @@
       --checkbox-border-width: 3px;
     }
   }
+
+  &[class*="--warning"]:not(:checked) {
+    --checkbox-border-color: var(--orange-1050);
+    --checkbox-border-width: 2px;
+
+    &:hover,
+    &:focus-within {
+      --checkbox-border-width: 3px;
+    }
+  }
 }

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -10,21 +10,42 @@ export type CheckboxProps = {
   hasWarning?: boolean;
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 
+type CheckboxPropsInternal = Omit<
+  ComponentProps<"input">,
+  "disabled" | "type"
+> & {
+  errorId?: string;
+  hasError?: boolean;
+  hasWarning?: boolean;
+};
+
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ errorId, hasError, hasWarning, className, ...inputProps }, ref) => (
-    <input
-      aria-errormessage={errorId}
-      aria-invalid={hasError}
-      {...inputProps}
-      className={getClassName({
-        baseClassName: "af-checkbox",
-        modifiers: [hasWarning && "warning"],
-        className,
-      })}
-      ref={ref}
-      type="checkbox"
-    />
-  ),
+  (props, ref) => {
+    const {
+      errorId,
+      hasError,
+      hasWarning,
+      className,
+      "aria-errormessage": ariaErrorMessage,
+      "aria-invalid": ariaInvalid,
+      ...inputProps
+    } = props as CheckboxPropsInternal;
+
+    return (
+      <input
+        aria-errormessage={ariaErrorMessage ?? errorId}
+        aria-invalid={ariaInvalid ?? hasError}
+        {...inputProps}
+        className={getClassName({
+          baseClassName: "af-checkbox",
+          modifiers: [hasWarning && "warning"],
+          className,
+        })}
+        ref={ref}
+        type="checkbox"
+      />
+    );
+  },
 );
 
 Checkbox.displayName = "Checkbox";

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -1,19 +1,26 @@
 import { type ComponentProps, forwardRef } from "react";
 
+import { getClassName } from "../../../utilities/getClassName";
+
 export type CheckboxProps = {
   /** @deprecated Use `aria-errormessage` instead */
   errorId?: string;
   /** @deprecated Use `aria-invalid` instead */
   hasError?: boolean;
+  hasWarning?: boolean;
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ errorId, hasError, className, ...inputProps }, ref) => (
+  ({ errorId, hasError, hasWarning, className, ...inputProps }, ref) => (
     <input
       aria-errormessage={errorId}
       aria-invalid={hasError}
       {...inputProps}
-      className={["af-checkbox", className].filter(Boolean).join(" ")}
+      className={getClassName({
+        baseClassName: "af-checkbox",
+        modifiers: [hasWarning && "warning"],
+        className,
+      })}
       ref={ref}
       type="checkbox"
     />


### PR DESCRIPTION
**issue concernée : #1813** 
**ticket jira : https://ajir.axa-fr.intraxa/browse/DESIGN-852**

Cette PR concerne l'ajout d'un variant `--warning` et `--hover-warning` pour le composant Checkbox.
Ce variant peut être testé dans les storybooks Client et Prospect via un toogle.

Fichiers concernés par ces ajustements :

Storybooks Checkbox:

- apps/apollo-stories/src/components/Checkbox/**Checkbox.stories.tsx**
- apps/look-and-feel-stories/src/components/Checkbox/**Checkbox.stories.tsx**

Composant Checkbox

- packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/**CheckboxApollo.css**
- packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/**CheckboxLF.css**
- packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/**CheckboxCommon.tsx**