### PR TITLE
fix(client,prospect)!: add --warning and --hover-warning variant for radio - new (#1814)

### DIFF
--- a/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
+++ b/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
@@ -47,6 +47,10 @@ const meta: Meta<
     src: {
       if: { arg: "iconVariant", eq: "base picture" },
     },
+    variant: {
+      control: { type: "select" },
+      options: ["error", "warning"],
+    },
   },
   args: {
     position: "vertical",

--- a/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
+++ b/apps/apollo-stories/src/components/CardRadio/CardRadio.stories.tsx
@@ -55,7 +55,6 @@ const meta: Meta<
     subtitle: "Sous-titre 2",
     name: "foo",
     value: "bar",
-    isInvalid: false,
     iconVariant: "icon",
     icon: "accountBalanceIcon",
     src: "https://picsum.photos/48",

--- a/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
@@ -16,9 +16,8 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     variant: {
-      control: { type: "inline-radio" },
-      options: ["none", "error", "warning"],
-      mapping: { none: undefined },
+      control: { type: "select" },
+      options: [undefined, "error", "warning"],
     },
   },
   args: {

--- a/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     isInvalid: { type: "boolean" },
+    hasWarning: { type: "boolean" },
   },
   args: {
     name: "option1",

--- a/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
@@ -15,8 +15,11 @@ const meta: Meta = {
     checked: {
       control: { type: "boolean" },
     },
-    isInvalid: { type: "boolean" },
-    hasWarning: { type: "boolean" },
+    variant: {
+      control: { type: "inline-radio" },
+      options: ["none", "error", "warning"],
+      mapping: { none: undefined },
+    },
   },
   args: {
     name: "option1",
@@ -28,7 +31,4 @@ export default meta;
 
 export const RadioStory: StoryObj<ComponentProps<typeof Radio>> = {
   name: "Playground",
-  render: ({ isInvalid, ...args }) => (
-    <Radio {...args} isInvalid={isInvalid ? true : undefined} />
-  ),
 };

--- a/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/apollo-stories/src/components/Radio/Radio.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta = {
     },
     variant: {
       control: { type: "select" },
-      options: [undefined, "error", "warning"],
+      options: ["error", "warning"],
     },
   },
   args: {

--- a/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
@@ -18,8 +18,10 @@ const meta: Meta = {
     checked: {
       control: { type: "boolean" },
     },
-    isInvalid: {
-      control: { type: "boolean" },
+    variant: {
+      control: { type: "inline-radio" },
+      options: ["none", "error", "warning"],
+      mapping: { none: undefined },
     },
   },
   args: {

--- a/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta = {
     },
     variant: {
       control: { type: "select" },
-      options: [undefined, "error", "warning"],
+      options: ["error", "warning"],
     },
   },
   args: {

--- a/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/apollo-stories/src/components/RadioText/RadioText.stories.tsx
@@ -19,9 +19,8 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     variant: {
-      control: { type: "inline-radio" },
-      options: ["none", "error", "warning"],
-      mapping: { none: undefined },
+      control: { type: "select" },
+      options: [undefined, "error", "warning"],
     },
   },
   args: {

--- a/apps/look-and-feel-stories/src/components/CardRadio/CardRadio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/CardRadio/CardRadio.stories.tsx
@@ -47,6 +47,10 @@ const meta: Meta<
     src: {
       if: { arg: "iconVariant", eq: "base picture" },
     },
+    variant: {
+      control: { type: "select" },
+      options: ["error", "warning"],
+    },
   },
   args: {
     position: "vertical",

--- a/apps/look-and-feel-stories/src/components/CardRadio/CardRadio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/CardRadio/CardRadio.stories.tsx
@@ -55,7 +55,6 @@ const meta: Meta<
     subtitle: "Sous-titre 2",
     name: "foo",
     value: "bar",
-    isInvalid: false,
     iconVariant: "icon",
     icon: "accountBalanceIcon",
     src: "https://picsum.photos/48",

--- a/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
@@ -16,9 +16,8 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     variant: {
-      control: { type: "inline-radio" },
-      options: ["none", "error", "warning"],
-      mapping: { none: undefined },
+      control: { type: "select" },
+      options: [undefined, "error", "warning"],
     },
   },
   args: {

--- a/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     isInvalid: { type: "boolean" },
+    hasWarning: { type: "boolean" },
   },
   args: {
     name: "option1",

--- a/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
@@ -15,8 +15,11 @@ const meta: Meta = {
     checked: {
       control: { type: "boolean" },
     },
-    isInvalid: { type: "boolean" },
-    hasWarning: { type: "boolean" },
+    variant: {
+      control: { type: "inline-radio" },
+      options: ["none", "error", "warning"],
+      mapping: { none: undefined },
+    },
   },
   args: {
     name: "option1",
@@ -28,7 +31,4 @@ export default meta;
 
 export const RadioStory: StoryObj<ComponentProps<typeof Radio>> = {
   name: "Playground",
-  render: ({ isInvalid, ...args }) => (
-    <Radio {...args} isInvalid={isInvalid ? true : undefined} />
-  ),
 };

--- a/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Radio/Radio.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta = {
     },
     variant: {
       control: { type: "select" },
-      options: [undefined, "error", "warning"],
+      options: ["error", "warning"],
     },
   },
   args: {

--- a/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
@@ -18,8 +18,10 @@ const meta: Meta = {
     checked: {
       control: { type: "boolean" },
     },
-    isInvalid: {
-      control: { type: "boolean" },
+    variant: {
+      control: { type: "inline-radio" },
+      options: ["none", "error", "warning"],
+      mapping: { none: undefined },
     },
   },
   args: {

--- a/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta = {
     },
     variant: {
       control: { type: "select" },
-      options: [undefined, "error", "warning"],
+      options: ["error", "warning"],
     },
   },
   args: {

--- a/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/RadioText/RadioText.stories.tsx
@@ -19,9 +19,8 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     variant: {
-      control: { type: "inline-radio" },
-      options: ["none", "error", "warning"],
-      mapping: { none: undefined },
+      control: { type: "select" },
+      options: [undefined, "error", "warning"],
     },
   },
   args: {

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioApollo.css
@@ -14,14 +14,12 @@
     &:checked {
       --radio-ckecked-color: var(--blue-1000);
     }
-  }
 
-  .af-radio--invalid:not(:checked) {
-    --radio-border-color: var(--red-alert-1000);
-
-    &:hover,
-    &:focus-within {
-      --radio-border-color: var(--red-alert-1000);
+    &[class*="--invalid"] {
+      &:checked,
+      &:not(:checked) {
+        --radio-border-color: var(--red-alert-1000);
+      }
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioApollo.css
@@ -15,7 +15,7 @@
       --radio-ckecked-color: var(--blue-1000);
     }
 
-    &[class*="--invalid"] {
+    &[class*="--error"] {
       &:checked,
       &:not(:checked) {
         --radio-border-color: var(--red-alert-1000);

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioCommon.css
@@ -34,25 +34,38 @@
     &:checked {
       --radio-border-width: 2px;
     }
-  }
 
-  .af-radio--invalid:not(:checked) {
-    --radio-border-width: 2px;
+    &[class*="--invalid"] {
+      &:checked {
+        --radio-ckecked-color: transparent;
+      }
 
-    &:hover,
-    &:focus-within {
-      --radio-border-width: 3px;
+      &:checked,
+      &:not(:checked) {
+        --radio-border-width: 2px;
+
+        &:hover,
+        &:focus-within {
+          --radio-border-width: 3px;
+        }
+      }
     }
-  }
 
-  .af-radio--warning:not(:checked) {
-    --radio-border-width: 2px;
-    --radio-border-color: var(--orange-1050);
+    &[class*="--warning"] {
+      &:checked {
+        --radio-ckecked-color: transparent;
+      }
 
-    &:hover,
-    &:focus-within {
-      --radio-border-width: 3px;
-      --radio-border-color: var(--orange-1050);
+      &:checked,
+      &:not(:checked) {
+        --radio-border-width: 2px;
+        --radio-border-color: var(--orange-1050);
+
+        &:hover,
+        &:focus-within {
+          --radio-border-width: 3px;
+        }
+      }
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioCommon.css
@@ -35,7 +35,7 @@
       --radio-border-width: 2px;
     }
 
-    &[class*="--invalid"] {
+    &[class*="--error"] {
       &:checked {
         --radio-ckecked-color: transparent;
       }

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioCommon.css
@@ -44,4 +44,15 @@
       --radio-border-width: 3px;
     }
   }
+
+  .af-radio--warning:not(:checked) {
+    --radio-border-width: 2px;
+    --radio-border-color: var(--orange-1050);
+
+    &:hover,
+    &:focus-within {
+      --radio-border-width: 3px;
+      --radio-border-color: var(--orange-1050);
+    }
+  }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
@@ -14,14 +14,12 @@
     &:checked {
       --radio-ckecked-color: var(--blue-1000);
     }
-  }
 
-  .af-radio--invalid:not(:checked) {
-    --radio-border-color: var(--red-alert-1200);
-
-    &:hover,
-    &:focus-within {
-      --radio-border-color: var(--red-alert-1200);
+    &[class*="--invalid"] {
+      &:checked,
+      &:not(:checked) {
+        --radio-border-color: var(--red-alert-1200);
+      }
     }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Radio/Radio/RadioLF.css
@@ -15,7 +15,7 @@
       --radio-ckecked-color: var(--blue-1000);
     }
 
-    &[class*="--invalid"] {
+    &[class*="--error"] {
       &:checked,
       &:not(:checked) {
         --radio-border-color: var(--red-alert-1200);

--- a/packages/canopee-react/src/prospect-client/Form/Radio/CardRadio/CardRadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/CardRadio/CardRadioCommon.tsx
@@ -35,7 +35,7 @@ export const CardRadioCommon = ({
   icon,
   src,
   basePictureProps,
-  isInvalid,
+  variant,
   className,
   RadioComponent,
   IconComponent,
@@ -48,7 +48,7 @@ export const CardRadioCommon = ({
       className={getClassName({
         baseClassName: "af-card-radio",
         modifiers: [
-          isInvalid && "invalid",
+          variant === "error" && "invalid",
           isCardRadioHorizontal && "horizontal",
         ],
         className,
@@ -67,7 +67,7 @@ export const CardRadioCommon = ({
           <p className="af-card-radio__subtitle">{subtitle}</p>
         )}
       </div>
-      <RadioComponent {...inputProps} isInvalid={isInvalid} />
+      <RadioComponent {...inputProps} variant={variant} />
     </label>
   );
 };

--- a/packages/canopee-react/src/prospect-client/Form/Radio/CardRadio/__tests__/CardRadioCommon.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/CardRadio/__tests__/CardRadioCommon.test.tsx
@@ -89,7 +89,7 @@ describe("CardRadioCommon", () => {
         IconComponent={MockIconComponent}
         name="test"
         value="radio-value"
-        isInvalid
+        variant="error"
       />,
     );
 

--- a/packages/canopee-react/src/prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/CardRadioGroup/CardRadioGroupCommon.tsx
@@ -12,14 +12,14 @@ import {
 } from "../../ItemMessage/ItemMessageCommon";
 import { type CardRadioProps } from "../CardRadio/CardRadioCommon";
 
-type RadioOption = Omit<CardRadioProps, "name" | "type" | "isInvalid">;
+type RadioOption = Omit<CardRadioProps, "name" | "type" | "variant">;
 
 export type CardRadioGroupProps = Omit<
   CardRadioProps,
   | "value"
   | "label"
   | "type"
-  | "isInvalid"
+  | "variant"
   | "icon"
   | "src"
   | "basePictureProps"
@@ -139,7 +139,7 @@ const CardRadioGroupCommon = ({
             position={cardStyle ?? type}
             {...inputProps}
             {...(cardRadioItemProps as CardRadioProps)}
-            isInvalid={hasError}
+            variant={hasError ? "error" : undefined}
             name={name}
           />
         ))}

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
@@ -3,24 +3,23 @@ import { type ComponentProps } from "react";
 import { getClassName } from "../../../utilities/getClassName";
 
 export type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
-  isInvalid?: boolean;
-  hasWarning?: boolean;
+  variant?: "error" | "warning";
 };
 
 export const Radio = ({
-  isInvalid,
-  hasWarning,
+  variant,
   className,
   ref,
   ...inputProps
 }: RadioProps) => (
-  // eslint-disable-next-line jsx-a11y/role-supports-aria-props -- aria-invalid is read by assistive technologies on radio inputs despite not being officially listed for the radio role
   <input
-    aria-invalid={isInvalid || undefined}
     {...inputProps}
     className={getClassName({
       baseClassName: "af-radio",
-      modifiers: [isInvalid && "invalid", hasWarning && "warning"],
+      modifiers: [
+        variant === "error" && "invalid",
+        variant === "warning" && "warning",
+      ],
       className,
     })}
     ref={ref}

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
@@ -16,10 +16,7 @@ export const Radio = ({
     {...inputProps}
     className={getClassName({
       baseClassName: "af-radio",
-      modifiers: [
-        variant === "error" && "invalid",
-        variant === "warning" && "warning",
-      ],
+      modifiers: [variant],
       className,
     })}
     ref={ref}

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
@@ -1,17 +1,27 @@
-import { type ComponentProps } from "react";
+import { type ComponentProps, forwardRef } from "react";
+
+import { getClassName } from "../../../utilities/getClassName";
 
 export type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
   isInvalid?: boolean;
+  hasWarning?: boolean;
 };
 
-export const Radio = ({ className, isInvalid, ...props }: RadioProps) => (
-  <input
-    {...props}
-    className={["af-radio", isInvalid && "af-radio--invalid", className]
-      .filter(Boolean)
-      .join(" ")}
-    type="radio"
-  />
-);
+export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
+  const { isInvalid, hasWarning, className, ...inputProps } = props;
+
+  return (
+    <input
+      {...inputProps}
+      className={getClassName({
+        baseClassName: "af-radio",
+        modifiers: [isInvalid && "invalid", hasWarning && "warning"],
+        className,
+      })}
+      ref={ref}
+      type="radio"
+    />
+  );
+});
 
 Radio.displayName = "Radio";

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, forwardRef } from "react";
+import { type ComponentProps } from "react";
 
 import { getClassName } from "../../../utilities/getClassName";
 
@@ -7,21 +7,21 @@ export type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
   hasWarning?: boolean;
 };
 
-export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
-  const { isInvalid, hasWarning, className, ...inputProps } = props;
-
-  return (
-    <input
-      {...inputProps}
-      className={getClassName({
-        baseClassName: "af-radio",
-        modifiers: [isInvalid && "invalid", hasWarning && "warning"],
-        className,
-      })}
-      ref={ref}
-      type="radio"
-    />
-  );
-});
-
-Radio.displayName = "Radio";
+export const Radio = ({
+  isInvalid,
+  hasWarning,
+  className,
+  ref,
+  ...inputProps
+}: RadioProps) => (
+  <input
+    {...inputProps}
+    className={getClassName({
+      baseClassName: "af-radio",
+      modifiers: [isInvalid && "invalid", hasWarning && "warning"],
+      className,
+    })}
+    ref={ref}
+    type="radio"
+  />
+);

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/RadioCommon.tsx
@@ -14,7 +14,9 @@ export const Radio = ({
   ref,
   ...inputProps
 }: RadioProps) => (
+  // eslint-disable-next-line jsx-a11y/role-supports-aria-props -- aria-invalid is read by assistive technologies on radio inputs despite not being officially listed for the radio role
   <input
+    aria-invalid={isInvalid || undefined}
     {...inputProps}
     className={getClassName({
       baseClassName: "af-radio",

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
@@ -47,14 +47,14 @@ describe("Radio Component", () => {
     render(<Radio variant="error" />);
 
     const radioInput = screen.getByRole("radio");
-    expect(radioInput).toHaveClass("af-radio af-radio--invalid");
+    expect(radioInput).toHaveClass("af-radio af-radio--error");
   });
 
   it("should not apply invalid modifier when variant is not set", () => {
     render(<Radio />);
 
     const radioInput = screen.getByRole("radio");
-    expect(radioInput).not.toHaveClass("af-radio--invalid");
+    expect(radioInput).not.toHaveClass("af-radio--error");
   });
 
   it("should apply warning modifier when variant is warning", () => {

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
@@ -42,4 +42,41 @@ describe("Radio Component", () => {
     const radioInput = screen.getByRole("radio");
     expect(radioInput).toHaveClass("af-radio custom-class");
   });
+
+  it("should apply invalid modifier when isInvalid is true", () => {
+    render(<Radio isInvalid />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toHaveClass("af-radio af-radio--invalid");
+  });
+
+  it("should not apply invalid modifier when isInvalid is false", () => {
+    render(<Radio isInvalid={false} />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).not.toHaveClass("af-radio--invalid");
+  });
+
+  it("should apply warning modifier when hasWarning is true", () => {
+    render(<Radio hasWarning />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toHaveClass("af-radio af-radio--warning");
+  });
+
+  it("should not apply warning modifier when hasWarning is false", () => {
+    render(<Radio hasWarning={false} />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).not.toHaveClass("af-radio--warning");
+  });
+
+  it("should apply both invalid and warning modifiers when both are true", () => {
+    render(<Radio isInvalid hasWarning />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toHaveClass(
+      "af-radio af-radio--invalid af-radio--warning",
+    );
+  });
 });

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
@@ -43,42 +43,31 @@ describe("Radio Component", () => {
     expect(radioInput).toHaveClass("af-radio custom-class");
   });
 
-  it("should apply invalid modifier when isInvalid is true", () => {
-    render(<Radio isInvalid />);
+  it("should apply invalid modifier when variant is error", () => {
+    render(<Radio variant="error" />);
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).toHaveClass("af-radio af-radio--invalid");
-    expect(radioInput).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("should not apply invalid modifier when isInvalid is false", () => {
-    render(<Radio isInvalid={false} />);
+  it("should not apply invalid modifier when variant is not set", () => {
+    render(<Radio />);
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).not.toHaveClass("af-radio--invalid");
-    expect(radioInput).not.toHaveAttribute("aria-invalid");
   });
 
-  it("should apply warning modifier when hasWarning is true", () => {
-    render(<Radio hasWarning />);
+  it("should apply warning modifier when variant is warning", () => {
+    render(<Radio variant="warning" />);
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).toHaveClass("af-radio af-radio--warning");
   });
 
-  it("should not apply warning modifier when hasWarning is false", () => {
-    render(<Radio hasWarning={false} />);
+  it("should not apply warning modifier when variant is not set", () => {
+    render(<Radio />);
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).not.toHaveClass("af-radio--warning");
-  });
-
-  it("should apply both invalid and warning modifiers when both are true", () => {
-    render(<Radio isInvalid hasWarning />);
-
-    const radioInput = screen.getByRole("radio");
-    expect(radioInput).toHaveClass(
-      "af-radio af-radio--invalid af-radio--warning",
-    );
   });
 });

--- a/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/Radio/__tests__/Radio.test.tsx
@@ -48,6 +48,7 @@ describe("Radio Component", () => {
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).toHaveClass("af-radio af-radio--invalid");
+    expect(radioInput).toHaveAttribute("aria-invalid", "true");
   });
 
   it("should not apply invalid modifier when isInvalid is false", () => {
@@ -55,6 +56,7 @@ describe("Radio Component", () => {
 
     const radioInput = screen.getByRole("radio");
     expect(radioInput).not.toHaveClass("af-radio--invalid");
+    expect(radioInput).not.toHaveAttribute("aria-invalid");
   });
 
   it("should apply warning modifier when hasWarning is true", () => {

--- a/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/__tests__/RadioText.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/__tests__/RadioText.test.tsx
@@ -36,14 +36,14 @@ describe("RadioText Component", () => {
     );
 
     const radio = screen.getByRole("radio", { name: "Option" });
-    expect(radio).toHaveClass("af-radio--invalid");
+    expect(radio).toHaveClass("af-radio--error");
   });
 
   it("should not apply invalid class when variant is not set", () => {
     render(<RadioText label="Option" name="option" value="1" />);
 
     const radio = screen.getByRole("radio", { name: "Option" });
-    expect(radio).not.toHaveClass("af-radio--invalid");
+    expect(radio).not.toHaveClass("af-radio--error");
   });
 
   it("should call onChange when clicked", async () => {

--- a/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/__tests__/RadioText.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Radio/RadioText/__tests__/RadioText.test.tsx
@@ -30,14 +30,16 @@ describe("RadioText Component", () => {
     expect(radio).toBeChecked();
   });
 
-  it("should apply invalid class when isInvalid is true", () => {
-    render(<RadioText label="Option" name="option" value="1" isInvalid />);
+  it("should apply invalid class when variant is error", () => {
+    render(
+      <RadioText label="Option" name="option" value="1" variant="error" />,
+    );
 
     const radio = screen.getByRole("radio", { name: "Option" });
     expect(radio).toHaveClass("af-radio--invalid");
   });
 
-  it("should not apply invalid class when isInvalid is false", () => {
+  it("should not apply invalid class when variant is not set", () => {
     render(<RadioText label="Option" name="option" value="1" />);
 
     const radio = screen.getByRole("radio", { name: "Option" });

--- a/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
+++ b/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
@@ -181,8 +181,7 @@ import { Radio } from "@axa-fr/canopee-react/prospect";
 
 ```tsx
 type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
-  isInvalid?: boolean;            // Ajoute la classe af-radio--invalid
-  hasWarning?: boolean;           // Ajoute la classe af-radio--warning (bordure orange)
+  variant?: "error" | "warning";  // "error" → af-radio--error, "warning" → af-radio--warning
 };
 ```
 
@@ -289,6 +288,6 @@ type CardRadioProps = {
   basePictureProps?: Partial<ComponentProps<typeof BasePicture>>;
   description?: ReactNode;
   subtitle?: ReactNode;
-  isInvalid?: boolean;
+  variant?: "error" | "warning";  // hérité de RadioProps
 } & Omit<ComponentProps<"input">, "size">;  // attributs <input type="radio">
 ```

--- a/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
+++ b/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
@@ -182,6 +182,7 @@ import { Radio } from "@axa-fr/canopee-react/prospect";
 ```tsx
 type RadioProps = Omit<ComponentProps<"input">, "disabled" | "type"> & {
   isInvalid?: boolean;            // Ajoute la classe af-radio--invalid
+  hasWarning?: boolean;           // Ajoute la classe af-radio--warning (bordure orange)
 };
 ```
 


### PR DESCRIPTION
**⚠️ ANNULE ET REMPLACE**
ancienne PR : https://github.com/AxaFrance/design-system/pull/1955
---

**issue concernée : #1814** 

Cette PR concerne l'ajout d'un variant `--warning` et `--hover-warning` pour le composant Radio.
Ce variant peut être testé dans les storybooks Client et Prospect via un toogle.

Fichiers concernés par ces ajustements :

Storybooks Radio:

- apps/apollo-stories/src/components/Radio/**Radio.stories.tsx**
- apps/look-and-feel-stories/src/components/Radio/**Radio.stories.tsx**

Composant Radio:

- packages/canopee-react/src/prospect-client/Form/Radio/Radio/**RadioCommon.css**
- packages/canopee-react/src/prospect-client/Form/Radio/Radio/**RadioCommon.tsx**

**BREAKING CHANGE :** les valeurs "error" et "warning" sont maintenant gérées par le prop "variant".