### PR TITLE
feat(client): update heading font family to publico-headline for h1 and h2

### DIFF
--- a/packages/canopee-css/src/prospect-client/Heading/HeadingLF.css
+++ b/packages/canopee-css/src/prospect-client/Heading/HeadingLF.css
@@ -12,13 +12,13 @@
     h1 {
       --heading-title-color: var(--blue-1000);
       --heading-title-font-size: var(--rem-24);
-      --heading-title-font-family: var(--font-family-publico);
+      --heading-title-font-family: var(--font-family-publico-headline);
       --heading-title-line-height: var(--rem-30);
     }
 
     h2 {
       --heading-title-font-size: var(--rem-20);
-      --heading-title-font-family: var(--font-family-publico);
+      --heading-title-font-family: var(--font-family-publico-headline);
       --heading-title-line-height: var(--rem-25);
     }
 


### PR DESCRIPTION
This pull request makes a small update to the heading styles in the `HeadingLF.css` file. The font family for both `h1` and `h2` elements has been changed to use `--font-family-publico-headline` instead of `--font-family-publico`.