### PR TITLE
fix(prospect,client): update flex property for modal on desktop

### DIFF
--- a/packages/canopee-css/src/prospect-client/Modal/ModalCommon.css
+++ b/packages/canopee-css/src/prospect-client/Modal/ModalCommon.css
@@ -137,7 +137,7 @@
 
     @media (--desktop-small) {
       min-width: 180px;
-      flex-grow: inherit;
+      flex: inherit;
     }
   }
 }


### PR DESCRIPTION
This pull request makes a minor CSS adjustment to the modal component for desktop-small screens, ensuring more predictable flexbox behavior.

* Updated the `@media (--desktop-small)` rule in `ModalCommon.css` to use `flex: inherit;` instead of `flex-grow: inherit;` for improved flexbox compatibility.

## Result :

Before : 

<img width="1145" height="394" alt="image" src="https://github.com/user-attachments/assets/95e09d0d-16f8-4f15-872b-2d7f2e6500f2" />

After : 

<img width="1149" height="374" alt="image" src="https://github.com/user-attachments/assets/048d240e-59d3-4764-9e6b-89d0de1fa343" />
