### PR TITLE
fix(client,prospect): add --warning and --hover-warning variant for radio(#1814)

### DIFF
--- a/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     isInvalid: { type: "boolean" },
+    hasWarning: { type: "boolean" },
   },
   args: {
     name: "option1",
@@ -27,7 +28,11 @@ export default meta;
 
 export const RadioStory: StoryObj<ComponentProps<typeof Radio>> = {
   name: "Playground",
-  render: ({ isInvalid, ...args }) => (
-    <Radio {...args} isInvalid={isInvalid ? true : undefined} />
+  render: ({ isInvalid, hasWarning, ...args }) => (
+    <Radio
+      {...args}
+      isInvalid={isInvalid ? true : undefined}
+      hasWarning={hasWarning ? true : undefined}
+    />
   ),
 };

--- a/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     isInvalid: { type: "boolean" },
+    hasWarning: { type: "boolean" },
   },
   args: {
     name: "option1",
@@ -27,7 +28,11 @@ export default meta;
 
 export const RadioStory: StoryObj<ComponentProps<typeof Radio>> = {
   name: "Playground",
-  render: ({ isInvalid, ...args }) => (
-    <Radio {...args} isInvalid={isInvalid ? true : undefined} />
+  render: ({ isInvalid, hasWarning, ...args }) => (
+    <Radio
+      {...args}
+      isInvalid={isInvalid ? true : undefined}
+      hasWarning={hasWarning ? true : undefined}
+    />
   ),
 };

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioApollo.css
@@ -23,3 +23,12 @@
     --radio-border-color: var(--red-alert-1000);
   }
 }
+
+.af-radio--warning:not(:checked) {
+  --radio-border-color: var(--orange-1050);
+
+  &:hover,
+  &:focus-within {
+    --radio-border-color: var(--orange-1050);
+  }
+}

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
@@ -23,3 +23,12 @@
     --radio-border-color: var(--red-alert-1200);
   }
 }
+
+.af-radio--warning:not(:checked) {
+  --radio-border-color: var(--orange-1050);
+
+  &:hover,
+  &:focus-within {
+    --radio-border-color: var(--orange-1050);
+  }
+}

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
@@ -2,13 +2,19 @@ import { forwardRef, type ComponentProps } from "react";
 
 export type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
   isInvalid?: boolean;
+  hasWarning?: boolean;
 };
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(
-  ({ className, isInvalid, ...props }, ref) => (
+  ({ className, isInvalid, hasWarning, ...props }, ref) => (
     <input
       {...props}
-      className={["af-radio", isInvalid && "af-radio--invalid", className]
+      className={[
+        "af-radio",
+        isInvalid && "af-radio--invalid",
+        hasWarning && "af-radio--warning",
+        className,
+      ]
         .filter(Boolean)
         .join(" ")}
       type="radio"


### PR DESCRIPTION
**issue concernée : #1814** 
**ticket jira : https://ajir.axa-fr.intraxa/browse/DESIGN-853**

Cette PR concerne l'ajout d'un variant `--warning` et `--hover-warning` pour le composant Radio.
Ce variant peut être testé dans les storybooks Client et Prospect via un toogle.

Fichiers concernés par ces ajustements :

Storybooks Radio:

- apps/apollo-stories/src/components/Radio/**Radio.stories.tsx**
- apps/look-and-feel-stories/src/components/Radio/**Radio.stories.tsx**

Composant Radio:

- packages/canopee-css/src/prospect-client/Form/Radio/Radio/**RadioApollo.css**
- packages/canopee-css/src/prospect-client/Form/Radio/Radio/**RadioLF.css**
- packages/canopee-react/src/prospect-client/Form/Radio/Radio/**RadioCommon.tsx**