### PR TITLE
feat(client, prospect): use publico headline font family on client stepper

### DIFF
--- a/packages/canopee-css/src/prospect-client/Stepper/StepperApollo.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperApollo.css
@@ -11,7 +11,6 @@
   }
 
   .af-stepper__title {
-    --title-font-family: var(--font-family-publico);
     --title-font-size: var(--rem-28);
     --title-font-weight: 300;
     --title-line-height: var(--rem-36);

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperCommon.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperCommon.css
@@ -16,7 +16,7 @@
   .af-stepper__title {
     margin: 0;
     vertical-align: middle;
-    font-family: var(--title-font-family);
+    font-family: var(--font-family-publico-headline);
     font-size: var(--title-font-size);
     font-weight: var(--title-font-weight);
     line-height: var(--title-line-height);

--- a/packages/canopee-css/src/prospect-client/Stepper/StepperLF.css
+++ b/packages/canopee-css/src/prospect-client/Stepper/StepperLF.css
@@ -10,7 +10,6 @@
   }
 
   .af-stepper__title {
-    --title-font-family: var(--font-family-publico);
     --title-font-size: var(--rem-24);
     --title-font-weight: 700;
     --title-line-height: var(--rem-30);

--- a/packages/canopee-css/src/prospect-client/client.css
+++ b/packages/canopee-css/src/prospect-client/client.css
@@ -1,4 +1,4 @@
-@layer canopee, reset;
+@layer reset, canopee;
 
 @import "./common/tokens.css";
 @import "./common/reboot.css";

--- a/packages/canopee-css/src/prospect-client/prospect.css
+++ b/packages/canopee-css/src/prospect-client/prospect.css
@@ -1,4 +1,4 @@
-@layer canopee, reset;
+@layer reset, canopee;
 
 @import "./common/tokens.css";
 @import "./common/reboot.css";


### PR DESCRIPTION
This pull request updates CSS in the prospect-client package to improve font consistency and corrects the order of CSS layers for proper style application.

**Font and Style Consistency:**

* The `font-family` for `.af-stepper__title` is now set directly to `var(--font-family-publico-headline)` in `StepperCommon.css`, removing the intermediate custom property.
* The custom property `--title-font-family` is removed from both `StepperApollo.css` and `StepperLF.css` to avoid redundancy and ensure the correct font is used. [[1]](diffhunk://#diff-14050e308c63a8d994e4b85a8a6b0a0b7a6287c494a3132bcb52b7fb2d06d980L14) [[2]](diffhunk://#diff-0ee2ae3c23a639d0b95b83b005d31e7a3cc87f04c231093228843ce1e486d31cL13)

**CSS Layer Order Correction:**

* The `@layer` directive order is changed from `canopee, reset` to `reset, canopee` in both `client.css` and `prospect.css`, ensuring that reset styles are applied before canopee-specific styles for consistent and predictable styling. [[1]](diffhunk://#diff-04bb828dd98ef9e7bef9cbbb1dcf81d9275b7a54f441376fc0251ba089585475L1-R1) [[2]](diffhunk://#diff-7637875dc9f96bd0f9238527128c03fd755a2464ee3ddac1ea3a425f03440b67L1-R1)