### PR TITLE
fix(distributeur): title bottom margin is now correct, was doubled

### DIFF
--- a/apps/slash-stories/src/Title.stories.tsx
+++ b/apps/slash-stories/src/Title.stories.tsx
@@ -1,4 +1,9 @@
-import { Button, Link, Title } from "@axa-fr/canopee-react/distributeur";
+import {
+  Button,
+  Link,
+  TextInput,
+  Title,
+} from "@axa-fr/canopee-react/distributeur";
 import { ReactElement } from "react";
 import preview from "../.storybook/preview";
 
@@ -60,14 +65,18 @@ const getContent = (content?: string) => {
 export const Template = meta.story({
   name: "Title",
   render: ({ children: text, classModifier, ...args }) => (
-    <Title
-      classModifier={classModifier}
-      {...args}
-      contentLeft={undefined}
-      contentRight={undefined}
-    >
-      {text}
-    </Title>
+    <>
+      <Title
+        classModifier={classModifier}
+        {...args}
+        contentLeft={undefined}
+        contentRight={undefined}
+      >
+        {text}
+      </Title>
+
+      <TextInput label="Sample Input to illustrate bottom margin" required />
+    </>
   ),
   args: {
     children: "Sample Title",

--- a/packages/canopee-css/src/distributeur/Title/Title.css
+++ b/packages/canopee-css/src/distributeur/Title/Title.css
@@ -1,16 +1,13 @@
 @layer canopee {
   h2.af-title {
-    margin-bottom: 2rem;
     font-size: 1.5rem;
   }
 
   h3.af-title {
-    margin-bottom: 1.5rem;
     font-size: 1.25rem;
   }
 
   h4.af-title {
-    margin-bottom: 1rem;
     font-size: 1.125rem;
   }
 

--- a/packages/canopee-react/src/distributeur/Title/Title.tsx
+++ b/packages/canopee-react/src/distributeur/Title/Title.tsx
@@ -49,7 +49,7 @@ export const Title = ({
         {contentLeft}
       </Heading>
       {contentRight ? (
-        <div className="content-right">{contentRight}</div>
+        <div className={`${baseClass}__content-right`}>{contentRight}</div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
During the mega merge we did for the 2.0.0 and merge error slipped through and the bottom margins for the Title component were doubled, once on the hx component, once on the container. This change was done in `08c66ef`, #1933.