### PR TITLE
fix(client,prospect): target svg correctly in button styles

### DIFF
--- a/packages/canopee-css/src/prospect-client/Button/ButtonCommon.css
+++ b/packages/canopee-css/src/prospect-client/Button/ButtonCommon.css
@@ -38,7 +38,7 @@
       }
     }
 
-    & > svg {
+    svg {
       aspect-ratio: 1;
       fill: currentcolor;
     }


### PR DESCRIPTION
This pull request makes a small change to the `ButtonCommon.css` file, updating the CSS selector for `svg` elements to ensure consistent styling. The selector now targets all `svg` elements inside the button, not just direct children.