### PR TITLE
fix(client,prospect)!: add --warning and --hover-warning variant for checkbox - new (#1813)

### DIFF
--- a/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -15,8 +15,10 @@ const meta: Meta = {
     checked: {
       control: { type: "boolean" },
     },
-    "aria-invalid": { type: "boolean" },
-    hasWarning: { type: "boolean" },
+    variant: {
+      control: { type: "select" },
+      options: ["error", "warning"],
+    },
     errorId: {
       table: {
         disable: true,

--- a/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/apollo-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     "aria-invalid": { type: "boolean" },
+    hasWarning: { type: "boolean" },
     errorId: {
       table: {
         disable: true,

--- a/apps/look-and-feel-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -15,8 +15,10 @@ const meta: Meta = {
     checked: {
       control: { type: "boolean" },
     },
-    "aria-invalid": { type: "boolean" },
-    hasWarning: { type: "boolean" },
+    variant: {
+      control: { type: "select" },
+      options: ["error", "warning"],
+    },
     errorId: {
       table: {
         disable: true,

--- a/apps/look-and-feel-stories/src/components/Checkbox/Checkbox.stories.tsx
+++ b/apps/look-and-feel-stories/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta = {
       control: { type: "boolean" },
     },
     "aria-invalid": { type: "boolean" },
+    hasWarning: { type: "boolean" },
     errorId: {
       table: {
         disable: true,

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
@@ -18,22 +18,11 @@
       --checkbox-background-color: var(--blue-1000);
     }
 
-    &[class*="--error"] {
-      &:checked {
-        --checkbox-background-color: var(--white-1000);
-
-        background-image: none;
-      }
-
+    &[class*="--error"],
+    &[aria-invalid="true"] {
       &:checked,
       &:not(:checked) {
         --checkbox-border-color: var(--red-alert-1000);
-        --checkbox-border-width: 2px;
-
-        &:hover,
-        &:focus-within {
-          --checkbox-border-width: 3px;
-        }
       }
     }
   }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
@@ -18,13 +18,22 @@
       --checkbox-background-color: var(--blue-1000);
     }
 
-    &[aria-invalid="true"]:not(:checked) {
-      --checkbox-border-color: var(--red-alert-1000);
-      --checkbox-border-width: 2px;
+    &[aria-invalid="true"] {
+      &:checked {
+        --checkbox-background-color: var(--white-1000);
 
-      &:hover,
-      &:focus-within {
-        --checkbox-border-width: 3px;
+        background-image: none;
+      }
+
+      &:checked,
+      &:not(:checked) {
+        --checkbox-border-color: var(--red-alert-1000);
+        --checkbox-border-width: 2px;
+
+        &:hover,
+        &:focus-within {
+          --checkbox-border-width: 3px;
+        }
       }
     }
   }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxApollo.css
@@ -18,7 +18,7 @@
       --checkbox-background-color: var(--blue-1000);
     }
 
-    &[aria-invalid="true"] {
+    &[class*="--error"] {
       &:checked {
         --checkbox-background-color: var(--white-1000);
 

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.css
@@ -36,5 +36,24 @@
         }
       }
     }
+
+    &[class*="--error"],
+    &[aria-invalid="true"] {
+      &:checked {
+        --checkbox-background-color: var(--white-1000);
+
+        background-image: none;
+      }
+
+      &:checked,
+      &:not(:checked) {
+        --checkbox-border-width: 2px;
+
+        &:hover,
+        &:focus-within {
+          --checkbox-border-width: 3px;
+        }
+      }
+    }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.css
@@ -17,5 +17,15 @@
     &:checked {
       background-image: var(--checkbox-background-image);
     }
+
+    &[class*="--warning"]:not(:checked) {
+      --checkbox-border-color: var(--orange-1050);
+      --checkbox-border-width: 2px;
+
+      &:hover,
+      &:focus-within {
+        --checkbox-border-width: 3px;
+      }
+    }
   }
 }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.css
@@ -18,13 +18,22 @@
       background-image: var(--checkbox-background-image);
     }
 
-    &[class*="--warning"]:not(:checked) {
-      --checkbox-border-color: var(--orange-1050);
-      --checkbox-border-width: 2px;
+    &[class*="--warning"] {
+      &:checked {
+        --checkbox-background-color: var(--white-1000);
 
-      &:hover,
-      &:focus-within {
-        --checkbox-border-width: 3px;
+        background-image: none;
+      }
+
+      &:checked,
+      &:not(:checked) {
+        --checkbox-border-color: var(--orange-1050);
+        --checkbox-border-width: 2px;
+
+        &:hover,
+        &:focus-within {
+          --checkbox-border-width: 3px;
+        }
       }
     }
   }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -18,22 +18,11 @@
       --checkbox-background-color: var(--blue-1000);
     }
 
-    &[class*="--error"] {
-      &:checked {
-        --checkbox-background-color: var(--white-1000);
-
-        background-image: none;
-      }
-
+    &[class*="--error"],
+    &[aria-invalid="true"] {
       &:checked,
       &:not(:checked) {
         --checkbox-border-color: var(--red-alert-1200);
-        --checkbox-border-width: 2px;
-
-        &:hover,
-        &:focus-within {
-          --checkbox-border-width: 3px;
-        }
       }
     }
   }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -18,13 +18,22 @@
       --checkbox-background-color: var(--blue-1000);
     }
 
-    &[aria-invalid="true"]:not(:checked) {
-      --checkbox-border-color: var(--red-alert-1200);
-      --checkbox-border-width: 2px;
+    &[aria-invalid="true"] {
+      &:checked {
+        --checkbox-background-color: var(--white-1000);
 
-      &:hover,
-      &:focus-within {
-        --checkbox-border-width: 3px;
+        background-image: none;
+      }
+
+      &:checked,
+      &:not(:checked) {
+        --checkbox-border-color: var(--red-alert-1200);
+        --checkbox-border-width: 2px;
+
+        &:hover,
+        &:focus-within {
+          --checkbox-border-width: 3px;
+        }
       }
     }
   }

--- a/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
+++ b/packages/canopee-css/src/prospect-client/Form/Checkbox/Checkbox/CheckboxLF.css
@@ -18,7 +18,7 @@
       --checkbox-background-color: var(--blue-1000);
     }
 
-    &[aria-invalid="true"] {
+    &[class*="--error"] {
       &:checked {
         --checkbox-background-color: var(--white-1000);
 

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -5,26 +5,26 @@ import { getClassName } from "../../../utilities/getClassName";
 export type CheckboxProps = {
   /** @deprecated Use `aria-errormessage` instead */
   errorId?: string;
-  /** @deprecated Use `aria-invalid` instead */
+  /** @deprecated Use `variant` instead */
   hasError?: boolean;
-  hasWarning?: boolean;
+  variant?: "error" | "warning";
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 
 export const Checkbox = ({
   errorId,
   hasError,
-  hasWarning,
+  variant,
   className,
   ref,
   ...inputProps
 }: CheckboxProps) => (
   <input
     aria-errormessage={errorId}
-    aria-invalid={hasError}
+    aria-invalid={variant === "error" || hasError || undefined}
     {...inputProps}
     className={getClassName({
       baseClassName: "af-checkbox",
-      modifiers: [hasWarning && "warning"],
+      modifiers: [variant],
       className,
     })}
     ref={ref}

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, forwardRef } from "react";
+import { type ComponentProps } from "react";
 
 import { getClassName } from "../../../utilities/getClassName";
 
@@ -10,33 +10,26 @@ export type CheckboxProps = {
   hasWarning?: boolean;
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  (props, ref) => {
-    const {
-      errorId,
-      hasError,
-      hasWarning,
+export const Checkbox = ({
+  errorId,
+  hasError,
+  hasWarning,
+  className,
+  "aria-errormessage": ariaErrorMessage,
+  "aria-invalid": ariaInvalid,
+  ref,
+  ...inputProps
+}: CheckboxProps) => (
+  <input
+    aria-errormessage={ariaErrorMessage ?? errorId}
+    aria-invalid={ariaInvalid ?? hasError}
+    {...inputProps}
+    className={getClassName({
+      baseClassName: "af-checkbox",
+      modifiers: [hasWarning && "warning"],
       className,
-      "aria-errormessage": ariaErrorMessage,
-      "aria-invalid": ariaInvalid,
-      ...inputProps
-    } = props;
-
-    return (
-      <input
-        aria-errormessage={ariaErrorMessage ?? errorId}
-        aria-invalid={ariaInvalid ?? hasError}
-        {...inputProps}
-        className={getClassName({
-          baseClassName: "af-checkbox",
-          modifiers: [hasWarning && "warning"],
-          className,
-        })}
-        ref={ref}
-        type="checkbox"
-      />
-    );
-  },
+    })}
+    ref={ref}
+    type="checkbox"
+  />
 );
-
-Checkbox.displayName = "Checkbox";

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -15,14 +15,12 @@ export const Checkbox = ({
   hasError,
   hasWarning,
   className,
-  "aria-errormessage": ariaErrorMessage,
-  "aria-invalid": ariaInvalid,
   ref,
   ...inputProps
 }: CheckboxProps) => (
   <input
-    aria-errormessage={ariaErrorMessage ?? errorId}
-    aria-invalid={ariaInvalid ?? hasError}
+    aria-errormessage={errorId}
+    aria-invalid={hasError}
     {...inputProps}
     className={getClassName({
       baseClassName: "af-checkbox",

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -5,14 +5,11 @@ import { getClassName } from "../../../utilities/getClassName";
 export type CheckboxProps = {
   /** @deprecated Use `aria-errormessage` instead */
   errorId?: string;
-  /** @deprecated Use `variant` instead */
-  hasError?: boolean;
   variant?: "error" | "warning";
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 
 export const Checkbox = ({
   errorId,
-  hasError,
   variant,
   className,
   ref,
@@ -20,7 +17,7 @@ export const Checkbox = ({
 }: CheckboxProps) => (
   <input
     aria-errormessage={errorId}
-    aria-invalid={variant === "error" || hasError || undefined}
+    aria-invalid={variant === "error" || undefined}
     {...inputProps}
     className={getClassName({
       baseClassName: "af-checkbox",

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/CheckboxCommon.tsx
@@ -1,25 +1,42 @@
-import { type ComponentProps } from "react";
+import { type ComponentProps, forwardRef } from "react";
+
+import { getClassName } from "../../../utilities/getClassName";
 
 export type CheckboxProps = {
   /** @deprecated Use `aria-errormessage` instead */
   errorId?: string;
   /** @deprecated Use `aria-invalid` instead */
   hasError?: boolean;
+  hasWarning?: boolean;
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 
-export const Checkbox = ({
-  errorId,
-  hasError,
-  className,
-  ...inputProps
-}: CheckboxProps) => (
-  <input
-    aria-errormessage={errorId}
-    aria-invalid={hasError}
-    {...inputProps}
-    className={["af-checkbox", className].filter(Boolean).join(" ")}
-    type="checkbox"
-  />
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (props, ref) => {
+    const {
+      errorId,
+      hasError,
+      hasWarning,
+      className,
+      "aria-errormessage": ariaErrorMessage,
+      "aria-invalid": ariaInvalid,
+      ...inputProps
+    } = props;
+
+    return (
+      <input
+        aria-errormessage={ariaErrorMessage ?? errorId}
+        aria-invalid={ariaInvalid ?? hasError}
+        {...inputProps}
+        className={getClassName({
+          baseClassName: "af-checkbox",
+          modifiers: [hasWarning && "warning"],
+          className,
+        })}
+        ref={ref}
+        type="checkbox"
+      />
+    );
+  },
 );
 
 Checkbox.displayName = "Checkbox";

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/__tests__/Checkbox.test.tsx
@@ -43,4 +43,47 @@ describe("CheckboxCommon Component", () => {
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).toHaveClass("af-checkbox custom-class");
   });
+
+  it("should apply warning modifier when hasWarning is true", () => {
+    render(<Checkbox hasWarning />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveClass("af-checkbox af-checkbox--warning");
+  });
+
+  it("should not apply warning modifier when hasWarning is false", () => {
+    render(<Checkbox hasWarning={false} />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toHaveClass("af-checkbox--warning");
+  });
+
+  it("should set aria-invalid when hasError is true", () => {
+    render(<Checkbox hasError />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("should not set aria-invalid when hasError is false", () => {
+    render(<Checkbox hasError={false} />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("should set aria-errormessage when errorId is provided", () => {
+    render(<Checkbox errorId="error-1" />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveAttribute("aria-errormessage", "error-1");
+  });
+
+  it("should apply warning modifier and aria-invalid when both hasWarning and hasError are true", () => {
+    render(<Checkbox hasWarning hasError />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveClass("af-checkbox af-checkbox--warning");
+    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+  });
 });

--- a/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/__tests__/Checkbox.test.tsx
@@ -44,32 +44,34 @@ describe("CheckboxCommon Component", () => {
     expect(checkbox).toHaveClass("af-checkbox custom-class");
   });
 
-  it("should apply warning modifier when hasWarning is true", () => {
-    render(<Checkbox hasWarning />);
+  it("should apply error modifier and aria-invalid when variant is error", () => {
+    render(<Checkbox variant="error" />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toHaveClass("af-checkbox af-checkbox--error");
+    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("should not apply error modifier when variant is not set", () => {
+    render(<Checkbox />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toHaveClass("af-checkbox--error");
+    expect(checkbox).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("should apply warning modifier when variant is warning", () => {
+    render(<Checkbox variant="warning" />);
 
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).toHaveClass("af-checkbox af-checkbox--warning");
   });
 
-  it("should not apply warning modifier when hasWarning is false", () => {
-    render(<Checkbox hasWarning={false} />);
+  it("should not apply warning modifier when variant is not set", () => {
+    render(<Checkbox />);
 
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).not.toHaveClass("af-checkbox--warning");
-  });
-
-  it("should set aria-invalid when hasError is true", () => {
-    render(<Checkbox hasError />);
-
-    const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveAttribute("aria-invalid", "true");
-  });
-
-  it("should not set aria-invalid when hasError is false", () => {
-    render(<Checkbox hasError={false} />);
-
-    const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).not.toHaveAttribute("aria-invalid", "true");
   });
 
   it("should set aria-errormessage when errorId is provided", () => {
@@ -77,13 +79,5 @@ describe("CheckboxCommon Component", () => {
 
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).toHaveAttribute("aria-errormessage", "error-1");
-  });
-
-  it("should apply warning modifier and aria-invalid when both hasWarning and hasError are true", () => {
-    render(<Checkbox hasWarning hasError />);
-
-    const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveClass("af-checkbox af-checkbox--warning");
-    expect(checkbox).toHaveAttribute("aria-invalid", "true");
   });
 });

--- a/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
+++ b/plugins/canopee-prospect-client/skills/canopee-prospect-client/references/05-form-checkbox-radio.md
@@ -16,6 +16,7 @@ import { Checkbox } from "@axa-fr/canopee-react/prospect";
 
 ```tsx
 type CheckboxProps = {
+  hasWarning?: boolean;           // Ajoute la classe af-checkbox--warning (bordure orange)
 } & Omit<ComponentProps<"input">, "disabled" | "type">;
 // Tous les attributs <input type="checkbox"> transmis
 ```


### PR DESCRIPTION
**⚠️ ANNULE ET REMPLACE**
ancienne PR : https://github.com/AxaFrance/design-system/pull/1954
---

**issue concernée : #1813** 

Cette PR concerne l'ajout d'un variant `--warning` et `--hover-warning` pour le composant Checkbox.
Ce variant peut être testé dans les storybooks Client et Prospect via un toogle.

Fichiers concernés par ces ajustements :

Storybooks Checkbox:

- apps/apollo-stories/src/components/Checkbox/**Checkbox.stories.tsx**
- apps/look-and-feel-stories/src/components/Checkbox/**Checkbox.stories.tsx**

Composant Checkbox

- packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/**CheckboxCommon.css**
- packages/canopee-react/src/prospect-client/Form/Checkbox/Checkbox/**CheckboxCommon.tsx**

**BREAKING CHANGE :** les valeurs "error" et "warning" sont maintenant gérées par le prop "variant".